### PR TITLE
remove duplicated call to `index_writer.commit` in example

### DIFF
--- a/examples/fuzzy_search.rs
+++ b/examples/fuzzy_search.rs
@@ -85,7 +85,6 @@ fn main() -> tantivy::Result<()> {
     index_writer.add_document(doc!(
         title => "The Diary of a Young Girl",
     ))?;
-    index_writer.commit()?;
 
     // ### Committing
     //


### PR DESCRIPTION
I think index_writer.commit is meant to be called once (after the related comment block)