### PR TITLE
Fix outdated comment for IndexWriter::new

### DIFF
--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -395,9 +395,7 @@ impl Index {
     ///
     /// # Errors
     /// If the lockfile already exists, returns `Error::DirectoryLockBusy` or an `Error::IoError`.
-    ///
-    /// # Panics
-    /// If the heap size per thread is too small, panics.
+    /// If the heap size per thread is too small or too big, returns `TantivyError::InvalidArgument`
     pub fn writer_with_num_threads(
         &self,
         num_threads: usize,
@@ -445,8 +443,7 @@ impl Index {
     ///
     /// # Errors
     /// If the lockfile already exists, returns `Error::FileAlreadyExists`.
-    /// # Panics
-    /// If the heap size per thread is too small, panics.
+    /// If the heap size per thread is too small or too big, returns `TantivyError::InvalidArgument`
     pub fn writer(&self, overall_heap_size_in_bytes: usize) -> crate::Result<IndexWriter> {
         let mut num_threads = std::cmp::min(num_cpus::get(), MAX_NUM_THREAD);
         let heap_size_in_bytes_per_thread = overall_heap_size_in_bytes / num_threads;

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -280,8 +280,7 @@ impl IndexWriter {
     /// should work at the same time.
     /// # Errors
     /// If the lockfile already exists, returns `Error::FileAlreadyExists`.
-    /// # Panics
-    /// If the heap size per thread is too small, panics.
+    /// If the heap size per thread is too small or too big, returns `TantivyError::InvalidArgument`
     pub(crate) fn new(
         index: &Index,
         num_threads: usize,


### PR DESCRIPTION
Fix outdated comments since `IndexWriter::new` doesn't cause panic by too small heap size per thread anymore and returns an error instead
https://github.com/quickwit-inc/tantivy/blob/c412a46105e87f92142eba159aa3413808a04252/src/indexer/index_writer.rs#L285-L296