### PR TITLE
reduce number of allocations

### DIFF
--- a/src/postings/serializer.rs
+++ b/src/postings/serializer.rs
@@ -355,7 +355,7 @@ impl<W: Write> PostingsSerializer<W> {
             return;
         }
 
-        self.bm25_weight = Some(Bm25Weight::for_one_term(
+        self.bm25_weight = Some(Bm25Weight::for_one_term_without_explain(
             term_doc_freq as u64,
             num_docs_in_segment,
             self.avg_fieldnorm,

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -74,7 +74,8 @@ impl Weight for BoostWeight {
     fn explain(&self, reader: &SegmentReader, doc: u32) -> crate::Result<Explanation> {
         let underlying_explanation = self.weight.explain(reader, doc)?;
         let score = underlying_explanation.value() * self.boost;
-        let mut explanation = Explanation::new(format!("Boost x{} of ...", self.boost), score);
+        let mut explanation =
+            Explanation::new_with_string(format!("Boost x{} of ...", self.boost), score);
         explanation.add_detail(underlying_explanation);
         Ok(explanation)
     }
@@ -151,7 +152,7 @@ mod tests {
         let explanation = query.explain(&searcher, DocAddress::new(0, 0u32)).unwrap();
         assert_eq!(
             explanation.to_pretty_json(),
-            "{\n  \"value\": 0.2,\n  \"description\": \"Boost x0.2 of ...\",\n  \"details\": [\n    {\n      \"value\": 1.0,\n      \"description\": \"AllQuery\",\n      \"context\": []\n    }\n  ],\n  \"context\": []\n}"
+            "{\n  \"value\": 0.2,\n  \"description\": \"Boost x0.2 of ...\",\n  \"details\": [\n    {\n      \"value\": 1.0,\n      \"description\": \"AllQuery\"\n    }\n  ]\n}"
         );
         Ok(())
     }

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -164,11 +164,9 @@ mod tests {
   "details": [
     {
       "value": 1.0,
-      "description": "AllQuery",
-      "context": []
+      "description": "AllQuery"
     }
-  ],
-  "context": []
+  ]
 }"#
         );
         Ok(())

--- a/src/query/explanation.rs
+++ b/src/query/explanation.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::{DocId, Score, TantivyError};
 
@@ -16,12 +16,26 @@ pub(crate) fn does_not_match(doc: DocId) -> TantivyError {
 #[derive(Clone, Serialize)]
 pub struct Explanation {
     value: Score,
-    description: String,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    details: Vec<Explanation>,
-    context: Vec<String>,
+    description: StaticOrDynamic,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<Vec<Explanation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context: Option<Vec<String>>,
 }
-
+#[derive(Clone)]
+enum StaticOrDynamic {
+    Static(&'static str),
+    Dynamic(String),
+}
+impl Serialize for StaticOrDynamic {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where S: Serializer {
+        match self {
+            StaticOrDynamic::Static(s) => serializer.serialize_str(s),
+            StaticOrDynamic::Dynamic(s) => serializer.serialize_str(s),
+        }
+    }
+}
 impl fmt::Debug for Explanation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Explanation({})", self.to_pretty_json())
@@ -30,12 +44,21 @@ impl fmt::Debug for Explanation {
 
 impl Explanation {
     /// Creates a new explanation object.
-    pub fn new<T: ToString>(description: T, value: Score) -> Explanation {
+    pub fn new_with_string(description: String, value: Score) -> Explanation {
         Explanation {
             value,
-            description: description.to_string(),
-            details: vec![],
-            context: vec![],
+            description: StaticOrDynamic::Dynamic(description),
+            details: None,
+            context: None,
+        }
+    }
+    /// Creates a new explanation object.
+    pub fn new(description: &'static str, value: Score) -> Explanation {
+        Explanation {
+            value,
+            description: StaticOrDynamic::Static(description),
+            details: None,
+            context: None,
         }
     }
 
@@ -48,17 +71,21 @@ impl Explanation {
     ///
     /// Details are treated as child of the current node.
     pub fn add_detail(&mut self, child_explanation: Explanation) {
-        self.details.push(child_explanation);
+        self.details
+            .get_or_insert_with(Vec::new)
+            .push(child_explanation);
     }
 
     /// Adds some extra context to the explanation.
     pub fn add_context(&mut self, context: String) {
-        self.context.push(context);
+        self.context.get_or_insert_with(Vec::new).push(context);
     }
 
     /// Shortcut for `self.details.push(Explanation::new(name, value));`
-    pub fn add_const<T: ToString>(&mut self, name: T, value: Score) {
-        self.details.push(Explanation::new(name, value));
+    pub fn add_const(&mut self, name: &'static str, value: Score) {
+        self.details
+            .get_or_insert_with(Vec::new)
+            .push(Explanation::new(name, value));
     }
 
     /// Returns an indented json representation of the explanation tree for debug usage.

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -101,7 +101,7 @@ impl TermQuery {
                 ..
             } => Bm25Weight::for_terms(statistics_provider, &[self.term.clone()])?,
             EnableScoring::Disabled { .. } => {
-                Bm25Weight::new(Explanation::new("<no score>".to_string(), 1.0f32), 1.0f32)
+                Bm25Weight::new(Explanation::new("<no score>", 1.0f32), 1.0f32)
             }
         };
         let scoring_enabled = enable_scoring.is_scoring_enabled();


### PR DESCRIPTION
Explanation makes up around 75% of all allocations (numbers not perf) when indexing.
It's created during serialization but not called.

- Make Explanation optional in BM25
- Avoid allocations when using Explanation
