### PR TITLE
Implement `collect_block` for `Collector`s which wrap other `Collector`s

### DIFF
--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -342,6 +342,11 @@ where
         self.1.collect(doc, score);
     }
 
+    fn collect_block(&mut self, docs: &[DocId]) {
+        self.0.collect_block(docs);
+        self.1.collect_block(docs);
+    }
+
     fn harvest(self) -> <Self as SegmentCollector>::Fruit {
         (self.0.harvest(), self.1.harvest())
     }
@@ -405,6 +410,12 @@ where
         self.0.collect(doc, score);
         self.1.collect(doc, score);
         self.2.collect(doc, score);
+    }
+
+    fn collect_block(&mut self, docs: &[DocId]) {
+        self.0.collect_block(docs);
+        self.1.collect_block(docs);
+        self.2.collect_block(docs);
     }
 
     fn harvest(self) -> <Self as SegmentCollector>::Fruit {
@@ -480,6 +491,13 @@ where
         self.1.collect(doc, score);
         self.2.collect(doc, score);
         self.3.collect(doc, score);
+    }
+
+    fn collect_block(&mut self, docs: &[DocId]) {
+        self.0.collect_block(docs);
+        self.1.collect_block(docs);
+        self.2.collect_block(docs);
+        self.3.collect_block(docs);
     }
 
     fn harvest(self) -> <Self as SegmentCollector>::Fruit {

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -214,6 +214,12 @@ impl<TSegmentCollector: SegmentCollector> SegmentCollector for Option<TSegmentCo
         }
     }
 
+    fn collect_block(&mut self, docs: &[DocId]) {
+        if let Some(segment_collector) = self {
+            segment_collector.collect_block(docs);
+        }
+    }
+
     fn harvest(self) -> Self::Fruit {
         self.map(|segment_collector| segment_collector.harvest())
     }

--- a/src/collector/multi_collector.rs
+++ b/src/collector/multi_collector.rs
@@ -250,6 +250,12 @@ impl SegmentCollector for MultiCollectorChild {
         }
     }
 
+    fn collect_block(&mut self, docs: &[DocId]) {
+        for child in &mut self.children {
+            child.collect_block(docs);
+        }
+    }
+
     fn harvest(self) -> MultiFruit {
         MultiFruit {
             sub_fruits: self


### PR DESCRIPTION
The:
* tuple `Collector`s
* `MultiCollector`
* `FilterCollector`s

...do not have explicit overrides of `collect_block`, meaning that wrapping a `Collector` which _does_ implement that method loses its advantage.

Noticed in a profile while using a tuple `Collector` of `TopDocs` and `Aggregations` (because `Aggregations` take advantage of `collect_block`).