### PR TITLE
fix: Fix json range query with different number type

### DIFF
--- a/common/src/bounds.rs
+++ b/common/src/bounds.rs
@@ -44,6 +44,18 @@ impl<T> BoundsRange<T> {
         }
     }
 
+    pub fn transform_inner_res<TTo, Err>(
+        &self,
+        transform_lower: impl Fn(&T) -> io::Result<TransformBound<TTo>>,
+        transform_upper: impl Fn(&T) -> io::Result<TransformBound<TTo>>,
+    ) -> io::Result<BoundsRange<TTo>> {
+        let range = BoundsRange {
+            lower_bound: transform_bound_inner_res(&self.lower_bound, &transform_lower)?,
+            upper_bound: transform_bound_inner_res(&self.upper_bound, &transform_upper)?,
+        };
+        Ok(range)
+    }
+
     /// Returns the first set inner value
     pub fn get_inner(&self) -> Option<&T> {
         inner_bound(&self.lower_bound).or(inner_bound(&self.upper_bound))

--- a/src/query/range_query/range_query_fastfield.rs
+++ b/src/query/range_query/range_query_fastfield.rs
@@ -86,8 +86,6 @@ impl Weight for FastFieldRangeWeight {
             //
             // In the JSON case the provided type in term may not exactly match the column type,
             // especially with the numeric type interpolation
-            //
-            //
             let lower_typ = inner_bound(&bounds.lower_bound).map(|bound| bound.typ());
             let upper_typ = inner_bound(&bounds.upper_bound).map(|bound| bound.typ());
 
@@ -278,13 +276,11 @@ fn search_on_json_numerical_field(
     let allowed_column_types: Option<&[ColumnType]> =
         Some(&[ColumnType::F64, ColumnType::I64, ColumnType::U64]);
     let fast_field_reader = reader.fast_fields();
-
     let Some((column, col_type)) =
         fast_field_reader.u64_lenient_for_type(allowed_column_types, field_name)?
     else {
         return Ok(Box::new(EmptyScorer));
     };
-
     let actual_column_type: NumericalType = col_type
         .numerical_type()
         .unwrap_or_else(|| panic!("internal error: couldn't cast to numerical_type: {col_type:?}"));


### PR DESCRIPTION
This PR fix json range query with different Numerical type caused panic
```
thread 'query::range_query::range_query_fastfield::tests::json_range_test' (805162) panicked at src/query/range_query/range_query_fastfield.rs:261:64:
called `Option::unwrap()` on a `None` value
```
