### PR TITLE
Make indexer::prepared_commit public

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -10,7 +10,7 @@ pub mod merge_policy;
 pub mod merger;
 mod merger_sorted_index_test;
 pub mod operation;
-mod prepared_commit;
+pub mod prepared_commit;
 mod segment_entry;
 mod segment_manager;
 mod segment_register;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub use crate::indexer::demuxer::*;
 pub use crate::indexer::merge_filtered_segments;
 pub use crate::indexer::merge_indices;
 pub use crate::indexer::operation::UserOperation;
+pub use crate::indexer::prepared_commit::PreparedCommit;
 pub use crate::indexer::IndexWriter;
 pub use crate::postings::Postings;
 pub use crate::reader::LeasedItem;


### PR DESCRIPTION
The `PreparedCommit` struct is returned by [IndexWriter::prepare_commit()](https://docs.rs/tantivy/0.16.1/tantivy/struct.IndexWriter.html#method.prepare_commit) for use by developers, so it should be public.

The docstring for `prepare_commit()` links to the docs for `PreparedCommit`, but the [link](https://docs.rs/tantivy/0.16.1/tantivy/PreparedCommit.html) doesn't work because the module is private.

It is an error to try to `use` the module directly because its parent is private:

```
17  | use tantivy::indexer::PreparedCommit;
    |              ^^^^^^^ private module
    |
note: the module `indexer` is defined here
```

Note: currently with the module private, it is still possible to use the struct:

```rs
let mut prepared_commit = index_writer.prepare_commit()?;
prepared_commit.set_payload("TEST");
prepared_commit.commit()?;
```