### PR TITLE
Add concurrency limiting to Executor to prevent thread pool exhaustion

### DIFF
--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -1,9 +1,43 @@
-use std::sync::Arc;
+use crate::TantivyError;
+use std::sync::{Arc, Condvar, Mutex};
 
 #[cfg(feature = "quickwit")]
 use futures_util::{future::Either, FutureExt};
 
-use crate::TantivyError;
+struct TaskLimiter {
+    available: Mutex<usize>,
+    condvar: Condvar,
+}
+
+impl TaskLimiter {
+    fn new(max_tasks: usize) -> Self {
+        TaskLimiter {
+            available: Mutex::new(max_tasks),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn acquire(&self) -> TaskPermit<'_> {
+        let mut available = self.available.lock().unwrap();
+        while *available == 0 {
+            available = self.condvar.wait(available).unwrap();
+        }
+        *available -= 1;
+        TaskPermit { limiter: self }
+    }
+}
+
+struct TaskPermit<'a> {
+    limiter: &'a TaskLimiter,
+}
+
+impl<'a> Drop for TaskPermit<'a> {
+    fn drop(&mut self) {
+        let mut available = self.limiter.available.lock().unwrap();
+        *available += 1;
+        self.limiter.condvar.notify_one();
+    }
+}
 
 /// Executor makes it possible to run tasks in single thread or
 /// in a thread pool.
@@ -12,7 +46,12 @@ pub enum Executor {
     /// Single thread variant of an Executor
     SingleThread,
     /// Thread pool variant of an Executor
-    ThreadPool(Arc<rayon::ThreadPool>),
+    ThreadPool {
+        /// The thread pool to use for executing tasks.
+        thread_pool: Arc<rayon::ThreadPool>,
+        /// Optional concurrency limit for the thread pool.
+        concurrency_limit: Option<usize>,
+    },
 }
 
 #[cfg(feature = "quickwit")]
@@ -34,33 +73,80 @@ impl Executor {
             .num_threads(num_threads)
             .thread_name(move |num| format!("{prefix}{num}"))
             .build()?;
-        Ok(Executor::ThreadPool(Arc::new(pool)))
+        Ok(Executor::ThreadPool {
+            thread_pool: Arc::new(pool),
+            concurrency_limit: None,
+        })
+    }
+
+    /// Creates an Executor that dispatches the tasks in a thread pool with a concurrency limit.
+    /// This is useful to limit the number of concurrent tasks that can be mapped by a single call to `map`.
+    /// So that a single call to `map` does not spawn more than `concurrency_limit` tasks at a time in order to not
+    /// overwhelm the pool by a single operation.
+    pub fn multi_thread_with_concurrency_limit(
+        num_threads: usize,
+        prefix: &'static str,
+        concurrency_limit: usize,
+    ) -> crate::Result<Executor> {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(move |num| format!("{prefix}{num}"))
+            .build()?;
+        Ok(Executor::ThreadPool {
+            thread_pool: Arc::new(pool),
+            concurrency_limit: Some(concurrency_limit),
+        })
     }
 
     /// Perform a map in the thread pool.
     ///
     /// Regardless of the executor (`SingleThread` or `ThreadPool`), panics in the task
     /// will propagate to the caller.
-    pub fn map<A, R, F>(&self, f: F, args: impl Iterator<Item = A>) -> crate::Result<Vec<R>>
-    where
+    pub fn map<
         A: Send,
         R: Send,
+        AIterator: Iterator<Item = A>,
         F: Sized + Sync + Fn(A) -> crate::Result<R>,
-    {
+    >(
+        &self,
+        f: F,
+        args: AIterator,
+    ) -> crate::Result<Vec<R>> {
         match self {
             Executor::SingleThread => args.map(f).collect::<crate::Result<_>>(),
-            Executor::ThreadPool(pool) => {
+            Executor::ThreadPool {
+                thread_pool,
+                concurrency_limit,
+            } => {
+                let limiter = match concurrency_limit {
+                    Some(limit) => {
+                        if *limit == 0 {
+                            return Err(TantivyError::InternalError(
+                                "Concurrency limit cannot be zero.".to_string(),
+                            ));
+                        }
+                        Some(Arc::new(TaskLimiter::new(*limit)))
+                    }
+                    _ => None,
+                };
+
                 let args: Vec<A> = args.collect();
                 let num_fruits = args.len();
                 let fruit_receiver = {
                     let (fruit_sender, fruit_receiver) = crossbeam_channel::unbounded();
-                    pool.scope(|scope| {
+                    thread_pool.scope(|scope| {
                         for (idx, arg) in args.into_iter().enumerate() {
+                            let limiter = limiter.clone();
+
                             // We name references for f and fruit_sender_ref because we do not
                             // want these two to be moved into the closure.
                             let f_ref = &f;
                             let fruit_sender_ref = &fruit_sender;
                             scope.spawn(move |_| {
+                                if let Some(limiter) = limiter {
+                                    let _permit = limiter.acquire();
+                                }
+
                                 let fruit = f_ref(arg);
                                 if let Err(err) = fruit_sender_ref.send((idx, fruit)) {
                                     error!(

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -261,6 +261,18 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_map_multithread_with_concurrency_limit() {
+        let result: Vec<usize> = Executor::multi_thread_with_concurrency_limit(3, "search-test", 2)
+            .unwrap()
+            .map(|i| Ok(i * 2), 0..10)
+            .unwrap();
+        assert_eq!(result.len(), 10);
+        for i in 0..10 {
+            assert_eq!(result[i], i * 2);
+        }
+    }
+
     #[cfg(feature = "quickwit")]
     #[test]
     fn test_cancel_cpu_intensive_tasks() {


### PR DESCRIPTION
**Problem**

When using the multithreaded executor with Tantivy, a single search query can exhaust all threads in the pool, preventing other queries from running concurrently. This happens because `Executor::map()` uses `rayon::scope()` which spawns all tasks at once, potentially using all available threads for a single operation.

This causes issues in production scenarios where:

- A slow/expensive query blocks fast queries from executing
- Multiple concurrent searches cannot effectively share the thread pool
- The only workaround is creating multiple `IndexReader` instances, which is inefficient

**Solution**

This PR adds an optional concurrency limit to the `Executor` that restricts how many tasks a single `map()` operation can spawn concurrently. This ensures that no single query can monopolize the entire thread pool.


