### PR TITLE
use Box<dyn Directory> as parameter to open/create an Index

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -123,8 +123,8 @@ impl IndexBuilder {
     /// If a previous index was in this directory, it returns an `IndexAlreadyExists` error.
     #[cfg(feature = "mmap")]
     pub fn create_in_dir<P: AsRef<Path>>(self, directory_path: P) -> crate::Result<Index> {
-        let mmap_directory = MmapDirectory::open(directory_path)?;
-        if Index::exists(&mmap_directory)? {
+        let mmap_directory: Box<dyn Directory> = Box::new(MmapDirectory::open(directory_path)?);
+        if Index::exists(&*mmap_directory)? {
             return Err(TantivyError::IndexAlreadyExists);
         }
         self.create(mmap_directory)
@@ -139,7 +139,7 @@ impl IndexBuilder {
     /// For other unit tests, prefer the `RAMDirectory`, see: `create_in_ram`.
     #[cfg(feature = "mmap")]
     pub fn create_from_tempdir(self) -> crate::Result<Index> {
-        let mmap_directory = MmapDirectory::create_from_tempdir()?;
+        let mmap_directory: Box<dyn Directory> = Box::new(MmapDirectory::create_from_tempdir()?);
         self.create(mmap_directory)
     }
     fn get_expect_schema(&self) -> crate::Result<Schema> {
@@ -149,8 +149,9 @@ impl IndexBuilder {
             .ok_or(TantivyError::IndexBuilderMissingArgument("schema"))
     }
     /// Opens or creates a new index in the provided directory
-    pub fn open_or_create<Dir: Directory>(self, dir: Dir) -> crate::Result<Index> {
-        if !Index::exists(&dir)? {
+    pub fn open_or_create<T: Into<Box<dyn Directory>>>(self, dir: T) -> crate::Result<Index> {
+        let dir = dir.into();
+        if !Index::exists(&*dir)? {
             return self.create(dir);
         }
         let index = Index::open(dir)?;
@@ -165,7 +166,8 @@ impl IndexBuilder {
     /// Creates a new index given an implementation of the trait `Directory`.
     ///
     /// If a directory previously existed, it will be erased.
-    fn create<Dir: Directory>(self, dir: Dir) -> crate::Result<Index> {
+    fn create<T: Into<Box<dyn Directory>>>(self, dir: T) -> crate::Result<Index> {
+        let dir = dir.into();
         let directory = ManagedDirectory::wrap(dir)?;
         save_new_metas(
             self.get_expect_schema()?,
@@ -198,7 +200,7 @@ impl Index {
     /// Examines the directory to see if it contains an index.
     ///
     /// Effectively, it only checks for the presence of the `meta.json` file.
-    pub fn exists<Dir: Directory>(dir: &Dir) -> Result<bool, OpenReadError> {
+    pub fn exists(dir: &dyn Directory) -> Result<bool, OpenReadError> {
         dir.exists(&META_FILEPATH)
     }
 
@@ -250,7 +252,11 @@ impl Index {
     }
 
     /// Opens or creates a new index in the provided directory
-    pub fn open_or_create<Dir: Directory>(dir: Dir, schema: Schema) -> crate::Result<Index> {
+    pub fn open_or_create<T: Into<Box<dyn Directory>>>(
+        dir: T,
+        schema: Schema,
+    ) -> crate::Result<Index> {
+        let dir = dir.into();
         IndexBuilder::new().schema(schema).open_or_create(dir)
     }
 
@@ -270,11 +276,12 @@ impl Index {
     /// Creates a new index given an implementation of the trait `Directory`.
     ///
     /// If a directory previously existed, it will be erased.
-    pub fn create<Dir: Directory>(
-        dir: Dir,
+    pub fn create<T: Into<Box<dyn Directory>>>(
+        dir: T,
         schema: Schema,
         settings: IndexSettings,
     ) -> crate::Result<Index> {
+        let dir: Box<dyn Directory> = dir.into();
         let mut builder = IndexBuilder::new().schema(schema);
         builder = builder.settings(settings);
         builder.create(dir)
@@ -365,7 +372,8 @@ impl Index {
     }
 
     /// Open the index using the provided directory
-    pub fn open<D: Directory>(directory: D) -> crate::Result<Index> {
+    pub fn open<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
+        let directory = directory.into();
         let directory = ManagedDirectory::wrap(directory)?;
         let inventory = SegmentMetaInventory::default();
         let metas = load_metas(&directory, &inventory)?;
@@ -577,15 +585,15 @@ mod tests {
 
     #[test]
     fn test_index_exists() {
-        let directory = RamDirectory::create();
-        assert!(!Index::exists(&directory).unwrap());
+        let directory: Box<dyn Directory> = Box::new(RamDirectory::create());
+        assert!(!Index::exists(directory.as_ref()).unwrap());
         assert!(Index::create(
             directory.clone(),
             throw_away_schema(),
             IndexSettings::default()
         )
         .is_ok());
-        assert!(Index::exists(&directory).unwrap());
+        assert!(Index::exists(directory.as_ref()).unwrap());
     }
 
     #[test]
@@ -598,27 +606,27 @@ mod tests {
 
     #[test]
     fn open_or_create_should_open() {
-        let directory = RamDirectory::create();
+        let directory: Box<dyn Directory> = Box::new(RamDirectory::create());
         assert!(Index::create(
             directory.clone(),
             throw_away_schema(),
             IndexSettings::default()
         )
         .is_ok());
-        assert!(Index::exists(&directory).unwrap());
+        assert!(Index::exists(directory.as_ref()).unwrap());
         assert!(Index::open_or_create(directory, throw_away_schema()).is_ok());
     }
 
     #[test]
     fn create_should_wipeoff_existing() {
-        let directory = RamDirectory::create();
+        let directory: Box<dyn Directory> = Box::new(RamDirectory::create());
         assert!(Index::create(
             directory.clone(),
             throw_away_schema(),
             IndexSettings::default()
         )
         .is_ok());
-        assert!(Index::exists(&directory).unwrap());
+        assert!(Index::exists(directory.as_ref()).unwrap());
         assert!(Index::create(
             directory,
             Schema::builder().build(),

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -230,3 +230,15 @@ where
         Box::new(self.clone())
     }
 }
+
+impl Clone for Box<dyn Directory> {
+    fn clone(&self) -> Self {
+        self.box_clone()
+    }
+}
+
+impl<T: Directory + 'static> From<T> for Box<dyn Directory> {
+    fn from(t: T) -> Self {
+        Box::new(t)
+    }
+}

--- a/src/indexer/demuxer.rs
+++ b/src/indexer/demuxer.rs
@@ -107,11 +107,11 @@ fn get_alive_bitsets(
 /// The number of output_directories need to match max new segment ordinal from `demux_mapping`.
 ///
 /// The ordinal of `segments` need to match the ordinals provided in `demux_mapping`.
-pub fn demux<Dir: Directory>(
+pub fn demux(
     segments: &[Segment],
     demux_mapping: &DemuxMapping,
     target_settings: IndexSettings,
-    output_directories: Vec<Dir>,
+    output_directories: Vec<Box<dyn Directory>>,
 ) -> crate::Result<Vec<Index>> {
     let mut indices = vec![];
     for (target_segment_ord, output_directory) in output_directories.into_iter().enumerate() {
@@ -253,7 +253,10 @@ mod tests {
             &segments,
             &demux_mapping,
             target_settings,
-            vec![RamDirectory::default(), RamDirectory::default()],
+            vec![
+                Box::new(RamDirectory::default()),
+                Box::new(RamDirectory::default()),
+            ],
         )?;
 
         {

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -160,9 +160,9 @@ fn merge(
 /// meant to work if you have an IndexWriter running for the origin indices, or
 /// the destination Index.
 #[doc(hidden)]
-pub fn merge_indices<Dir: Directory>(
+pub fn merge_indices<T: Into<Box<dyn Directory>>>(
     indices: &[Index],
-    output_directory: Dir,
+    output_directory: T,
 ) -> crate::Result<Index> {
     if indices.is_empty() {
         // If there are no indices to merge, there is no need to do anything.
@@ -206,11 +206,11 @@ pub fn merge_indices<Dir: Directory>(
 /// meant to work if you have an IndexWriter running for the origin indices, or
 /// the destination Index.
 #[doc(hidden)]
-pub fn merge_filtered_segments<Dir: Directory>(
+pub fn merge_filtered_segments<T: Into<Box<dyn Directory>>>(
     segments: &[Segment],
     target_settings: IndexSettings,
     filter_doc_ids: Vec<Option<AliveBitSet>>,
-    output_directory: Dir,
+    output_directory: T,
 ) -> crate::Result<Index> {
     if segments.is_empty() {
         // If there are no indices to merge, there is no need to do anything.
@@ -690,6 +690,7 @@ mod tests {
     use crate::indexer::segment_updater::merge_filtered_segments;
     use crate::query::QueryParser;
     use crate::schema::*;
+    use crate::Directory;
     use crate::DocAddress;
     use crate::Index;
     use crate::Segment;
@@ -882,7 +883,7 @@ mod tests {
         }
 
         assert_eq!(indices.len(), 3);
-        let output_directory = RamDirectory::default();
+        let output_directory: Box<dyn Directory> = Box::new(RamDirectory::default());
         let index = merge_indices(&indices, output_directory)?;
         assert_eq!(index.schema(), schema);
 

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -10,7 +10,7 @@ fn test_failpoints_managed_directory_gc_if_delete_fails() {
 
     let test_path: &'static Path = Path::new("some_path_for_test");
 
-    let ram_directory = RamDirectory::create();
+    let ram_directory = Box::new(RamDirectory::create());
     let mut managed_directory = ManagedDirectory::wrap(ram_directory).unwrap();
     managed_directory
         .open_write(test_path)


### PR DESCRIPTION
Replace <D: Directory> generic and support `Box<dyn Directory>` instead. Box<T> does not implement the trait for T, so this it the more powerful api.
Remove boxing in ManagedDirectory.

This is an breaking API change, all `Directory` parameters in Index::create etc. need to be wrapped in Box::new().

Closes #1171
