### PR TITLE
Replace AggregationsWithAccessor

### DIFF
--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -71,6 +71,7 @@ fn bench_agg(mut group: InputGroup<Index>) {
     register!(group, histogram);
     register!(group, histogram_hard_bounds);
     register!(group, histogram_with_avg_sub_agg);
+    register!(group, histogram_with_term_agg_few);
     register!(group, avg_and_range_with_avg_sub_agg);
 
     group.run();
@@ -334,6 +335,17 @@ fn histogram_with_avg_sub_agg(index: &Index) {
             "histogram": { "field": "score_f64", "interval": 100 },
             "aggs": {
                 "average_f64": { "avg": { "field": "score_f64" } }
+            }
+        }
+    });
+    execute_agg(index, agg_req);
+}
+fn histogram_with_term_agg_few(index: &Index) {
+    let agg_req = json!({
+        "rangef64": {
+            "histogram": { "field": "score_f64", "interval": 10 },
+            "aggs": {
+                "my_texts": { "terms": { "field": "text_few_terms" } }
             }
         }
     });

--- a/src/aggregation/README.md
+++ b/src/aggregation/README.md
@@ -20,17 +20,16 @@ Contains all metric aggregations, like average aggregation. Metric aggregations 
 #### agg_req
 agg_req contains the users aggregation request. Deserialization from json is compatible with elasticsearch aggregation requests.
 
-#### agg_req_with_accessor
-agg_req_with_accessor contains the users aggregation request enriched with fast field accessors etc, which are
+#### agg_data
+agg_data contains the users aggregation request enriched with fast field accessors etc, which are
 used during collection.
 
 #### segment_agg_result
 segment_agg_result contains the aggregation result tree, which is used for collection of a segment.
-The tree from agg_req_with_accessor is passed during collection.
+agg_data is passed during collection.
 
 #### intermediate_agg_result
 intermediate_agg_result contains the aggregation tree for merging with other trees.
 
 #### agg_result
 agg_result contains the final aggregation tree.
-

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -1,0 +1,985 @@
+use std::collections::HashMap;
+
+use columnar::{Column, ColumnBlockAccessor, ColumnType, DynamicColumn, StrColumn};
+use serde::Serialize;
+
+use crate::aggregation::agg_req::{Aggregation, AggregationVariants, Aggregations};
+use crate::aggregation::agg_req_with_accessor::{
+    get_all_ff_reader_or_empty, get_dynamic_columns, get_ff_reader, get_missing_val_as_u64_lenient,
+    get_numeric_or_date_column_types,
+};
+use crate::aggregation::bucket::{
+    HistogramAggregation, HistogramBounds, RangeAggregation, SegmentHistogramCollector,
+    SegmentRangeCollector, SegmentTermCollector, TermMissingAgg, TermsAggregation,
+    TermsAggregationInternal,
+};
+use crate::aggregation::metric::{
+    AverageAggregation, CardinalityAggregationReq, CountAggregation, ExtendedStatsAggregation,
+    MaxAggregation, MinAggregation, SegmentCardinalityCollector, SegmentExtendedStatsCollector,
+    SegmentPercentilesCollector, SegmentStatsCollector, StatsAggregation, StatsType,
+    SumAggregation, TopHitsAggregationReq, TopHitsSegmentCollector,
+};
+use crate::aggregation::segment_agg_result::{
+    GenericSegmentAggregationResultsCollector, SegmentAggregationCollector,
+};
+use crate::aggregation::{f64_to_fastfield_u64, AggregationLimitsGuard, Key};
+use crate::{SegmentOrdinal, SegmentReader};
+
+#[derive(Default)]
+/// Datastructure holding all request data for executing aggregations on a segment.
+/// It is passed to the collectors during collection.
+pub struct AggregationsData {
+    /// Request data for each aggregation type.
+    pub per_request: PerRequestAggData,
+    pub limits: AggregationLimitsGuard,
+}
+
+impl AggregationsData {
+    pub(crate) fn push_term_req_data(&mut self, data: TermsAggReqData) -> usize {
+        self.per_request.term_req_data.push(Some(Box::new(data)));
+        self.per_request.term_req_data.len() - 1
+    }
+    pub(crate) fn push_cardinality_req_data(&mut self, data: CardinalityAggReqData) -> usize {
+        self.per_request.cardinality_req_data.push(data);
+        self.per_request.cardinality_req_data.len() - 1
+    }
+    pub(crate) fn push_metric_req_data(&mut self, data: MetricAggReqData) -> usize {
+        self.per_request.stats_metric_req_data.push(data);
+        self.per_request.stats_metric_req_data.len() - 1
+    }
+    pub(crate) fn push_top_hits_req_data(&mut self, data: TopHitsAggReqData) -> usize {
+        self.per_request.top_hits_req_data.push(data);
+        self.per_request.top_hits_req_data.len() - 1
+    }
+    pub(crate) fn push_missing_term_req_data(&mut self, data: MissingTermAggReqData) -> usize {
+        self.per_request.missing_term_req_data.push(data);
+        self.per_request.missing_term_req_data.len() - 1
+    }
+    pub(crate) fn push_histogram_req_data(&mut self, data: HistogramAggReqData) -> usize {
+        self.per_request
+            .histogram_req_data
+            .push(Some(Box::new(data)));
+        self.per_request.histogram_req_data.len() - 1
+    }
+    pub(crate) fn push_range_req_data(&mut self, data: RangeAggReqData) -> usize {
+        self.per_request.range_req_data.push(Some(Box::new(data)));
+        self.per_request.range_req_data.len() - 1
+    }
+
+    #[inline]
+    pub(crate) fn get_term_req_data(&self, idx: usize) -> &TermsAggReqData {
+        self.per_request.term_req_data[idx]
+            .as_deref()
+            .expect("term_req_data slot is empty (taken)")
+    }
+    #[inline]
+    pub(crate) fn get_cardinality_req_data(&self, idx: usize) -> &CardinalityAggReqData {
+        &self.per_request.cardinality_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_metric_req_data(&self, idx: usize) -> &MetricAggReqData {
+        &self.per_request.stats_metric_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_top_hits_req_data(&self, idx: usize) -> &TopHitsAggReqData {
+        &self.per_request.top_hits_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_missing_term_req_data(&self, idx: usize) -> &MissingTermAggReqData {
+        &self.per_request.missing_term_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_histogram_req_data(&self, idx: usize) -> &HistogramAggReqData {
+        self.per_request.histogram_req_data[idx]
+            .as_deref()
+            .expect("histogram_req_data slot is empty (taken)")
+    }
+    #[inline]
+    pub(crate) fn get_range_req_data(&self, idx: usize) -> &RangeAggReqData {
+        self.per_request.range_req_data[idx]
+            .as_deref()
+            .expect("range_req_data slot is empty (taken)")
+    }
+
+    // ---------- mutable getters ----------
+
+    #[inline]
+    pub(crate) fn get_term_req_data_mut(&mut self, idx: usize) -> &mut TermsAggReqData {
+        self.per_request.term_req_data[idx]
+            .as_deref_mut()
+            .expect("term_req_data slot is empty (taken)")
+    }
+    #[inline]
+    pub(crate) fn get_cardinality_req_data_mut(
+        &mut self,
+        idx: usize,
+    ) -> &mut CardinalityAggReqData {
+        &mut self.per_request.cardinality_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_metric_req_data_mut(&mut self, idx: usize) -> &mut MetricAggReqData {
+        &mut self.per_request.stats_metric_req_data[idx]
+    }
+    #[inline]
+    pub(crate) fn get_histogram_req_data_mut(&mut self, idx: usize) -> &mut HistogramAggReqData {
+        self.per_request.histogram_req_data[idx]
+            .as_deref_mut()
+            .expect("histogram_req_data slot is empty (taken)")
+    }
+
+    // ---------- take / put (terms, histogram, range) ----------
+
+    /// Move out the boxed Terms request at `idx`, leaving `None`.
+    #[inline]
+    pub(crate) fn take_term_req_data(&mut self, idx: usize) -> Box<TermsAggReqData> {
+        self.per_request.term_req_data[idx]
+            .take()
+            .expect("term_req_data slot is empty (taken)")
+    }
+
+    /// Put back a Terms request into an empty slot at `idx`.
+    #[inline]
+    pub(crate) fn put_back_term_req_data(&mut self, idx: usize, value: Box<TermsAggReqData>) {
+        debug_assert!(self.per_request.term_req_data[idx].is_none());
+        self.per_request.term_req_data[idx] = Some(value);
+    }
+
+    /// Move out the boxed Histogram request at `idx`, leaving `None`.
+    #[inline]
+    pub(crate) fn take_histogram_req_data(&mut self, idx: usize) -> Box<HistogramAggReqData> {
+        self.per_request.histogram_req_data[idx]
+            .take()
+            .expect("histogram_req_data slot is empty (taken)")
+    }
+
+    /// Put back a Histogram request into an empty slot at `idx`.
+    #[inline]
+    pub(crate) fn put_back_histogram_req_data(
+        &mut self,
+        idx: usize,
+        value: Box<HistogramAggReqData>,
+    ) {
+        debug_assert!(self.per_request.histogram_req_data[idx].is_none());
+        self.per_request.histogram_req_data[idx] = Some(value);
+    }
+
+    /// Move out the boxed Range request at `idx`, leaving `None`.
+    #[inline]
+    pub(crate) fn take_range_req_data(&mut self, idx: usize) -> Box<RangeAggReqData> {
+        self.per_request.range_req_data[idx]
+            .take()
+            .expect("range_req_data slot is empty (taken)")
+    }
+
+    /// Put back a Range request into an empty slot at `idx`.
+    #[inline]
+    pub(crate) fn put_back_range_req_data(&mut self, idx: usize, value: Box<RangeAggReqData>) {
+        debug_assert!(self.per_request.range_req_data[idx].is_none());
+        self.per_request.range_req_data[idx] = Some(value);
+    }
+}
+
+/// Each type of aggregation has its own request data struct.
+/// This struct holds all request data to execute the aggregation request on a single segment.
+///
+/// The request tree is represented by `agg_tree` which contains nodes with references
+/// into the various request ata vectors.
+#[derive(Default)]
+pub struct PerRequestAggData {
+    // Box for cheap take/put - Only necessary for bucket aggs that have sub-aggregations
+    /// TermsAggReqData contains the request data for a terms aggregation.
+    pub term_req_data: Vec<Option<Box<TermsAggReqData>>>,
+    /// HistogramAggReqData contains the request data for a histogram aggregation.
+    pub histogram_req_data: Vec<Option<Box<HistogramAggReqData>>>,
+    /// RangeAggReqData contains the request data for a range aggregation.
+    pub range_req_data: Vec<Option<Box<RangeAggReqData>>>,
+    /// Shared by avg, min, max, sum, stats, extended_stats, count
+    pub stats_metric_req_data: Vec<MetricAggReqData>,
+    /// CardinalityAggReqData contains the request data for a cardinality aggregation.
+    pub cardinality_req_data: Vec<CardinalityAggReqData>,
+    /// TopHitsAggReqData contains the request data for a top_hits aggregation.
+    pub top_hits_req_data: Vec<TopHitsAggReqData>,
+    /// MissingTermAggReqData contains the request data for a missing term aggregation.
+    pub missing_term_req_data: Vec<MissingTermAggReqData>,
+
+    /// Request tree used to build collectors.
+    pub agg_tree: Vec<AggRefNode>,
+}
+
+impl PerRequestAggData {
+    pub fn get_name(&self, node: &AggRefNode) -> &str {
+        let idx = node.idx_in_req_data;
+        let kind = node.kind;
+        match kind {
+            AggKind::Terms => self.term_req_data[idx]
+                .as_deref()
+                .expect("term_req_data slot is empty (taken)")
+                .name
+                .as_str(),
+            AggKind::Cardinality => &self.cardinality_req_data[idx].name,
+            AggKind::StatsKind(_) => &self.stats_metric_req_data[idx].name,
+            AggKind::TopHits => &self.top_hits_req_data[idx].name,
+            AggKind::MissingTerm => &self.missing_term_req_data[idx].name,
+            AggKind::Histogram => self.histogram_req_data[idx]
+                .as_deref()
+                .expect("histogram_req_data slot is empty (taken)")
+                .name
+                .as_str(),
+            AggKind::DateHistogram => self.histogram_req_data[idx]
+                .as_deref()
+                .expect("histogram_req_data slot is empty (taken)")
+                .name
+                .as_str(),
+            AggKind::Range => self.range_req_data[idx]
+                .as_deref()
+                .expect("range_req_data slot is empty (taken)")
+                .name
+                .as_str(),
+        }
+    }
+
+    /// Convert the aggregation tree into a serializable struct representation.
+    /// Each node contains: { name, kind, children }.
+    pub fn get_view_tree(&self) -> Vec<AggTreeViewNode> {
+        fn node_to_view(node: &AggRefNode, pr: &PerRequestAggData) -> AggTreeViewNode {
+            let mut children: Vec<AggTreeViewNode> =
+                node.children.iter().map(|c| node_to_view(c, pr)).collect();
+            children.sort_by_key(|v| serde_json::to_string(v).unwrap());
+            AggTreeViewNode {
+                name: pr.get_name(node).to_string(),
+                kind: node.kind.as_str().to_string(),
+                children,
+            }
+        }
+
+        let mut roots: Vec<AggTreeViewNode> = self
+            .agg_tree
+            .iter()
+            .map(|n| node_to_view(n, self))
+            .collect();
+        roots.sort_by_key(|v| serde_json::to_string(v).unwrap());
+        roots
+    }
+}
+
+pub(crate) fn build_segment_agg_collectors_root(
+    req: &mut AggregationsData,
+) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    build_segment_agg_collectors(req, &req.per_request.agg_tree.clone())
+}
+
+pub(crate) fn build_segment_agg_collectors(
+    req: &mut AggregationsData,
+    nodes: &[AggRefNode],
+) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    let mut collectors = Vec::new();
+    for node in nodes.iter() {
+        collectors.push(build_segment_agg_collector(req, node)?);
+    }
+
+    // Single collector special case
+    if collectors.len() == 1 {
+        return Ok(collectors.pop().unwrap());
+    }
+    let agg = GenericSegmentAggregationResultsCollector { aggs: collectors };
+    Ok(Box::new(agg))
+}
+
+pub(crate) fn build_segment_agg_collector(
+    req: &mut AggregationsData,
+    node: &AggRefNode,
+) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    match node.kind {
+        AggKind::Terms => Ok(Box::new(SegmentTermCollector::from_req_and_validate(
+            req, node,
+        )?)),
+        AggKind::MissingTerm => {
+            let req_data = &mut req.per_request.missing_term_req_data[node.idx_in_req_data];
+            if req_data.accessors.is_empty() {
+                return Err(crate::TantivyError::InternalError(
+                    "MissingTerm aggregation requires at least one field accessor.".to_string(),
+                ));
+            }
+            Ok(Box::new(TermMissingAgg::new(req, node)?))
+        }
+        AggKind::Cardinality => {
+            let req_data = &mut req.get_cardinality_req_data_mut(node.idx_in_req_data);
+            Ok(Box::new(SegmentCardinalityCollector::from_req(
+                req_data.column_type,
+                node.idx_in_req_data,
+            )))
+        }
+        AggKind::StatsKind(stats_type) => {
+            let req_data = &mut req.per_request.stats_metric_req_data[node.idx_in_req_data];
+            match stats_type {
+                StatsType::Sum
+                | StatsType::Average
+                | StatsType::Count
+                | StatsType::Max
+                | StatsType::Min
+                | StatsType::Stats => Ok(Box::new(SegmentStatsCollector::from_req(
+                    node.idx_in_req_data,
+                ))),
+                StatsType::ExtendedStats(sigma) => {
+                    Ok(Box::new(SegmentExtendedStatsCollector::from_req(
+                        req_data.field_type,
+                        sigma,
+                        node.idx_in_req_data,
+                        req_data.missing,
+                    )))
+                }
+                StatsType::Percentiles => Ok(Box::new(
+                    SegmentPercentilesCollector::from_req_and_validate(node.idx_in_req_data)?,
+                )),
+            }
+        }
+        AggKind::TopHits => {
+            let req_data = &mut req.per_request.top_hits_req_data[node.idx_in_req_data];
+            Ok(Box::new(TopHitsSegmentCollector::from_req(
+                &req_data.req,
+                node.idx_in_req_data,
+                req_data.segment_ordinal,
+            )))
+        }
+        AggKind::Histogram => Ok(Box::new(SegmentHistogramCollector::from_req_and_validate(
+            req, node,
+        )?)),
+        AggKind::DateHistogram => Ok(Box::new(SegmentHistogramCollector::from_req_and_validate(
+            req, node,
+        )?)),
+        AggKind::Range => Ok(Box::new(SegmentRangeCollector::from_req_and_validate(
+            req, node,
+        )?)),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AggRefNode {
+    pub kind: AggKind,
+    pub idx_in_req_data: usize,
+    pub children: Vec<AggRefNode>,
+}
+impl AggRefNode {
+    pub fn get_sub_agg(&self, name: &str, pr: &PerRequestAggData) -> Option<&AggRefNode> {
+        self.children
+            .iter()
+            .find(|&child| pr.get_name(child) == name)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum AggKind {
+    Terms,
+    Cardinality,
+    /// One of: Statistics, Average, Min, Max, Sum, Count, Stats, ExtendedStats
+    StatsKind(StatsType),
+    TopHits,
+    MissingTerm,
+    Histogram,
+    DateHistogram,
+    Range,
+}
+
+impl AggKind {
+    #[cfg_attr(not(test), allow(dead_code))]
+    fn as_str(&self) -> &'static str {
+        match self {
+            AggKind::Terms => "Terms",
+            AggKind::Cardinality => "Cardinality",
+            AggKind::StatsKind(_) => "Metric",
+            AggKind::TopHits => "TopHits",
+            AggKind::MissingTerm => "MissingTerm",
+            AggKind::Histogram => "Histogram",
+            AggKind::DateHistogram => "DateHistogram",
+            AggKind::Range => "Range",
+        }
+    }
+}
+
+/// Contains all information required by the SegmentTermCollector to perform the
+/// terms aggregation on a segment.
+pub struct TermsAggReqData {
+    pub accessor: Column<u64>,
+    pub column_type: ColumnType,
+    pub str_dict_column: Option<StrColumn>,
+    pub missing_value_for_accessor: Option<u64>,
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    pub field_type: ColumnType,
+    /// Note: sub_aggregation_blueprint is filled later when building collectors
+    pub sub_aggregation_blueprint: Option<Box<dyn SegmentAggregationCollector>>,
+    pub sug_aggregations: Aggregations,
+    pub name: String,
+    pub req: TermsAggregationInternal,
+}
+
+/// Special aggregation to handle missing values for term aggregations.
+/// This missing aggregation will check multiple columns for existence.
+///
+/// This is needed when:
+/// - The field is multi-valued and we therefore have multiple columns
+/// - The field is not text and missing is provided as string (we cannot use the numeric missing
+///   value optimization)
+#[derive(Default)]
+pub struct MissingTermAggReqData {
+    pub accessors: Vec<(Column<u64>, ColumnType)>,
+    pub name: String,
+    pub req: TermsAggregation,
+}
+
+/// Contains all information required by the SegmentCardinalityCollector to perform the
+/// cardinality aggregation on a segment.
+pub struct CardinalityAggReqData {
+    pub accessor: Column<u64>,
+    pub column_type: ColumnType,
+    pub str_dict_column: Option<StrColumn>,
+    pub missing_value_for_accessor: Option<u64>,
+    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
+    pub name: String,
+    pub req: CardinalityAggregationReq,
+}
+
+/// Contains all information required by the TopHitsSegmentCollector to perform the
+/// top_hits aggregation on a segment.
+#[derive(Default)]
+pub struct TopHitsAggReqData {
+    pub accessors: Vec<(Column<u64>, ColumnType)>,
+    pub value_accessors: HashMap<String, Vec<DynamicColumn>>,
+    pub(crate) segment_ordinal: SegmentOrdinal,
+    pub name: String,
+    pub req: TopHitsAggregationReq,
+}
+
+/// Contains all information required by metric aggregations like avg, min, max, sum, stats,
+/// extended_stats, count, percentiles.
+#[repr(C)]
+pub struct MetricAggReqData {
+    pub is_number_or_date_type: bool,
+    pub field_type: ColumnType,
+    pub missing_u64: Option<u64>,
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    pub accessor: Column<u64>,
+    /// Used when converting to intermediate result
+    pub collecting_for: StatsType,
+    pub missing: Option<f64>,
+    pub name: String,
+}
+
+/// Contains all information required by the SegmentHistogramCollector to perform the
+/// histogram or date_histogram aggregation on a segment.
+pub struct HistogramAggReqData {
+    pub accessor: Column<u64>,
+    pub field_type: ColumnType,
+    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
+    pub name: String,
+    pub sub_aggregation_blueprint: Option<Box<dyn SegmentAggregationCollector>>,
+    pub req: HistogramAggregation,
+    pub is_date_histogram: bool,
+    pub bounds: HistogramBounds,
+    pub offset: f64,
+}
+
+/// Contains all information required by the SegmentRangeCollector to perform the
+/// range aggregation on a segment.
+pub struct RangeAggReqData {
+    pub accessor: Column<u64>,
+    pub field_type: ColumnType,
+    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
+    pub req: RangeAggregation,
+    pub name: String,
+}
+
+/// Build AggregationsData by walking the request tree.
+pub(crate) fn build_aggregations_data_from_req(
+    aggs: &Aggregations,
+    reader: &SegmentReader,
+    segment_ordinal: SegmentOrdinal,
+    limits: AggregationLimitsGuard,
+) -> crate::Result<AggregationsData> {
+    let mut data = AggregationsData {
+        per_request: Default::default(),
+        limits,
+    };
+
+    for (name, agg) in aggs.iter() {
+        let nodes = build_nodes(name, agg, reader, segment_ordinal, &mut data)?;
+        data.per_request.agg_tree.extend(nodes);
+    }
+    Ok(data)
+}
+
+fn build_nodes(
+    agg_name: &str,
+    req: &Aggregation,
+    reader: &SegmentReader,
+    segment_ordinal: SegmentOrdinal,
+    data: &mut AggregationsData,
+) -> crate::Result<Vec<AggRefNode>> {
+    use AggregationVariants::*;
+    match &req.agg {
+        Range(range_req) => {
+            let (accessor, field_type) = get_ff_reader(
+                reader,
+                &range_req.field,
+                Some(get_numeric_or_date_column_types()),
+            )?;
+            let idx_in_req_data = data.push_range_req_data(RangeAggReqData {
+                accessor,
+                field_type,
+                column_block_accessor: Default::default(),
+                name: agg_name.to_string(),
+                req: range_req.clone(),
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::Range,
+                idx_in_req_data,
+                children,
+            }])
+        }
+        Histogram(histo_req) => {
+            let (accessor, field_type) = get_ff_reader(
+                reader,
+                &histo_req.field,
+                Some(get_numeric_or_date_column_types()),
+            )?;
+            let idx_in_req_data = data.push_histogram_req_data(HistogramAggReqData {
+                accessor,
+                field_type,
+                column_block_accessor: Default::default(),
+                name: agg_name.to_string(),
+                sub_aggregation_blueprint: None,
+                req: histo_req.clone(),
+                is_date_histogram: false,
+                bounds: HistogramBounds {
+                    min: f64::MIN,
+                    max: f64::MAX,
+                },
+                offset: 0.0,
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::Histogram,
+                idx_in_req_data,
+                children,
+            }])
+        }
+        DateHistogram(date_req) => {
+            let (accessor, field_type) =
+                get_ff_reader(reader, &date_req.field, Some(&[ColumnType::DateTime]))?;
+            // Convert to histogram request, normalize to ns precision
+            let mut histo_req = date_req.to_histogram_req()?;
+            histo_req.normalize_date_time();
+            let idx_in_req_data = data.push_histogram_req_data(HistogramAggReqData {
+                accessor,
+                field_type,
+                column_block_accessor: Default::default(),
+                name: agg_name.to_string(),
+                sub_aggregation_blueprint: None,
+                req: histo_req,
+                is_date_histogram: true,
+                bounds: HistogramBounds {
+                    min: f64::MIN,
+                    max: f64::MAX,
+                },
+                offset: 0.0,
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::DateHistogram,
+                idx_in_req_data,
+                children,
+            }])
+        }
+        Terms(terms_req) => build_terms_or_cardinality_nodes(
+            agg_name,
+            &terms_req.field,
+            &terms_req.missing,
+            reader,
+            segment_ordinal,
+            data,
+            &req.sub_aggregation,
+            TermsOrCardinalityRequest::Terms(terms_req.clone()),
+        ),
+        Cardinality(card_req) => build_terms_or_cardinality_nodes(
+            agg_name,
+            &card_req.field,
+            &card_req.missing,
+            reader,
+            segment_ordinal,
+            data,
+            &req.sub_aggregation,
+            TermsOrCardinalityRequest::Cardinality(card_req.clone()),
+        ),
+        Average(AverageAggregation { field, missing, .. })
+        | Max(MaxAggregation { field, missing, .. })
+        | Min(MinAggregation { field, missing, .. })
+        | Stats(StatsAggregation { field, missing, .. })
+        | ExtendedStats(ExtendedStatsAggregation { field, missing, .. })
+        | Sum(SumAggregation { field, missing, .. })
+        | Count(CountAggregation { field, missing, .. }) => {
+            let allowed_column_types = if matches!(&req.agg, Count(_)) {
+                Some(
+                    &[
+                        ColumnType::I64,
+                        ColumnType::U64,
+                        ColumnType::F64,
+                        ColumnType::Str,
+                        ColumnType::DateTime,
+                        ColumnType::Bool,
+                        ColumnType::IpAddr,
+                    ][..],
+                )
+            } else {
+                Some(get_numeric_or_date_column_types())
+            };
+            let collecting_for = match &req.agg {
+                Average(_) => StatsType::Average,
+                Max(_) => StatsType::Max,
+                Min(_) => StatsType::Min,
+                Stats(_) => StatsType::Stats,
+                ExtendedStats(req) => StatsType::ExtendedStats(req.sigma),
+                Sum(_) => StatsType::Sum,
+                Count(_) => StatsType::Count,
+                _ => {
+                    return Err(crate::TantivyError::InvalidArgument(
+                        "Internal error: unexpected aggregation type in metric aggregation \
+                         handling."
+                            .to_string(),
+                    ))
+                }
+            };
+            let (accessor, field_type) = get_ff_reader(reader, field, allowed_column_types)?;
+            let idx_in_req_data = data.push_metric_req_data(MetricAggReqData {
+                accessor,
+                field_type,
+                column_block_accessor: Default::default(),
+                name: agg_name.to_string(),
+                collecting_for,
+                missing: *missing,
+                missing_u64: (*missing).and_then(|m| f64_to_fastfield_u64(m, &field_type)),
+                is_number_or_date_type: matches!(
+                    field_type,
+                    ColumnType::I64 | ColumnType::U64 | ColumnType::F64 | ColumnType::DateTime
+                ),
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::StatsKind(collecting_for),
+                idx_in_req_data,
+                children,
+            }])
+        }
+        // Percentiles handled as Metric as well
+        AggregationVariants::Percentiles(percentiles_req) => {
+            percentiles_req.validate()?;
+            let (accessor, field_type) = get_ff_reader(
+                reader,
+                percentiles_req.field_name(),
+                Some(get_numeric_or_date_column_types()),
+            )?;
+            let idx_in_req_data = data.push_metric_req_data(MetricAggReqData {
+                accessor,
+                field_type,
+                column_block_accessor: Default::default(),
+                name: agg_name.to_string(),
+                collecting_for: StatsType::Percentiles,
+                missing: percentiles_req.missing,
+                missing_u64: percentiles_req
+                    .missing
+                    .and_then(|m| f64_to_fastfield_u64(m, &field_type)),
+                is_number_or_date_type: matches!(
+                    field_type,
+                    ColumnType::I64 | ColumnType::U64 | ColumnType::F64 | ColumnType::DateTime
+                ),
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::StatsKind(StatsType::Percentiles),
+                idx_in_req_data,
+                children,
+            }])
+        }
+        AggregationVariants::TopHits(top_hits_req) => {
+            let mut top_hits = top_hits_req.clone();
+            top_hits.validate_and_resolve_field_names(reader.fast_fields().columnar())?;
+            let accessors: Vec<(Column<u64>, ColumnType)> = top_hits
+                .field_names()
+                .iter()
+                .map(|field| get_ff_reader(reader, field, Some(get_numeric_or_date_column_types())))
+                .collect::<crate::Result<_>>()?;
+
+            let value_accessors = top_hits
+                .value_field_names()
+                .iter()
+                .map(|field_name| {
+                    Ok((
+                        field_name.to_string(),
+                        get_dynamic_columns(reader, field_name)?,
+                    ))
+                })
+                .collect::<crate::Result<_>>()?;
+
+            let idx_in_req_data = data.push_top_hits_req_data(TopHitsAggReqData {
+                accessors,
+                value_accessors,
+                segment_ordinal,
+                name: agg_name.to_string(),
+                req: top_hits.clone(),
+            });
+            let children = build_children(&req.sub_aggregation, reader, segment_ordinal, data)?;
+            Ok(vec![AggRefNode {
+                kind: AggKind::TopHits,
+                idx_in_req_data,
+                children,
+            }])
+        }
+    }
+}
+
+fn build_children(
+    aggs: &Aggregations,
+    reader: &SegmentReader,
+    segment_ordinal: SegmentOrdinal,
+    data: &mut AggregationsData,
+) -> crate::Result<Vec<AggRefNode>> {
+    let mut children = Vec::new();
+    for (name, agg) in aggs.iter() {
+        children.extend(build_nodes(name, agg, reader, segment_ordinal, data)?);
+    }
+    Ok(children)
+}
+
+fn get_term_agg_accessors(
+    reader: &SegmentReader,
+    field_name: &str,
+    missing: &Option<Key>,
+) -> crate::Result<Vec<(Column<u64>, ColumnType)>> {
+    let allowed_column_types = [
+        ColumnType::I64,
+        ColumnType::U64,
+        ColumnType::F64,
+        ColumnType::Str,
+        ColumnType::DateTime,
+        ColumnType::Bool,
+        ColumnType::IpAddr,
+    ];
+
+    // In case the column is empty we want the shim column to match the missing type
+    let fallback_type = missing
+        .as_ref()
+        .map(|missing| match missing {
+            Key::Str(_) => ColumnType::Str,
+            Key::F64(_) => ColumnType::F64,
+            Key::I64(_) => ColumnType::I64,
+            Key::U64(_) => ColumnType::U64,
+        })
+        .unwrap_or(ColumnType::U64);
+
+    let column_and_types = get_all_ff_reader_or_empty(
+        reader,
+        field_name,
+        Some(&allowed_column_types),
+        fallback_type,
+    )?;
+
+    Ok(column_and_types)
+}
+
+enum TermsOrCardinalityRequest {
+    Terms(TermsAggregation),
+    Cardinality(CardinalityAggregationReq),
+}
+impl TermsOrCardinalityRequest {
+    fn as_terms(&self) -> Option<&TermsAggregation> {
+        match self {
+            TermsOrCardinalityRequest::Terms(t) => Some(t),
+            _ => None,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_terms_or_cardinality_nodes(
+    agg_name: &str,
+    field_name: &str,
+    missing: &Option<Key>,
+    reader: &SegmentReader,
+    segment_ordinal: SegmentOrdinal,
+    data: &mut AggregationsData,
+    sub_aggs: &Aggregations,
+    req: TermsOrCardinalityRequest,
+) -> crate::Result<Vec<AggRefNode>> {
+    let mut nodes = Vec::new();
+
+    let str_dict_column = reader.fast_fields().str(field_name)?;
+
+    let column_and_types = get_term_agg_accessors(reader, field_name, missing)?;
+
+    // Special handling when missing + multi column or incompatible type on text/date.
+    let missing_and_more_than_one_col = column_and_types.len() > 1 && missing.is_some();
+    let text_on_non_text_col = column_and_types.len() == 1
+        && column_and_types[0].1 != ColumnType::Str
+        && matches!(missing, Some(Key::Str(_)));
+
+    let use_special_missing_agg = missing_and_more_than_one_col || text_on_non_text_col;
+
+    // If special missing handling is required, build a MissingTerm node that carries all
+    // accessors (across any column types) for existence checks.
+    if use_special_missing_agg {
+        let fallback_type = missing
+            .as_ref()
+            .map(|missing| match missing {
+                Key::Str(_) => ColumnType::Str,
+                Key::F64(_) => ColumnType::F64,
+                Key::I64(_) => ColumnType::I64,
+                Key::U64(_) => ColumnType::U64,
+            })
+            .unwrap_or(ColumnType::U64);
+        let all_accessors = get_all_ff_reader_or_empty(reader, field_name, None, fallback_type)?
+            .into_iter()
+            .collect::<Vec<_>>();
+        // This case only happens when we have term aggregation, or we fail
+        let req = req.as_terms().cloned().ok_or_else(|| {
+            crate::TantivyError::InvalidArgument(
+                "Cardinality aggregation with missing on non-text/number field is not supported."
+                    .to_string(),
+            )
+        })?;
+
+        let children = build_children(sub_aggs, reader, segment_ordinal, data)?;
+        let idx_in_req_data = data.push_missing_term_req_data(MissingTermAggReqData {
+            accessors: all_accessors,
+            name: agg_name.to_string(),
+            req,
+        });
+        nodes.push(AggRefNode {
+            kind: AggKind::MissingTerm,
+            idx_in_req_data,
+            children,
+        });
+    }
+
+    // Add one node per accessor to mirror previous behavior and allow per-type missing handling.
+    for (accessor, column_type) in column_and_types {
+        let missing_value_for_accessor = if use_special_missing_agg {
+            None
+        } else if let Some(m) = missing.as_ref() {
+            get_missing_val_as_u64_lenient(column_type, m, field_name)?
+        } else {
+            None
+        };
+
+        let children = build_children(sub_aggs, reader, segment_ordinal, data)?;
+        let (idx, kind) = match req {
+            TermsOrCardinalityRequest::Terms(ref req) => {
+                let idx_in_req_data = data.push_term_req_data(TermsAggReqData {
+                    accessor,
+                    column_type,
+                    str_dict_column: str_dict_column.clone(),
+                    missing_value_for_accessor,
+                    column_block_accessor: Default::default(),
+                    name: agg_name.to_string(),
+                    field_type: column_type,
+                    req: TermsAggregationInternal::from_req(req),
+                    // Will be filled later when building collectors
+                    sub_aggregation_blueprint: None,
+                    sug_aggregations: sub_aggs.clone(),
+                });
+                (idx_in_req_data, AggKind::Terms)
+            }
+            TermsOrCardinalityRequest::Cardinality(ref req) => {
+                let idx_in_req_data = data.push_cardinality_req_data(CardinalityAggReqData {
+                    accessor,
+                    column_type,
+                    str_dict_column: str_dict_column.clone(),
+                    missing_value_for_accessor,
+                    column_block_accessor: Default::default(),
+                    name: agg_name.to_string(),
+                    req: req.clone(),
+                });
+                (idx_in_req_data, AggKind::Cardinality)
+            }
+        };
+        nodes.push(AggRefNode {
+            kind,
+            idx_in_req_data: idx,
+            children,
+        });
+    }
+
+    Ok(nodes)
+}
+
+/// Convert the aggregation tree to something serializable and easy to read.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct AggTreeViewNode {
+    pub name: String,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub children: Vec<AggTreeViewNode>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aggregation::agg_req::Aggregations;
+    use crate::aggregation::tests::get_test_index_2_segments;
+
+    fn agg_from_json(val: serde_json::Value) -> crate::aggregation::agg_req::Aggregation {
+        serde_json::from_value(val).unwrap()
+    }
+
+    #[test]
+    fn test_tree_roots_and_expansion_terms_missing_on_numeric() -> crate::Result<()> {
+        let index = get_test_index_2_segments(true)?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let seg_reader = searcher.segment_reader(0u32);
+
+        // Build request with:
+        // 1) Terms on numeric field with missing as string => expands to MissingTerm + Terms
+        // 2) Avg metric
+        // 3) Terms on string with child histogram
+        let terms_score_missing = agg_from_json(json!({
+            "terms": {"field": "score", "missing": "NA"}
+        }));
+        let avg_score = agg_from_json(json!({
+            "avg": {"field": "score"}
+        }));
+        let terms_string_with_child = agg_from_json(json!({
+            "terms": {"field": "string_id"},
+            "aggs": {
+                "histo": {"histogram": {"field": "score", "interval": 10.0}}
+            }
+        }));
+
+        let aggs: Aggregations = vec![
+            ("t_score_missing_str".to_string(), terms_score_missing),
+            ("avg_score".to_string(), avg_score),
+            ("terms_string".to_string(), terms_string_with_child),
+        ]
+        .into_iter()
+        .collect();
+
+        let data = build_aggregations_data_from_req(&aggs, seg_reader, 0u32, Default::default())?;
+        let printed_nodes = data.per_request.get_view_tree();
+        let printed = serde_json::to_value(&printed_nodes).unwrap();
+
+        let expected = json!([
+            {"name": "avg_score", "kind": "Metric"},
+            {"name": "t_score_missing_str", "kind": "MissingTerm"},
+            {"name": "t_score_missing_str", "kind": "Terms"},
+            {"name": "terms_string", "kind": "Terms", "children": [
+                {"name": "histo", "kind": "Histogram"}
+            ]}
+        ]);
+        assert_eq!(
+            printed,
+            expected,
+            "tree json:\n{}",
+            serde_json::to_string_pretty(&printed).unwrap()
+        );
+
+        Ok(())
+    }
+}

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -208,13 +208,6 @@ impl AggregationVariants {
             _ => None,
         }
     }
-    pub(crate) fn as_top_hits(&self) -> Option<&TopHitsAggregationReq> {
-        match &self {
-            AggregationVariants::TopHits(top_hits) => Some(top_hits),
-            _ => None,
-        }
-    }
-
     pub(crate) fn as_percentile(&self) -> Option<&PercentilesAggregationReq> {
         match &self {
             AggregationVariants::Percentiles(percentile_req) => Some(percentile_req),

--- a/src/aggregation/agg_req_with_accessor.rs
+++ b/src/aggregation/agg_req_with_accessor.rs
@@ -1,354 +1,11 @@
 //! This will enhance the request tree with access to the fastfield and metadata.
 
-use std::collections::HashMap;
 use std::io;
 
-use columnar::{Column, ColumnBlockAccessor, ColumnType, DynamicColumn, StrColumn};
+use columnar::{Column, ColumnType};
 
-use super::agg_req::{Aggregation, AggregationVariants, Aggregations};
-use super::bucket::{
-    DateHistogramAggregationReq, HistogramAggregation, RangeAggregation, TermsAggregation,
-};
-use super::metric::{
-    AverageAggregation, CardinalityAggregationReq, CountAggregation, ExtendedStatsAggregation,
-    MaxAggregation, MinAggregation, StatsAggregation, SumAggregation,
-};
-use super::segment_agg_result::AggregationLimitsGuard;
-use super::VecWithNames;
 use crate::aggregation::{f64_to_fastfield_u64, Key};
 use crate::index::SegmentReader;
-use crate::SegmentOrdinal;
-
-#[derive(Default)]
-pub(crate) struct AggregationsWithAccessor {
-    pub aggs: VecWithNames<AggregationWithAccessor>,
-}
-
-impl AggregationsWithAccessor {
-    fn from_data(aggs: VecWithNames<AggregationWithAccessor>) -> Self {
-        Self { aggs }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.aggs.is_empty()
-    }
-}
-
-pub struct AggregationWithAccessor {
-    pub(crate) segment_ordinal: SegmentOrdinal,
-    /// In general there can be buckets without fast field access, e.g. buckets that are created
-    /// based on search terms. That is not that case currently, but eventually this needs to be
-    /// Option or moved.
-    pub(crate) accessor: Column<u64>,
-    /// Load insert u64 for missing use case
-    pub(crate) missing_value_for_accessor: Option<u64>,
-    pub(crate) str_dict_column: Option<StrColumn>,
-    pub(crate) field_type: ColumnType,
-    pub(crate) sub_aggregation: AggregationsWithAccessor,
-    pub(crate) limits: AggregationLimitsGuard,
-    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
-    /// Used for missing term aggregation, which checks all columns for existence.
-    /// And also for `top_hits` aggregation, which may sort on multiple fields.
-    /// By convention the missing aggregation is chosen, when this property is set
-    /// (instead bein set in `agg`).
-    /// If this needs to used by other aggregations, we need to refactor this.
-    // NOTE: we can make all other aggregations use this instead of the `accessor` and `field_type`
-    // (making them obsolete) But will it have a performance impact?
-    pub(crate) accessors: Vec<(Column<u64>, ColumnType)>,
-    /// Map field names to all associated column accessors.
-    /// This field is used for `docvalue_fields`, which is currently only supported for `top_hits`.
-    pub(crate) value_accessors: HashMap<String, Vec<DynamicColumn>>,
-    pub(crate) agg: Aggregation,
-}
-
-impl AggregationWithAccessor {
-    /// May return multiple accessors if the aggregation is e.g. on mixed field types.
-    fn try_from_agg(
-        agg: &Aggregation,
-        sub_aggregation: &Aggregations,
-        reader: &SegmentReader,
-        segment_ordinal: SegmentOrdinal,
-        limits: AggregationLimitsGuard,
-    ) -> crate::Result<Vec<AggregationWithAccessor>> {
-        let mut agg = agg.clone();
-
-        let add_agg_with_accessor = |agg: &Aggregation,
-                                     accessor: Column<u64>,
-                                     column_type: ColumnType,
-                                     aggs: &mut Vec<AggregationWithAccessor>|
-         -> crate::Result<()> {
-            let res = AggregationWithAccessor {
-                segment_ordinal,
-                accessor,
-                accessors: Default::default(),
-                value_accessors: Default::default(),
-                field_type: column_type,
-                sub_aggregation: get_aggs_with_segment_accessor_and_validate(
-                    sub_aggregation,
-                    reader,
-                    segment_ordinal,
-                    &limits,
-                )?,
-                agg: agg.clone(),
-                limits: limits.clone(),
-                missing_value_for_accessor: None,
-                str_dict_column: None,
-                column_block_accessor: Default::default(),
-            };
-            aggs.push(res);
-            Ok(())
-        };
-
-        let add_agg_with_accessors = |agg: &Aggregation,
-                                      accessors: Vec<(Column<u64>, ColumnType)>,
-                                      aggs: &mut Vec<AggregationWithAccessor>,
-                                      value_accessors: HashMap<String, Vec<DynamicColumn>>|
-         -> crate::Result<()> {
-            let (accessor, field_type) = accessors.first().expect("at least one accessor");
-            let limits = limits.clone();
-            let res = AggregationWithAccessor {
-                segment_ordinal,
-                // TODO: We should do away with the `accessor` field altogether
-                accessor: accessor.clone(),
-                value_accessors,
-                field_type: *field_type,
-                accessors,
-                sub_aggregation: get_aggs_with_segment_accessor_and_validate(
-                    sub_aggregation,
-                    reader,
-                    segment_ordinal,
-                    &limits,
-                )?,
-                agg: agg.clone(),
-                limits,
-                missing_value_for_accessor: None,
-                str_dict_column: None,
-                column_block_accessor: Default::default(),
-            };
-            aggs.push(res);
-            Ok(())
-        };
-
-        let mut res: Vec<AggregationWithAccessor> = Vec::new();
-        use AggregationVariants::*;
-
-        match agg.agg {
-            Range(RangeAggregation {
-                field: ref field_name,
-                ..
-            }) => {
-                let (accessor, column_type) =
-                    get_ff_reader(reader, field_name, Some(get_numeric_or_date_column_types()))?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            Histogram(HistogramAggregation {
-                field: ref field_name,
-                ..
-            }) => {
-                let (accessor, column_type) =
-                    get_ff_reader(reader, field_name, Some(get_numeric_or_date_column_types()))?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            DateHistogram(DateHistogramAggregationReq {
-                field: ref field_name,
-                ..
-            }) => {
-                let (accessor, column_type) =
-                    // Only DateTime is supported for DateHistogram
-                    get_ff_reader(reader, field_name, Some(&[ColumnType::DateTime]))?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            Terms(TermsAggregation {
-                field: ref field_name,
-                ref missing,
-                ..
-            })
-            | Cardinality(CardinalityAggregationReq {
-                field: ref field_name,
-                ref missing,
-                ..
-            }) => {
-                let str_dict_column = reader.fast_fields().str(field_name)?;
-                let allowed_column_types = [
-                    ColumnType::I64,
-                    ColumnType::U64,
-                    ColumnType::F64,
-                    ColumnType::Str,
-                    ColumnType::DateTime,
-                    ColumnType::Bool,
-                    ColumnType::IpAddr,
-                    // ColumnType::Bytes Unsupported
-                ];
-
-                // In case the column is empty we want the shim column to match the missing type
-                let fallback_type = missing
-                    .as_ref()
-                    .map(|missing| match missing {
-                        Key::Str(_) => ColumnType::Str,
-                        Key::F64(_) => ColumnType::F64,
-                        Key::I64(_) => ColumnType::I64,
-                        Key::U64(_) => ColumnType::U64,
-                    })
-                    .unwrap_or(ColumnType::U64);
-                let column_and_types = get_all_ff_reader_or_empty(
-                    reader,
-                    field_name,
-                    Some(&allowed_column_types),
-                    fallback_type,
-                )?;
-                let missing_and_more_than_one_col = column_and_types.len() > 1 && missing.is_some();
-                let text_on_non_text_col = column_and_types.len() == 1
-                    && column_and_types[0].1.numerical_type().is_some()
-                    && missing
-                        .as_ref()
-                        .map(|m| matches!(m, Key::Str(_)))
-                        .unwrap_or(false);
-
-                // Actually we could convert the text to a number and have the fast path, if it is
-                // provided in Rfc3339 format. But this use case is probably common
-                // enough to justify the effort.
-                let text_on_date_col = column_and_types.len() == 1
-                    && column_and_types[0].1 == ColumnType::DateTime
-                    && missing
-                        .as_ref()
-                        .map(|m| matches!(m, Key::Str(_)))
-                        .unwrap_or(false);
-
-                let use_special_missing_agg =
-                    missing_and_more_than_one_col || text_on_non_text_col || text_on_date_col;
-                if use_special_missing_agg {
-                    let column_and_types =
-                        get_all_ff_reader_or_empty(reader, field_name, None, fallback_type)?;
-
-                    let accessors = column_and_types
-                        .iter()
-                        .map(|c_t| (c_t.0.clone(), c_t.1))
-                        .collect();
-                    add_agg_with_accessors(&agg, accessors, &mut res, Default::default())?;
-                }
-
-                for (accessor, column_type) in column_and_types {
-                    let missing_value_term_agg = if use_special_missing_agg {
-                        None
-                    } else {
-                        missing.clone()
-                    };
-
-                    let missing_value_for_accessor =
-                        if let Some(missing) = missing_value_term_agg.as_ref() {
-                            get_missing_val_as_u64_lenient(
-                                column_type,
-                                missing,
-                                agg.agg.get_fast_field_names()[0],
-                            )?
-                        } else {
-                            None
-                        };
-
-                    let limits = limits.clone();
-                    let agg = AggregationWithAccessor {
-                        segment_ordinal,
-                        missing_value_for_accessor,
-                        accessor,
-                        accessors: Default::default(),
-                        value_accessors: Default::default(),
-                        field_type: column_type,
-                        sub_aggregation: get_aggs_with_segment_accessor_and_validate(
-                            sub_aggregation,
-                            reader,
-                            segment_ordinal,
-                            &limits,
-                        )?,
-                        agg: agg.clone(),
-                        str_dict_column: str_dict_column.clone(),
-                        limits,
-                        column_block_accessor: Default::default(),
-                    };
-                    res.push(agg);
-                }
-            }
-            Average(AverageAggregation {
-                field: ref field_name,
-                ..
-            })
-            | Max(MaxAggregation {
-                field: ref field_name,
-                ..
-            })
-            | Min(MinAggregation {
-                field: ref field_name,
-                ..
-            })
-            | Stats(StatsAggregation {
-                field: ref field_name,
-                ..
-            })
-            | ExtendedStats(ExtendedStatsAggregation {
-                field: ref field_name,
-                ..
-            })
-            | Sum(SumAggregation {
-                field: ref field_name,
-                ..
-            }) => {
-                let (accessor, column_type) =
-                    get_ff_reader(reader, field_name, Some(get_numeric_or_date_column_types()))?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            Count(CountAggregation {
-                field: ref field_name,
-                ..
-            }) => {
-                let allowed_column_types = [
-                    ColumnType::I64,
-                    ColumnType::U64,
-                    ColumnType::F64,
-                    ColumnType::Str,
-                    ColumnType::DateTime,
-                    ColumnType::Bool,
-                    ColumnType::IpAddr,
-                    // ColumnType::Bytes Unsupported
-                ];
-                let (accessor, column_type) =
-                    get_ff_reader(reader, field_name, Some(&allowed_column_types))?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            Percentiles(ref percentiles) => {
-                let (accessor, column_type) = get_ff_reader(
-                    reader,
-                    percentiles.field_name(),
-                    Some(get_numeric_or_date_column_types()),
-                )?;
-                add_agg_with_accessor(&agg, accessor, column_type, &mut res)?;
-            }
-            TopHits(ref mut top_hits) => {
-                top_hits.validate_and_resolve_field_names(reader.fast_fields().columnar())?;
-                let accessors: Vec<(Column<u64>, ColumnType)> = top_hits
-                    .field_names()
-                    .iter()
-                    .map(|field| {
-                        get_ff_reader(reader, field, Some(get_numeric_or_date_column_types()))
-                    })
-                    .collect::<crate::Result<_>>()?;
-
-                let value_accessors = top_hits
-                    .value_field_names()
-                    .iter()
-                    .map(|field_name| {
-                        Ok((
-                            field_name.to_string(),
-                            get_dynamic_columns(reader, field_name)?,
-                        ))
-                    })
-                    .collect::<crate::Result<_>>()?;
-
-                add_agg_with_accessors(&agg, accessors, &mut res, value_accessors)?;
-            }
-        };
-
-        Ok(res)
-    }
-}
 
 /// Get the missing value as internal u64 representation
 ///
@@ -357,7 +14,7 @@ impl AggregationWithAccessor {
 /// we would get from the fast field, when we open it as u64_lenient_for_type.
 ///
 /// That way we can use it the same way as if it would come from the fastfield.
-fn get_missing_val_as_u64_lenient(
+pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
     missing: &Key,
     field_name: &str,
@@ -388,7 +45,7 @@ fn get_missing_val_as_u64_lenient(
     Ok(missing_val)
 }
 
-fn get_numeric_or_date_column_types() -> &'static [ColumnType] {
+pub(crate) fn get_numeric_or_date_column_types() -> &'static [ColumnType] {
     &[
         ColumnType::F64,
         ColumnType::U64,
@@ -397,32 +54,8 @@ fn get_numeric_or_date_column_types() -> &'static [ColumnType] {
     ]
 }
 
-pub(crate) fn get_aggs_with_segment_accessor_and_validate(
-    aggs: &Aggregations,
-    reader: &SegmentReader,
-    segment_ordinal: SegmentOrdinal,
-    limits: &AggregationLimitsGuard,
-) -> crate::Result<AggregationsWithAccessor> {
-    let mut aggss = Vec::new();
-    for (key, agg) in aggs.iter() {
-        let aggs = AggregationWithAccessor::try_from_agg(
-            agg,
-            agg.sub_aggregation(),
-            reader,
-            segment_ordinal,
-            limits.clone(),
-        )?;
-        for agg in aggs {
-            aggss.push((key.to_string(), agg));
-        }
-    }
-    Ok(AggregationsWithAccessor::from_data(
-        VecWithNames::from_entries(aggss),
-    ))
-}
-
 /// Get fast field reader or empty as default.
-fn get_ff_reader(
+pub(crate) fn get_ff_reader(
     reader: &SegmentReader,
     field_name: &str,
     allowed_column_types: Option<&[ColumnType]>,
@@ -439,7 +72,7 @@ fn get_ff_reader(
     Ok(ff_field_with_type)
 }
 
-fn get_dynamic_columns(
+pub(crate) fn get_dynamic_columns(
     reader: &SegmentReader,
     field_name: &str,
 ) -> crate::Result<Vec<columnar::DynamicColumn>> {
@@ -455,7 +88,7 @@ fn get_dynamic_columns(
 /// Get all fast field reader or empty as default.
 ///
 /// Is guaranteed to return at least one column.
-fn get_all_ff_reader_or_empty(
+pub(crate) fn get_all_ff_reader_or_empty(
     reader: &SegmentReader,
     field_name: &str,
     allowed_column_types: Option<&[ColumnType]>,

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use columnar::{Column, ColumnBlockAccessor, ColumnType};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use tantivy_bitpacker::minmax;
@@ -17,6 +18,30 @@ use crate::aggregation::intermediate_agg_result::{
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::TantivyError;
+
+/// Contains all information required by the SegmentHistogramCollector to perform the
+/// histogram or date_histogram aggregation on a segment.
+pub struct HistogramAggReqData {
+    /// The column accessor to access the fast field values.
+    pub accessor: Column<u64>,
+    /// The field type of the fast field.
+    pub field_type: ColumnType,
+    /// The column block accessor to access the fast field values.
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    /// The name of the aggregation.
+    pub name: String,
+    /// The sub aggregation blueprint, used to create sub aggregations for each bucket.
+    /// Will be filled during initialization of the collector.
+    pub sub_aggregation_blueprint: Option<Box<dyn SegmentAggregationCollector>>,
+    /// The histogram aggregation request.
+    pub req: HistogramAggregation,
+    /// True if this is a date_histogram aggregation.
+    pub is_date_histogram: bool,
+    /// The bounds to limit the buckets to.
+    pub bounds: HistogramBounds,
+    /// The offset used to calculate the bucket position.
+    pub offset: f64,
+}
 
 /// Histogram is a bucket aggregation, where buckets are created dynamically for given `interval`.
 /// Each document value is rounded down to its bucket.

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::ops::Range;
 
+use columnar::{Column, ColumnBlockAccessor, ColumnType};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -14,6 +15,21 @@ use crate::aggregation::intermediate_agg_result::{
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::TantivyError;
+
+/// Contains all information required by the SegmentRangeCollector to perform the
+/// range aggregation on a segment.
+pub struct RangeAggReqData {
+    /// The column accessor to access the fast field values.
+    pub accessor: Column<u64>,
+    /// The type of the fast field.
+    pub field_type: ColumnType,
+    /// The column block accessor to access the fast field values.
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    /// The range aggregation request.
+    pub req: RangeAggregation,
+    /// The name of the aggregation.
+    pub name: String,
+}
 
 /// Provide user-defined buckets to aggregate on.
 ///

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -4,14 +4,12 @@ use std::ops::Range;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use crate::aggregation::agg_req_with_accessor::AggregationsWithAccessor;
+use crate::aggregation::agg_data::{build_segment_agg_collectors, AggRefNode, AggregationsData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
     IntermediateRangeBucketEntry, IntermediateRangeBucketResult,
 };
-use crate::aggregation::segment_agg_result::{
-    build_segment_agg_collector, SegmentAggregationCollector,
-};
+use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::TantivyError;
 
@@ -161,12 +159,12 @@ impl Debug for SegmentRangeBucketEntry {
 impl SegmentRangeBucketEntry {
     pub(crate) fn into_intermediate_bucket_entry(
         self,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_data: &AggregationsData,
     ) -> crate::Result<IntermediateRangeBucketEntry> {
         let mut sub_aggregation_res = IntermediateAggregationResults::default();
         if let Some(sub_aggregation) = self.sub_aggregation {
             sub_aggregation
-                .add_intermediate_aggregation_result(agg_with_accessor, &mut sub_aggregation_res)?
+                .add_intermediate_aggregation_result(agg_data, &mut sub_aggregation_res)?
         } else {
             Default::default()
         };
@@ -184,12 +182,14 @@ impl SegmentRangeBucketEntry {
 impl SegmentAggregationCollector for SegmentRangeCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_data: &AggregationsData,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let field_type = self.column_type;
-        let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
-        let sub_agg = &agg_with_accessor.aggs.values[self.accessor_idx].sub_aggregation;
+        let name = agg_data
+            .get_range_req_data(self.accessor_idx)
+            .name
+            .to_string();
 
         let buckets: FxHashMap<SerializedKey, IntermediateRangeBucketEntry> = self
             .buckets
@@ -199,7 +199,7 @@ impl SegmentAggregationCollector for SegmentRangeCollector {
                     range_to_string(&range_bucket.range, &field_type)?,
                     range_bucket
                         .bucket
-                        .into_intermediate_bucket_entry(sub_agg)?,
+                        .into_intermediate_bucket_entry(agg_data)?,
                 ))
             })
             .collect::<crate::Result<_>>()?;
@@ -215,69 +215,69 @@ impl SegmentAggregationCollector for SegmentRangeCollector {
     }
 
     #[inline]
-    fn collect(
-        &mut self,
-        doc: crate::DocId,
-        agg_with_accessor: &mut AggregationsWithAccessor,
-    ) -> crate::Result<()> {
-        self.collect_block(&[doc], agg_with_accessor)
+    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+        self.collect_block(&[doc], agg_data)
     }
 
     #[inline]
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &mut AggregationsWithAccessor,
+        agg_data: &mut AggregationsData,
     ) -> crate::Result<()> {
-        let bucket_agg_accessor = &mut agg_with_accessor.aggs.values[self.accessor_idx];
+        // Take request data to avoid borrow conflicts during sub-aggregation
+        let mut req = agg_data.take_range_req_data(self.accessor_idx);
 
-        bucket_agg_accessor
-            .column_block_accessor
-            .fetch_block(docs, &bucket_agg_accessor.accessor);
+        req.column_block_accessor.fetch_block(docs, &req.accessor);
 
-        for (doc, val) in bucket_agg_accessor
+        for (doc, val) in req
             .column_block_accessor
-            .iter_docid_vals(docs, &bucket_agg_accessor.accessor)
+            .iter_docid_vals(docs, &req.accessor)
         {
             let bucket_pos = self.get_bucket_pos(val);
-
             let bucket = &mut self.buckets[bucket_pos];
-
             bucket.bucket.doc_count += 1;
-            if let Some(sub_aggregation) = &mut bucket.bucket.sub_aggregation {
-                sub_aggregation.collect(doc, &mut bucket_agg_accessor.sub_aggregation)?;
+            if let Some(sub_agg) = bucket.bucket.sub_aggregation.as_mut() {
+                sub_agg.collect(doc, agg_data)?;
             }
         }
+
+        agg_data.put_back_range_req_data(self.accessor_idx, req);
 
         Ok(())
     }
 
-    fn flush(&mut self, agg_with_accessor: &mut AggregationsWithAccessor) -> crate::Result<()> {
-        let sub_aggregation_accessor =
-            &mut agg_with_accessor.aggs.values[self.accessor_idx].sub_aggregation;
-
+    fn flush(&mut self, agg_data: &mut AggregationsData) -> crate::Result<()> {
         for bucket in self.buckets.iter_mut() {
             if let Some(sub_agg) = bucket.bucket.sub_aggregation.as_mut() {
-                sub_agg.flush(sub_aggregation_accessor)?;
+                sub_agg.flush(agg_data)?;
             }
         }
-
         Ok(())
     }
 }
 
 impl SegmentRangeCollector {
     pub(crate) fn from_req_and_validate(
-        req: &RangeAggregation,
-        sub_aggregation: &mut AggregationsWithAccessor,
-        limits: &mut AggregationLimitsGuard,
-        field_type: ColumnType,
-        accessor_idx: usize,
+        req_data: &mut AggregationsData,
+        node: &AggRefNode,
     ) -> crate::Result<Self> {
+        let accessor_idx = node.idx_in_req_data;
+        let (field_type, ranges) = {
+            let req_view = req_data.get_range_req_data(node.idx_in_req_data);
+            (req_view.field_type, req_view.req.ranges.clone())
+        };
+
         // The range input on the request is f64.
         // We need to convert to u64 ranges, because we read the values as u64.
         // The mapping from the conversion is monotonic so ordering is preserved.
-        let buckets: Vec<_> = extend_validate_ranges(&req.ranges, &field_type)?
+        let sub_agg_prototype = if !node.children.is_empty() {
+            Some(build_segment_agg_collectors(req_data, &node.children)?)
+        } else {
+            None
+        };
+
+        let buckets: Vec<_> = extend_validate_ranges(&ranges, &field_type)?
             .iter()
             .map(|range| {
                 let key = range
@@ -295,11 +295,7 @@ impl SegmentRangeCollector {
                 } else {
                     Some(f64_from_fastfield_u64(range.range.start, &field_type))
                 };
-                let sub_aggregation = if sub_aggregation.is_empty() {
-                    None
-                } else {
-                    Some(build_segment_agg_collector(sub_aggregation)?)
-                };
+                let sub_aggregation = sub_agg_prototype.clone();
 
                 Ok(SegmentRangeAndBucketEntry {
                     range: range.range.clone(),
@@ -314,7 +310,7 @@ impl SegmentRangeCollector {
             })
             .collect::<crate::Result<_>>()?;
 
-        limits.add_memory_consumed(
+        req_data.limits.add_memory_consumed(
             buckets.len() as u64 * std::mem::size_of::<SegmentRangeAndBucketEntry>() as u64,
         )?;
 
@@ -467,15 +463,45 @@ mod tests {
             ranges,
             ..Default::default()
         };
+        // Build buckets directly as in from_req_and_validate without AggregationsData
+        let buckets: Vec<_> = extend_validate_ranges(&req.ranges, &field_type)
+            .expect("unexpected error in extend_validate_ranges")
+            .iter()
+            .map(|range| {
+                let key = range
+                    .key
+                    .clone()
+                    .map(|key| Ok(Key::Str(key)))
+                    .unwrap_or_else(|| range_to_key(&range.range, &field_type))
+                    .expect("unexpected error in range_to_key");
+                let to = if range.range.end == u64::MAX {
+                    None
+                } else {
+                    Some(f64_from_fastfield_u64(range.range.end, &field_type))
+                };
+                let from = if range.range.start == u64::MIN {
+                    None
+                } else {
+                    Some(f64_from_fastfield_u64(range.range.start, &field_type))
+                };
+                SegmentRangeAndBucketEntry {
+                    range: range.range.clone(),
+                    bucket: SegmentRangeBucketEntry {
+                        doc_count: 0,
+                        sub_aggregation: None,
+                        key,
+                        from,
+                        to,
+                    },
+                }
+            })
+            .collect();
 
-        SegmentRangeCollector::from_req_and_validate(
-            &req,
-            &mut Default::default(),
-            &mut AggregationLimitsGuard::default(),
-            field_type,
-            0,
-        )
-        .expect("unexpected error")
+        SegmentRangeCollector {
+            buckets,
+            column_type: field_type,
+            accessor_idx: 0,
+        }
     }
 
     #[test]

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -1,13 +1,32 @@
+use columnar::{Column, ColumnType};
 use rustc_hash::FxHashMap;
 
 use crate::aggregation::agg_data::{
     build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
 };
+use crate::aggregation::bucket::term_agg::TermsAggregation;
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
     IntermediateKey, IntermediateTermBucketEntry, IntermediateTermBucketResult,
 };
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
+
+/// Special aggregation to handle missing values for term aggregations.
+/// This missing aggregation will check multiple columns for existence.
+///
+/// This is needed when:
+/// - The field is multi-valued and we therefore have multiple columns
+/// - The field is not text and missing is provided as string (we cannot use the numeric missing
+///   value optimization)
+#[derive(Default)]
+pub struct MissingTermAggReqData {
+    /// The accessors to check for existence of a value.
+    pub accessors: Vec<(Column<u64>, ColumnType)>,
+    /// The name of the aggregation.
+    pub name: String,
+    /// The original terms aggregation request.
+    pub req: TermsAggregation,
+}
 
 /// The specialized missing term aggregation.
 #[derive(Default, Debug, Clone)]

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -4,7 +4,7 @@ use super::buf_collector::BufAggregationCollector;
 use super::intermediate_agg_result::IntermediateAggregationResults;
 use super::segment_agg_result::{AggregationLimitsGuard, SegmentAggregationCollector};
 use crate::aggregation::agg_data::{
-    build_aggregations_data_from_req, build_segment_agg_collectors_root, AggregationsData,
+    build_aggregations_data_from_req, build_segment_agg_collectors_root, AggregationsSegmentCtx,
 };
 use crate::collector::{Collector, SegmentCollector};
 use crate::index::SegmentReader;
@@ -134,7 +134,7 @@ fn merge_fruits(
 
 /// `AggregationSegmentCollector` does the aggregation collection on a segment.
 pub struct AggregationSegmentCollector {
-    aggs_with_accessor: AggregationsData,
+    aggs_with_accessor: AggregationsSegmentCtx,
     agg_collector: BufAggregationCollector,
     error: Option<TantivyError>,
 }

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -246,6 +246,7 @@ pub(crate) fn empty_from_req(req: &Aggregation) -> IntermediateAggregationResult
 
 /// An aggregation is either a bucket or a metric.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum IntermediateAggregationResult {
     /// Bucket variant
     Bucket(IntermediateBucketResult),

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -8,9 +8,7 @@ use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 
-use crate::aggregation::agg_req_with_accessor::{
-    AggregationWithAccessor, AggregationsWithAccessor,
-};
+use crate::aggregation::agg_data::{AggregationsData, CardinalityAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -115,47 +113,44 @@ impl CardinalityAggregationReq {
 pub(crate) struct SegmentCardinalityCollector {
     cardinality: CardinalityCollector,
     entries: FxHashSet<u64>,
-    column_type: ColumnType,
     accessor_idx: usize,
-    missing: Option<Key>,
 }
 
 impl SegmentCardinalityCollector {
-    pub fn from_req(column_type: ColumnType, accessor_idx: usize, missing: &Option<Key>) -> Self {
+    pub fn from_req(column_type: ColumnType, accessor_idx: usize) -> Self {
         Self {
             cardinality: CardinalityCollector::new(column_type as u8),
             entries: Default::default(),
-            column_type,
             accessor_idx,
-            missing: missing.clone(),
         }
     }
 
     fn fetch_block_with_field(
         &mut self,
         docs: &[crate::DocId],
-        agg_accessor: &mut AggregationWithAccessor,
+        agg_data: &mut CardinalityAggReqData,
     ) {
-        if let Some(missing) = agg_accessor.missing_value_for_accessor {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
+        if let Some(missing) = agg_data.missing_value_for_accessor {
+            agg_data.column_block_accessor.fetch_block_with_missing(
                 docs,
-                &agg_accessor.accessor,
+                &agg_data.accessor,
                 missing,
             );
         } else {
-            agg_accessor
+            agg_data
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, &agg_data.accessor);
         }
     }
 
     fn into_intermediate_metric_result(
         mut self,
-        agg_with_accessor: &AggregationWithAccessor,
+        agg_data: &AggregationsData,
     ) -> crate::Result<IntermediateMetricResult> {
-        if self.column_type == ColumnType::Str {
+        let req_data = &agg_data.get_cardinality_req_data(self.accessor_idx);
+        if req_data.column_type == ColumnType::Str {
             let fallback_dict = Dictionary::empty();
-            let dict = agg_with_accessor
+            let dict = req_data
                 .str_dict_column
                 .as_ref()
                 .map(|el| el.dictionary())
@@ -180,10 +175,10 @@ impl SegmentCardinalityCollector {
             })?;
             if has_missing {
                 // Replace missing with the actual value provided
-                let missing_key = self
-                    .missing
-                    .as_ref()
-                    .expect("Found sentinel value u64::MAX for term_ord but `missing` is not set");
+                let missing_key =
+                    req_data.req.missing.as_ref().expect(
+                        "Found sentinel value u64::MAX for term_ord but `missing` is not set",
+                    );
                 match missing_key {
                     Key::Str(missing) => {
                         self.cardinality.sketch.insert_any(&missing);
@@ -209,13 +204,13 @@ impl SegmentCardinalityCollector {
 impl SegmentAggregationCollector for SegmentCardinalityCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_data: &AggregationsData,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
-        let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
-        let agg_with_accessor = &agg_with_accessor.aggs.values[self.accessor_idx];
+        let req_data = &agg_data.get_cardinality_req_data(self.accessor_idx);
+        let name = req_data.name.to_string();
 
-        let intermediate_result = self.into_intermediate_metric_result(agg_with_accessor)?;
+        let intermediate_result = self.into_intermediate_metric_result(agg_data)?;
         results.push(
             name,
             IntermediateAggregationResult::Metric(intermediate_result),
@@ -224,29 +219,25 @@ impl SegmentAggregationCollector for SegmentCardinalityCollector {
         Ok(())
     }
 
-    fn collect(
-        &mut self,
-        doc: crate::DocId,
-        agg_with_accessor: &mut AggregationsWithAccessor,
-    ) -> crate::Result<()> {
-        self.collect_block(&[doc], agg_with_accessor)
+    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+        self.collect_block(&[doc], agg_data)
     }
 
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &mut AggregationsWithAccessor,
+        agg_data: &mut AggregationsData,
     ) -> crate::Result<()> {
-        let bucket_agg_accessor = &mut agg_with_accessor.aggs.values[self.accessor_idx];
-        self.fetch_block_with_field(docs, bucket_agg_accessor);
+        let req_data = agg_data.get_cardinality_req_data_mut(self.accessor_idx);
+        self.fetch_block_with_field(docs, req_data);
 
-        let col_block_accessor = &bucket_agg_accessor.column_block_accessor;
-        if self.column_type == ColumnType::Str {
+        let col_block_accessor = &req_data.column_block_accessor;
+        if req_data.column_type == ColumnType::Str {
             for term_ord in col_block_accessor.iter_vals() {
                 self.entries.insert(term_ord);
             }
-        } else if self.column_type == ColumnType::IpAddr {
-            let compact_space_accessor = bucket_agg_accessor
+        } else if req_data.column_type == ColumnType::IpAddr {
+            let compact_space_accessor = req_data
                 .accessor
                 .values
                 .clone()

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -8,7 +8,7 @@ use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 
-use crate::aggregation::agg_data::{AggregationsData, CardinalityAggReqData};
+use crate::aggregation::agg_data::{AggregationsSegmentCtx, CardinalityAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -145,7 +145,7 @@ impl SegmentCardinalityCollector {
 
     fn into_intermediate_metric_result(
         mut self,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
     ) -> crate::Result<IntermediateMetricResult> {
         let req_data = &agg_data.get_cardinality_req_data(self.accessor_idx);
         if req_data.column_type == ColumnType::Str {
@@ -204,7 +204,7 @@ impl SegmentCardinalityCollector {
 impl SegmentAggregationCollector for SegmentCardinalityCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let req_data = &agg_data.get_cardinality_req_data(self.accessor_idx);
@@ -219,14 +219,18 @@ impl SegmentAggregationCollector for SegmentCardinalityCollector {
         Ok(())
     }
 
-    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
         self.collect_block(&[doc], agg_data)
     }
 
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_cardinality_req_data_mut(self.accessor_idx);
         self.fetch_block_with_field(docs, req_data);

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -4,9 +4,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_req_with_accessor::{
-    AggregationWithAccessor, AggregationsWithAccessor,
-};
+use crate::aggregation::agg_data::{AggregationsData, MetricAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -348,20 +346,20 @@ impl SegmentExtendedStatsCollector {
     pub(crate) fn collect_block_with_field(
         &mut self,
         docs: &[DocId],
-        agg_accessor: &mut AggregationWithAccessor,
+        req_data: &mut MetricAggReqData,
     ) {
         if let Some(missing) = self.missing.as_ref() {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
+            req_data.column_block_accessor.fetch_block_with_missing(
                 docs,
-                &agg_accessor.accessor,
+                &req_data.accessor,
                 *missing,
             );
         } else {
-            agg_accessor
+            req_data
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, &req_data.accessor);
         }
-        for val in agg_accessor.column_block_accessor.iter_vals() {
+        for val in req_data.column_block_accessor.iter_vals() {
             let val1 = f64_from_fastfield_u64(val, &self.field_type);
             self.extended_stats.collect(val1);
         }
@@ -372,10 +370,10 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     #[inline]
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_data: &AggregationsData,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
-        let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
+        let name = agg_data.get_metric_req_data(self.accessor_idx).name.clone();
         results.push(
             name,
             IntermediateAggregationResult::Metric(IntermediateMetricResult::ExtendedStats(
@@ -387,15 +385,11 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     }
 
     #[inline]
-    fn collect(
-        &mut self,
-        doc: crate::DocId,
-        agg_with_accessor: &mut AggregationsWithAccessor,
-    ) -> crate::Result<()> {
-        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessor;
+    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+        let req_data = agg_data.get_metric_req_data(self.accessor_idx);
         if let Some(missing) = self.missing {
             let mut has_val = false;
-            for val in field.values_for_doc(doc) {
+            for val in req_data.accessor.values_for_doc(doc) {
                 let val1 = f64_from_fastfield_u64(val, &self.field_type);
                 self.extended_stats.collect(val1);
                 has_val = true;
@@ -405,7 +399,7 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
                     .collect(f64_from_fastfield_u64(missing, &self.field_type));
             }
         } else {
-            for val in field.values_for_doc(doc) {
+            for val in req_data.accessor.values_for_doc(doc) {
                 let val1 = f64_from_fastfield_u64(val, &self.field_type);
                 self.extended_stats.collect(val1);
             }
@@ -418,10 +412,10 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &mut AggregationsWithAccessor,
+        agg_data: &mut AggregationsData,
     ) -> crate::Result<()> {
-        let field = &mut agg_with_accessor.aggs.values[self.accessor_idx];
-        self.collect_block_with_field(docs, field);
+        let req_data = agg_data.get_metric_req_data_mut(self.accessor_idx);
+        self.collect_block_with_field(docs, req_data);
         Ok(())
     }
 }

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -4,10 +4,11 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
+use crate::aggregation::agg_data::AggregationsSegmentCtx;
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
+use crate::aggregation::metric::MetricAggReqData;
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::{DocId, TantivyError};

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -4,7 +4,7 @@ use std::mem;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsData, MetricAggReqData};
+use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -370,7 +370,7 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     #[inline]
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let name = agg_data.get_metric_req_data(self.accessor_idx).name.clone();
@@ -385,7 +385,11 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     }
 
     #[inline]
-    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data(self.accessor_idx);
         if let Some(missing) = self.missing {
             let mut has_val = false;
@@ -412,7 +416,7 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data_mut(self.accessor_idx);
         self.collect_block_with_field(docs, req_data);

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -31,6 +31,7 @@ use std::collections::HashMap;
 
 pub use average::*;
 pub use cardinality::*;
+use columnar::{Column, ColumnBlockAccessor, ColumnType};
 pub use count::*;
 pub use extended_stats::*;
 pub use max::*;
@@ -43,6 +44,28 @@ pub use sum::*;
 pub use top_hits::*;
 
 use crate::schema::OwnedValue;
+
+/// Contains all information required by metric aggregations like avg, min, max, sum, stats,
+/// extended_stats, count, percentiles.
+#[repr(C)]
+pub struct MetricAggReqData {
+    /// True if the field is of number or date type.
+    pub is_number_or_date_type: bool,
+    /// The type of the field.
+    pub field_type: ColumnType,
+    /// The missing value normalized to the internal u64 representation of the field type.
+    pub missing_u64: Option<u64>,
+    /// The column block accessor to access the fast field values.
+    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    /// The column accessor to access the fast field values.
+    pub accessor: Column<u64>,
+    /// Used when converting to intermediate result
+    pub collecting_for: StatsType,
+    /// The missing value
+    pub missing: Option<f64>,
+    /// The name of the aggregation.
+    pub name: String,
+}
 
 /// Single-metric aggregations use this common result structure.
 ///

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsData, MetricAggReqData};
+use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -263,7 +263,7 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
     #[inline]
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let name = agg_data.get_metric_req_data(self.accessor_idx).name.clone();
@@ -278,7 +278,11 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
     }
 
     #[inline]
-    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data(self.accessor_idx);
 
         if let Some(missing) = req_data.missing_u64 {
@@ -306,7 +310,7 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data_mut(self.accessor_idx);
         self.collect_block_with_field(docs, req_data);

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -3,10 +3,11 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
+use crate::aggregation::agg_data::AggregationsSegmentCtx;
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
+use crate::aggregation::metric::MetricAggReqData;
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::{DocId, TantivyError};

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -3,10 +3,11 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
+use crate::aggregation::agg_data::AggregationsSegmentCtx;
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
+use crate::aggregation::metric::MetricAggReqData;
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::*;
 use crate::{DocId, TantivyError};

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_data::{AggregationsData, MetricAggReqData};
+use crate::aggregation::agg_data::{AggregationsSegmentCtx, MetricAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -234,7 +234,7 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     #[inline]
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let req = agg_data.get_metric_req_data(self.accessor_idx);
@@ -268,7 +268,11 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     }
 
     #[inline]
-    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data(self.accessor_idx);
         if let Some(missing) = req_data.missing_u64 {
             let mut has_val = false;
@@ -295,7 +299,7 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_metric_req_data_mut(self.accessor_idx);
         self.collect_block_with_field(docs, req_data);

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -3,9 +3,7 @@ use std::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::aggregation::agg_req_with_accessor::{
-    AggregationWithAccessor, AggregationsWithAccessor,
-};
+use crate::aggregation::agg_data::{AggregationsData, MetricAggReqData};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateMetricResult,
 };
@@ -166,74 +164,65 @@ impl IntermediateStats {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum SegmentStatsType {
+/// The type of stats aggregation to perform.
+/// Note that not all stats types are supported in the stats aggregation.
+#[derive(Clone, Copy, Debug)]
+pub enum StatsType {
+    /// The average of the values.
     Average,
+    /// The count of the values.
     Count,
+    /// The maximum value.
     Max,
+    /// The minimum value.
     Min,
+    /// The stats (count, sum, min, max, avg) of the values.
     Stats,
+    /// The extended stats (count, sum, min, max, avg, sum_of_squares, variance, std_deviation,
+    ExtendedStats(Option<f64>), // sigma
+    /// The sum of the values.
     Sum,
+    /// The percentiles of the values.
+    Percentiles,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct SegmentStatsCollector {
-    missing: Option<u64>,
-    field_type: ColumnType,
-    pub(crate) collecting_for: SegmentStatsType,
     pub(crate) stats: IntermediateStats,
     pub(crate) accessor_idx: usize,
-    val_cache: Vec<u64>,
 }
 
 impl SegmentStatsCollector {
-    pub fn from_req(
-        field_type: ColumnType,
-        collecting_for: SegmentStatsType,
-        accessor_idx: usize,
-        missing: Option<f64>,
-    ) -> Self {
-        let missing = missing.and_then(|val| f64_to_fastfield_u64(val, &field_type));
+    pub fn from_req(accessor_idx: usize) -> Self {
         Self {
-            field_type,
-            collecting_for,
             stats: IntermediateStats::default(),
             accessor_idx,
-            missing,
-            val_cache: Default::default(),
         }
     }
     #[inline]
     pub(crate) fn collect_block_with_field(
         &mut self,
         docs: &[DocId],
-        agg_accessor: &mut AggregationWithAccessor,
+        req_data: &mut MetricAggReqData,
     ) {
-        if let Some(missing) = self.missing.as_ref() {
-            agg_accessor.column_block_accessor.fetch_block_with_missing(
+        if let Some(missing) = req_data.missing_u64.as_ref() {
+            req_data.column_block_accessor.fetch_block_with_missing(
                 docs,
-                &agg_accessor.accessor,
+                &req_data.accessor,
                 *missing,
             );
         } else {
-            agg_accessor
+            req_data
                 .column_block_accessor
-                .fetch_block(docs, &agg_accessor.accessor);
+                .fetch_block(docs, &req_data.accessor);
         }
-        if [
-            ColumnType::I64,
-            ColumnType::U64,
-            ColumnType::F64,
-            ColumnType::DateTime,
-        ]
-        .contains(&self.field_type)
-        {
-            for val in agg_accessor.column_block_accessor.iter_vals() {
-                let val1 = f64_from_fastfield_u64(val, &self.field_type);
+        if req_data.is_number_or_date_type {
+            for val in req_data.column_block_accessor.iter_vals() {
+                let val1 = f64_from_fastfield_u64(val, &req_data.field_type);
                 self.stats.collect(val1);
             }
         } else {
-            for _val in agg_accessor.column_block_accessor.iter_vals() {
+            for _val in req_data.column_block_accessor.iter_vals() {
                 // we ignore the value and simply record that we got something
                 self.stats.collect(0.0);
             }
@@ -245,27 +234,28 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     #[inline]
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_with_accessor: &AggregationsWithAccessor,
+        agg_data: &AggregationsData,
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()> {
-        let name = agg_with_accessor.aggs.keys[self.accessor_idx].to_string();
+        let req = agg_data.get_metric_req_data(self.accessor_idx);
+        let name = req.name.clone();
 
-        let intermediate_metric_result = match self.collecting_for {
-            SegmentStatsType::Average => {
+        let intermediate_metric_result = match req.collecting_for {
+            StatsType::Average => {
                 IntermediateMetricResult::Average(IntermediateAverage::from_collector(*self))
             }
-            SegmentStatsType::Count => {
+            StatsType::Count => {
                 IntermediateMetricResult::Count(IntermediateCount::from_collector(*self))
             }
-            SegmentStatsType::Max => {
-                IntermediateMetricResult::Max(IntermediateMax::from_collector(*self))
-            }
-            SegmentStatsType::Min => {
-                IntermediateMetricResult::Min(IntermediateMin::from_collector(*self))
-            }
-            SegmentStatsType::Stats => IntermediateMetricResult::Stats(self.stats),
-            SegmentStatsType::Sum => {
-                IntermediateMetricResult::Sum(IntermediateSum::from_collector(*self))
+            StatsType::Max => IntermediateMetricResult::Max(IntermediateMax::from_collector(*self)),
+            StatsType::Min => IntermediateMetricResult::Min(IntermediateMin::from_collector(*self)),
+            StatsType::Stats => IntermediateMetricResult::Stats(self.stats),
+            StatsType::Sum => IntermediateMetricResult::Sum(IntermediateSum::from_collector(*self)),
+            _ => {
+                return Err(TantivyError::InvalidArgument(format!(
+                    "Unsupported stats type for stats aggregation: {:?}",
+                    req.collecting_for
+                )))
             }
         };
 
@@ -278,26 +268,22 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     }
 
     #[inline]
-    fn collect(
-        &mut self,
-        doc: crate::DocId,
-        agg_with_accessor: &mut AggregationsWithAccessor,
-    ) -> crate::Result<()> {
-        let field = &agg_with_accessor.aggs.values[self.accessor_idx].accessor;
-        if let Some(missing) = self.missing {
+    fn collect(&mut self, doc: crate::DocId, agg_data: &mut AggregationsData) -> crate::Result<()> {
+        let req_data = agg_data.get_metric_req_data(self.accessor_idx);
+        if let Some(missing) = req_data.missing_u64 {
             let mut has_val = false;
-            for val in field.values_for_doc(doc) {
-                let val1 = f64_from_fastfield_u64(val, &self.field_type);
+            for val in req_data.accessor.values_for_doc(doc) {
+                let val1 = f64_from_fastfield_u64(val, &req_data.field_type);
                 self.stats.collect(val1);
                 has_val = true;
             }
             if !has_val {
                 self.stats
-                    .collect(f64_from_fastfield_u64(missing, &self.field_type));
+                    .collect(f64_from_fastfield_u64(missing, &req_data.field_type));
             }
         } else {
-            for val in field.values_for_doc(doc) {
-                let val1 = f64_from_fastfield_u64(val, &self.field_type);
+            for val in req_data.accessor.values_for_doc(doc) {
+                let val1 = f64_from_fastfield_u64(val, &req_data.field_type);
                 self.stats.collect(val1);
             }
         }
@@ -309,10 +295,10 @@ impl SegmentAggregationCollector for SegmentStatsCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_with_accessor: &mut AggregationsWithAccessor,
+        agg_data: &mut AggregationsData,
     ) -> crate::Result<()> {
-        let field = &mut agg_with_accessor.aggs.values[self.accessor_idx];
-        self.collect_block_with_field(docs, field);
+        let req_data = agg_data.get_metric_req_data_mut(self.accessor_idx);
+        self.collect_block_with_field(docs, req_data);
         Ok(())
     }
 }

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -9,7 +9,7 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::{TopHitsMetricResult, TopHitsVecEntry};
-use crate::aggregation::agg_data::AggregationsData;
+use crate::aggregation::agg_data::AggregationsSegmentCtx;
 use crate::aggregation::bucket::Order;
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateMetricResult,
@@ -567,7 +567,7 @@ impl TopHitsSegmentCollector {
 impl SegmentAggregationCollector for TopHitsSegmentCollector {
     fn add_intermediate_aggregation_result(
         self: Box<Self>,
-        agg_data: &AggregationsData,
+        agg_data: &AggregationsSegmentCtx,
         results: &mut crate::aggregation::intermediate_agg_result::IntermediateAggregationResults,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_top_hits_req_data(self.accessor_idx);
@@ -587,7 +587,7 @@ impl SegmentAggregationCollector for TopHitsSegmentCollector {
     fn collect(
         &mut self,
         doc_id: crate::DocId,
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_top_hits_req_data(self.accessor_idx);
         self.collect_with(doc_id, &req_data.req, &req_data.accessors)?;
@@ -597,7 +597,7 @@ impl SegmentAggregationCollector for TopHitsSegmentCollector {
     fn collect_block(
         &mut self,
         docs: &[crate::DocId],
-        agg_data: &mut AggregationsData,
+        agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let req_data = agg_data.get_top_hits_req_data(self.accessor_idx);
         // TODO: Consider getting fields with the column block accessor.

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -19,6 +19,23 @@ use crate::aggregation::AggregationError;
 use crate::collector::TopNComputer;
 use crate::schema::OwnedValue;
 use crate::{DocAddress, DocId, SegmentOrdinal};
+// duplicate import removed; already imported above
+
+/// Contains all information required by the TopHitsSegmentCollector to perform the
+/// top_hits aggregation on a segment.
+#[derive(Default)]
+pub struct TopHitsAggReqData {
+    /// The accessors to access the fast field values.
+    pub accessors: Vec<(Column<u64>, ColumnType)>,
+    /// The accessors to access the fast field values for retrieving document fields.
+    pub value_accessors: HashMap<String, Vec<DynamicColumn>>,
+    /// The ordinal of the segment this request data is for.
+    pub segment_ordinal: SegmentOrdinal,
+    /// The name of the aggregation.
+    pub name: String,
+    /// The top_hits aggregation request.
+    pub req: TopHitsAggregationReq,
+}
 
 /// # Top Hits
 ///

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -127,6 +127,7 @@
 //! [`AggregationResults`](agg_result::AggregationResults) via the
 //! [`into_final_result`](intermediate_agg_result::IntermediateAggregationResults::into_final_result) method.
 
+mod agg_data;
 mod agg_limits;
 pub mod agg_req;
 mod agg_req_with_accessor;
@@ -140,7 +141,6 @@ pub mod intermediate_agg_result;
 pub mod metric;
 
 mod segment_agg_result;
-use std::collections::HashMap;
 use std::fmt::Display;
 
 #[cfg(test)]
@@ -255,80 +255,6 @@ where D: Deserializer<'de> {
     }
 
     deserializer.deserialize_any(StringOrFloatVisitor)
-}
-
-/// Represents an associative array `(key => values)` in a very efficient manner.
-#[derive(PartialEq, Serialize, Deserialize)]
-pub(crate) struct VecWithNames<T> {
-    pub(crate) values: Vec<T>,
-    keys: Vec<String>,
-}
-
-impl<T: Clone> Clone for VecWithNames<T> {
-    fn clone(&self) -> Self {
-        Self {
-            values: self.values.clone(),
-            keys: self.keys.clone(),
-        }
-    }
-}
-
-impl<T> Default for VecWithNames<T> {
-    fn default() -> Self {
-        Self {
-            values: Default::default(),
-            keys: Default::default(),
-        }
-    }
-}
-
-impl<T: std::fmt::Debug> std::fmt::Debug for VecWithNames<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_map().entries(self.iter()).finish()
-    }
-}
-
-impl<T> From<HashMap<String, T>> for VecWithNames<T> {
-    fn from(map: HashMap<String, T>) -> Self {
-        VecWithNames::from_entries(map.into_iter().collect_vec())
-    }
-}
-
-impl<T> VecWithNames<T> {
-    fn from_entries(mut entries: Vec<(String, T)>) -> Self {
-        // Sort to ensure order of elements match across multiple instances
-        entries.sort_by(|left, right| left.0.cmp(&right.0));
-        let mut data = Vec::with_capacity(entries.len());
-        let mut data_names = Vec::with_capacity(entries.len());
-        for entry in entries {
-            data_names.push(entry.0);
-            data.push(entry.1);
-        }
-        VecWithNames {
-            values: data,
-            keys: data_names,
-        }
-    }
-    fn iter(&self) -> impl Iterator<Item = (&str, &T)> + '_ {
-        self.keys().zip(self.values.iter())
-    }
-    fn keys(&self) -> impl Iterator<Item = &str> + '_ {
-        self.keys.iter().map(|key| key.as_str())
-    }
-    fn values_mut(&mut self) -> impl Iterator<Item = &mut T> + '_ {
-        self.values.iter_mut()
-    }
-    fn is_empty(&self) -> bool {
-        self.keys.is_empty()
-    }
-    fn len(&self) -> usize {
-        self.keys.len()
-    }
-    fn get(&self, name: &str) -> Option<&T> {
-        self.keys()
-            .position(|key| key == name)
-            .map(|pos| &self.values[pos])
-    }
 }
 
 /// The serialized key is used in a `HashMap`.


### PR DESCRIPTION
Replace `AggregationsWithAccessor` with `AggregationsData`.

With `AggregationsWithAccessor` is a tree matching the elastic search request structure.  It contained one field for all with all kinds of accessors for all collectors. Pre-computation and caching was done on the collector level. 
If you have 10000 sub collectors (e.g. a term aggregation with sub aggregations) storing a lot of data per collector is very expensive.

`AggregationsData` allows to store and cache collector specific data with the cardinality of the request tree instead of the cardinality of the segment collector. It also moves the global struct shared with all aggregations into aggregation specific structs. So each aggregation has its own space in `AggregationsData` for its accessors and to store cached data and aggregation specific information.

This also breaks up the dependency to the elastic search aggregation structure somewhat.

# Issues
Due to lifetime issues, we move the agg request specific object out of `AggData` during the collection and move it back at the end in bucket aggregations. That's some unnecessary work, which costs CPU and could e.g. be circumvented by `unsafe`.

# Future work
This allows better caching and will also pave the way for another potential optimization, by separating the collector and its storage. Currently we allocate a new collector for each sub aggregation bucket (for nested aggregations), but ideally we would have just one collector instance and store its data in `AggData`


# Benchmark

Memory usage is reduced in many cases, up to 28%, especially some heavy hitters (`terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB (-28.43%)`)
Performance is roughly the same.

```
full
average_u64                                    Memory: 14.9 KB (-12.00%)    Avg: 4.0841ms (+1.29%)      Median: 4.0775ms (+3.64%)      [3.9905ms .. 4.3958ms]
average_f64                                    Memory: 14.1 KB (-15.67%)    Avg: 4.1988ms (+1.60%)      Median: 4.1963ms (+3.49%)      [4.1019ms .. 4.4135ms]
average_f64_u64                                Memory: 15.8 KB (-11.09%)    Avg: 6.8832ms (+1.67%)      Median: 6.8747ms (+3.94%)      [6.7848ms .. 7.1310ms]
stats_f64                                      Memory: 14.6 KB (-15.31%)    Avg: 4.1996ms (+1.93%)      Median: 4.1965ms (+3.54%)      [4.1142ms .. 4.4202ms]
extendedstats_f64                              Memory: 15.4 KB (-9.54%)     Avg: 4.3787ms (-0.02%)      Median: 4.3557ms (+1.60%)      [4.2844ms .. 4.8469ms]
percentiles_f64                                Memory: 17.9 KB (+5.11%)     Avg: 7.0112ms (+0.00%)      Median: 7.0084ms (+0.60%)      [6.9625ms .. 7.0733ms]
terms_few                                      Memory: 27.6 KB (-0.77%)     Avg: 1.9562ms (+0.78%)      Median: 1.9516ms (+1.48%)      [1.9353ms .. 2.0515ms]
terms_many                                     Memory: 6.9 MB (+0.00%)      Avg: 5.9283ms (-0.47%)      Median: 5.8993ms (-1.15%)      [5.7979ms .. 6.3908ms]
terms_many_top_1000                            Memory: 6.9 MB (+0.00%)      Avg: 7.3120ms (-0.35%)      Median: 7.2559ms (+0.14%)      [7.0926ms .. 8.0116ms]
terms_many_order_by_term                       Memory: 6.9 MB (-0.00%)      Avg: 7.0861ms (-0.09%)      Median: 7.0606ms (+0.05%)      [6.9661ms .. 7.4447ms]
terms_many_with_top_hits                       Memory: 58.3 MB (+0.00%)     Avg: 177.8196ms (+1.20%)    Median: 177.9878ms (+1.57%)    [170.8771ms .. 190.5457ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB (-25.86%)    Avg: 26.6457ms (-10.71%)    Median: 26.6484ms (-9.32%)     [25.7137ms .. 27.3234ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB (-28.43%)    Avg: 43.0950ms (-10.67%)    Median: 42.7887ms (-10.67%)    [41.5391ms .. 51.5141ms]
cardinality_agg                                Memory: 3.6 MB (+0.03%)      Avg: 16.8665ms (+1.36%)     Median: 16.8523ms (+2.40%)     [16.1436ms .. 17.7674ms]
terms_few_with_cardinality_agg                 Memory: 10.6 MB (+0.01%)     Avg: 66.2787ms (+0.38%)     Median: 66.0720ms (+0.45%)     [65.4916ms .. 68.7217ms]
range_agg                                      Memory: 16.1 KB (-1.71%)     Avg: 3.0208ms (+0.50%)      Median: 3.0131ms (+0.15%)      [2.9931ms .. 3.2746ms]
range_agg_with_avg_sub_agg                     Memory: 30.7 KB (-2.67%)     Avg: 6.8809ms (-0.94%)      Median: 6.8753ms (-0.92%)      [6.8429ms .. 6.9249ms]
range_agg_with_term_agg_few                    Memory: 43.9 KB (-4.14%)     Avg: 13.4313ms (+6.98%)     Median: 13.4076ms (+6.92%)     [13.3124ms .. 13.6949ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.04%)      Avg: 24.9421ms (+9.98%)     Median: 24.8423ms (+9.71%)     [24.6613ms .. 26.1414ms]
histogram                                      Memory: 16.1 KB (-2.09%)     Avg: 3.0427ms (+6.21%)      Median: 3.0312ms (+5.75%)      [3.0066ms .. 3.2470ms]
histogram_hard_bounds                          Memory: 14.1 KB (-9.75%)     Avg: 1.4737ms (+3.05%)      Median: 1.4643ms (+3.03%)      [1.4512ms .. 1.5551ms]
histogram_with_avg_sub_agg                     Memory: 48.1 KB (-2.07%)     Avg: 8.6509ms (+7.69%)      Median: 8.6087ms (+7.23%)      [8.5724ms .. 9.2463ms]
histogram_with_term_agg_few                    Memory: 307.6 KB (-5.74%)    Avg: 16.2016ms (+11.13%)    Median: 16.1562ms (+10.89%)    [16.0291ms .. 16.5437ms]
avg_and_range_with_avg_sub_agg                 Memory: 25.5 KB (-7.59%)     Avg: 9.5745ms (+0.57%)      Median: 9.5579ms (+0.60%)      [9.3965ms .. 9.9458ms]
dense
average_u64                                    Memory: 14.9 KB (-13.29%)    Avg: 6.5390ms (+5.44%)      Median: 6.5128ms (+4.73%)      [6.3453ms .. 7.0298ms]
average_f64                                    Memory: 15.0 KB (-10.15%)    Avg: 6.6766ms (+5.01%)      Median: 6.6198ms (+4.00%)      [6.5287ms .. 7.8671ms]
average_f64_u64                                Memory: 16.9 KB (-3.96%)     Avg: 11.8454ms (+5.09%)     Median: 11.7136ms (+3.91%)     [11.6531ms .. 12.7760ms]
stats_f64                                      Memory: 15.2 KB (-9.84%)     Avg: 6.6718ms (+5.31%)      Median: 6.6186ms (+4.23%)      [6.4883ms .. 7.2035ms]
extendedstats_f64                              Memory: 14.7 KB (-13.39%)    Avg: 6.8051ms (+4.98%)      Median: 6.7901ms (+4.76%)      [6.6219ms .. 7.2417ms]
percentiles_f64                                Memory: 19.5 KB (-6.80%)     Avg: 9.3133ms (+1.90%)      Median: 9.2979ms (+1.84%)      [9.2575ms .. 9.4984ms]
terms_few                                      Memory: 29.1 KB (-0.73%)     Avg: 4.2746ms (+5.44%)      Median: 4.2622ms (+5.49%)      [4.2459ms .. 4.3757ms]
terms_many                                     Memory: 6.9 MB (-0.00%)      Avg: 8.2769ms (+2.29%)      Median: 8.2473ms (+1.97%)      [8.1363ms .. 8.4795ms]
terms_many_top_1000                            Memory: 6.9 MB (-0.00%)      Avg: 9.6570ms (+2.53%)      Median: 9.6235ms (+2.10%)      [9.4095ms .. 10.5245ms]
terms_many_order_by_term                       Memory: 6.9 MB (+0.00%)      Avg: 9.4708ms (+2.08%)      Median: 9.4544ms (+2.34%)      [9.3154ms .. 9.7464ms]
terms_many_with_top_hits                       Memory: 58.3 MB (+0.00%)     Avg: 187.7306ms (-0.46%)    Median: 185.2152ms (-1.71%)    [175.0327ms .. 213.4113ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB (-25.86%)    Avg: 32.9413ms (-15.30%)    Median: 32.6651ms (-14.13%)    [31.7965ms .. 35.1071ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB (-28.43%)    Avg: 47.9647ms (-15.82%)    Median: 47.6588ms (-13.98%)    [46.1692ms .. 58.3458ms]
cardinality_agg                                Memory: 3.6 MB (+0.03%)      Avg: 19.3243ms (+0.94%)     Median: 19.2158ms (+1.39%)     [18.6805ms .. 20.2355ms]
terms_few_with_cardinality_agg                 Memory: 10.6 MB (+0.01%)     Avg: 76.5374ms (+0.28%)     Median: 76.1895ms (+0.08%)     [75.4253ms .. 79.3365ms]
range_agg                                      Memory: 16.1 KB (-4.74%)     Avg: 5.3679ms (+3.50%)      Median: 5.3501ms (+3.76%)      [5.3045ms .. 5.7346ms]
range_agg_with_avg_sub_agg                     Memory: 31.5 KB (-4.47%)     Avg: 11.2390ms (+6.20%)     Median: 11.2267ms (+6.16%)     [11.0506ms .. 11.5441ms]
range_agg_with_term_agg_few                    Memory: 45.3 KB (-4.53%)     Avg: 20.5734ms (+2.74%)     Median: 20.5073ms (+3.18%)     [20.3074ms .. 21.5211ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.06%)      Avg: 31.7529ms (+0.92%)     Median: 31.5543ms (+0.87%)     [31.2518ms .. 33.4997ms]
histogram                                      Memory: 15.8 KB (-8.28%)     Avg: 5.3894ms (+7.38%)      Median: 5.3674ms (+7.21%)      [5.3022ms .. 5.6741ms]
histogram_hard_bounds                          Memory: 15.1 KB (-5.89%)     Avg: 3.8337ms (+7.31%)      Median: 3.8193ms (+6.96%)      [3.7805ms .. 4.0556ms]
histogram_with_avg_sub_agg                     Memory: 49.4 KB (-2.28%)     Avg: 13.3867ms (+9.35%)     Median: 13.2618ms (+8.61%)     [13.1626ms .. 14.5048ms]
histogram_with_term_agg_few                    Memory: 309.3 KB (-5.71%)    Avg: 21.9584ms (-4.61%)     Median: 21.8246ms (-4.89%)     [21.6258ms .. 22.9164ms]
avg_and_range_with_avg_sub_agg                 Memory: 28.1 KB (-6.94%)     Avg: 15.9910ms (+4.83%)     Median: 15.9090ms (+4.48%)     [15.7938ms .. 16.7246ms]
sparse
average_u64                                    Memory: 14.0 KB (-16.34%)    Avg: 14.2910ms (-0.79%)    Median: 14.2993ms (-0.22%)    [13.9480ms .. 14.7414ms]
average_f64                                    Memory: 14.4 KB (-14.86%)    Avg: 14.2779ms (-0.98%)    Median: 14.2754ms (-0.55%)    [13.9108ms .. 14.6854ms]
average_f64_u64                                Memory: 15.0 KB (-16.54%)    Avg: 28.5396ms (-0.50%)    Median: 28.4743ms (-0.54%)    [27.8324ms .. 29.7428ms]
stats_f64                                      Memory: 13.6 KB (-19.26%)    Avg: 14.3046ms (-0.52%)    Median: 14.2866ms (-0.08%)    [14.0956ms .. 14.7377ms]
extendedstats_f64                              Memory: 14.3 KB (-15.44%)    Avg: 14.3431ms (-0.86%)    Median: 14.3499ms (-0.31%)    [13.8398ms .. 14.7057ms]
percentiles_f64                                Memory: 16.6 KB (+0.57%)     Avg: 13.7300ms (+0.90%)    Median: 13.6416ms (+0.36%)    [13.3465ms .. 14.4728ms]
terms_few                                      Memory: 27.3 KB (-0.78%)     Avg: 13.3986ms (+0.77%)    Median: 13.3050ms (-0.01%)    [13.0827ms .. 14.9911ms]
terms_many                                     Memory: 1.8 MB (-0.01%)      Avg: 14.5670ms (+1.02%)    Median: 14.4135ms (+0.30%)    [13.9166ms .. 16.6441ms]
terms_many_top_1000                            Memory: 2.6 MB               Avg: 15.5631ms (+1.98%)    Median: 15.3935ms (+0.97%)    [15.1642ms .. 17.9644ms]
terms_many_order_by_term                       Memory: 1.8 MB (-0.01%)      Avg: 14.5961ms (+1.14%)    Median: 14.5266ms (+0.97%)    [14.0838ms .. 15.4280ms]
terms_many_with_top_hits                       Memory: 13.1 MB (+0.00%)     Avg: 20.9541ms (-1.05%)    Median: 20.8396ms (-1.25%)    [20.5260ms .. 22.4310ms]
terms_many_with_avg_sub_agg                    Memory: 5.5 MB (-27.09%)     Avg: 17.6843ms (-4.36%)    Median: 17.6997ms (-4.18%)    [17.2045ms .. 18.1541ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 5.4 MB (-26.83%)     Avg: 27.4945ms (-1.20%)    Median: 27.3968ms (-1.31%)    [27.0543ms .. 29.5726ms]
cardinality_agg                                Memory: 896.5 KB (+0.10%)    Avg: 20.1178ms (-0.01%)    Median: 20.0903ms (-0.15%)    [19.4800ms .. 21.1727ms]
terms_few_with_cardinality_agg                 Memory: 681.0 KB (+0.08%)    Avg: 24.9286ms (+0.78%)    Median: 24.8819ms (+0.74%)    [24.5644ms .. 25.7962ms]
range_agg                                      Memory: 15.9 KB (-3.05%)     Avg: 13.3643ms (+0.11%)    Median: 13.3549ms (+0.56%)    [12.8595ms .. 13.7748ms]
range_agg_with_avg_sub_agg                     Memory: 30.4 KB (-2.69%)     Avg: 14.9167ms (+1.75%)    Median: 14.9137ms (+1.68%)    [14.4918ms .. 15.2341ms]
range_agg_with_term_agg_few                    Memory: 43.9 KB (-4.14%)     Avg: 16.4941ms (+0.04%)    Median: 16.4983ms (-0.12%)    [16.0963ms .. 16.9547ms]
range_agg_with_term_agg_many                   Memory: 1.8 MB (-0.15%)      Avg: 18.1107ms (+0.21%)    Median: 18.0661ms (+0.60%)    [17.7192ms .. 18.8957ms]
histogram                                      Memory: 14.1 KB (-10.86%)    Avg: 13.4221ms (+0.75%)    Median: 13.4229ms (+0.73%)    [13.0523ms .. 13.7310ms]
histogram_hard_bounds                          Memory: 12.4 KB (-20.51%)    Avg: 13.3608ms (+0.44%)    Median: 13.3464ms (+0.21%)    [12.8105ms .. 15.1108ms]
histogram_with_avg_sub_agg                     Memory: 34.6 KB              Avg: 15.0087ms (+1.65%)    Median: 14.9419ms (+1.51%)    [14.1733ms .. 17.2736ms]
histogram_with_term_agg_few                    Memory: 191.2 KB (-5.87%)    Avg: 16.5492ms (+6.42%)    Median: 16.5438ms (+6.37%)    [16.0973ms .. 17.3564ms]
avg_and_range_with_avg_sub_agg                 Memory: 24.8 KB (-8.52%)     Avg: 29.1190ms (+1.13%)    Median: 29.0512ms (+0.56%)    [28.3858ms .. 30.5359ms]
multivalue
average_u64                                    Memory: 15.6 KB (-8.56%)     Avg: 9.0149ms (+0.28%)      Median: 8.9847ms (+0.02%)      [8.9112ms .. 9.5589ms]
average_f64                                    Memory: 15.6 KB (-10.87%)    Avg: 9.1166ms (-0.15%)      Median: 9.1032ms (-0.57%)      [9.0016ms .. 9.6939ms]
average_f64_u64                                Memory: 17.7 KB (-3.55%)     Avg: 16.7749ms (+0.57%)     Median: 16.7482ms (+0.38%)     [16.6607ms .. 17.2135ms]
stats_f64                                      Memory: 15.8 KB (-6.53%)     Avg: 9.1202ms (-0.44%)      Median: 9.0953ms (-0.62%)      [9.0507ms .. 9.6075ms]
extendedstats_f64                              Memory: 15.7 KB (-8.02%)     Avg: 9.2277ms (-0.73%)      Median: 9.2259ms (-0.58%)      [9.1220ms .. 9.3026ms]
percentiles_f64                                Memory: 18.6 KB (+2.30%)     Avg: 11.9277ms (+0.31%)     Median: 11.9170ms (+0.42%)     [11.8114ms .. 12.1689ms]
terms_few                                      Memory: 244.6 KB             Avg: 7.7423ms (+0.51%)      Median: 7.7260ms (+0.37%)      [7.5665ms .. 8.3000ms]
terms_many                                     Memory: 6.9 MB (-0.00%)      Avg: 11.1267ms (+0.86%)     Median: 11.0043ms (-0.07%)     [10.8690ms .. 12.4952ms]
terms_many_top_1000                            Memory: 6.9 MB (-0.00%)      Avg: 12.4807ms (+0.56%)     Median: 12.3433ms (-0.13%)     [12.1775ms .. 13.8828ms]
terms_many_order_by_term                       Memory: 6.9 MB (-0.01%)      Avg: 12.2123ms (+0.54%)     Median: 12.1350ms (+0.10%)     [11.9864ms .. 13.6171ms]
terms_many_with_top_hits                       Memory: 58.3 MB (+0.00%)     Avg: 205.8671ms (+2.19%)    Median: 199.5562ms (+0.06%)    [190.3145ms .. 252.9033ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB (-25.86%)    Avg: 44.2658ms (-13.72%)    Median: 42.3643ms (-16.41%)    [40.8020ms .. 55.2698ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB (-28.43%)    Avg: 61.3515ms (-8.83%)     Median: 58.4062ms (-12.31%)    [57.3210ms .. 78.0104ms]
cardinality_agg                                Memory: 3.6 MB (+0.03%)      Avg: 22.3379ms (+1.14%)     Median: 22.1770ms (+1.27%)     [21.3895ms .. 25.1331ms]
terms_few_with_cardinality_agg                 Memory: 10.8 MB (+0.01%)     Avg: 85.2310ms (+1.89%)     Median: 84.0893ms (+0.83%)     [83.1400ms .. 93.6265ms]
range_agg                                      Memory: 15.9 KB (-7.09%)     Avg: 7.8410ms (-0.17%)      Median: 7.8245ms (+0.03%)      [7.7781ms .. 8.0522ms]
range_agg_with_avg_sub_agg                     Memory: 32.2 KB (-2.24%)     Avg: 17.6036ms (+1.60%)     Median: 17.5736ms (+1.43%)     [17.3533ms .. 17.8695ms]
range_agg_with_term_agg_few                    Memory: 247.4 KB (-0.44%)    Avg: 27.2054ms (-4.43%)     Median: 27.0951ms (-4.45%)     [26.7593ms .. 29.1588ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.05%)      Avg: 37.4951ms (-1.85%)     Median: 37.3937ms (-1.69%)     [36.8708ms .. 38.6719ms]
histogram                                      Memory: 16.4 KB (-1.29%)     Avg: 7.8844ms (+1.99%)      Median: 7.8617ms (+1.91%)      [7.7947ms .. 8.0918ms]
histogram_hard_bounds                          Memory: 14.5 KB (-11.25%)    Avg: 6.3697ms (+1.68%)      Median: 6.3165ms (+0.81%)      [6.2673ms .. 6.8617ms]
histogram_with_avg_sub_agg                     Memory: 48.3 KB (-4.31%)     Avg: 20.0344ms (+7.64%)     Median: 19.7838ms (+6.49%)     [19.5324ms .. 27.0047ms]
histogram_with_term_agg_few                    Memory: 465.8 KB (-3.87%)    Avg: 32.1512ms (+11.15%)    Median: 31.4746ms (+8.40%)     [29.8826ms .. 35.1168ms]
avg_and_range_with_avg_sub_agg                 Memory: 28.1 KB (-7.34%)     Avg: 25.2043ms (+0.79%)     Median: 25.0320ms (+1.11%)     [24.7915ms .. 27.7293ms]
```
