### PR TITLE
docs: fix a typo in basic example

### DIFF
--- a/examples/basic_search.rs
+++ b/examples/basic_search.rs
@@ -51,7 +51,7 @@ fn main() -> tantivy::Result<()> {
 
     // Our second field is body.
     // We want full-text search for it, but we do not
-    // need to be able to be able to retrieve it
+    // need to be able to retrieve it
     // for our application.
     //
     // We can make our index lighter by omitting the `STORED` flag.


### PR DESCRIPTION
Hi, I just noticed a minor typo in the basic example and wanted to correct it.

![Shot 2025-07-07 at 10 04 20](https://github.com/user-attachments/assets/f3e22941-b04d-4ef1-9a68-dcfc09b7b88e)
