### PR TITLE
low cardinality optimisation

### DIFF
--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -10,10 +10,10 @@ use crate::aggregation::accessor_helpers::{
 };
 use crate::aggregation::agg_req::{Aggregation, AggregationVariants, Aggregations};
 use crate::aggregation::bucket::{
-    FilterAggReqData, HistogramAggReqData, HistogramBounds, IncludeExcludeParam,
-    MissingTermAggReqData, RangeAggReqData, SegmentFilterCollector, SegmentHistogramCollector,
-    SegmentRangeCollector, SegmentTermCollector, TermMissingAgg, TermsAggReqData, TermsAggregation,
-    TermsAggregationInternal,
+    build_segment_aggregation_collector, FilterAggReqData, HistogramAggReqData, HistogramBounds,
+    IncludeExcludeParam, MissingTermAggReqData, RangeAggReqData, SegmentFilterCollector,
+    SegmentHistogramCollector, SegmentRangeCollector, TermMissingAgg, TermsAggReqData,
+    TermsAggregation, TermsAggregationInternal,
 };
 use crate::aggregation::metric::{
     AverageAggregation, CardinalityAggReqData, CardinalityAggregationReq, CountAggregation,
@@ -373,9 +373,7 @@ pub(crate) fn build_segment_agg_collector(
     node: &AggRefNode,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
     match node.kind {
-        AggKind::Terms => Ok(Box::new(SegmentTermCollector::from_req_and_validate(
-            req, node,
-        )?)),
+        AggKind::Terms => build_segment_aggregation_collector(req, node),
         AggKind::MissingTerm => {
             let req_data = &mut req.per_request.missing_term_req_data[node.idx_in_req_data];
             if req_data.accessors.is_empty() {

--- a/src/aggregation/agg_limits.rs
+++ b/src/aggregation/agg_limits.rs
@@ -70,7 +70,7 @@ impl AggregationLimitsGuard {
     /// *memory_limit*
     /// memory_limit is defined in bytes.
     /// Aggregation fails when the estimated memory consumption of the aggregation is higher than
-    /// memory_limit.     
+    /// memory_limit.
     /// memory_limit will default to `DEFAULT_MEMORY_LIMIT` (500MB)
     ///
     /// *bucket_limit*

--- a/src/aggregation/bucket/term_agg/default_impl.rs
+++ b/src/aggregation/bucket/term_agg/default_impl.rs
@@ -1,0 +1,196 @@
+use std::fmt::Debug;
+
+use columnar::ColumnType;
+use rustc_hash::FxHashMap;
+
+use super::OrderTarget;
+use crate::aggregation::agg_data::{
+    build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
+};
+use crate::aggregation::agg_limits::MemoryConsumption;
+use crate::aggregation::bucket::get_agg_name_and_property;
+use crate::aggregation::intermediate_agg_result::{
+    IntermediateAggregationResult, IntermediateAggregationResults,
+};
+use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
+use crate::TantivyError;
+
+#[derive(Clone, Debug, Default)]
+/// Container to store term_ids/or u64 values and their buckets.
+struct TermBuckets {
+    pub(crate) entries: FxHashMap<u64, u32>,
+    pub(crate) sub_aggs: FxHashMap<u64, Box<dyn SegmentAggregationCollector>>,
+}
+
+impl TermBuckets {
+    fn get_memory_consumption(&self) -> usize {
+        let sub_aggs_mem = self.sub_aggs.memory_consumption();
+        let buckets_mem = self.entries.memory_consumption();
+        sub_aggs_mem + buckets_mem
+    }
+
+    fn force_flush(&mut self, agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
+        for sub_aggregations in &mut self.sub_aggs.values_mut() {
+            sub_aggregations.as_mut().flush(agg_data)?;
+        }
+        Ok(())
+    }
+}
+
+/// The collector puts values from the fast field into the correct buckets and does a conversion to
+/// the correct datatype.
+#[derive(Clone, Debug)]
+pub struct SegmentTermCollector {
+    /// The buckets containing the aggregation data.
+    term_buckets: TermBuckets,
+    accessor_idx: usize,
+}
+
+impl SegmentAggregationCollector for SegmentTermCollector {
+    fn add_intermediate_aggregation_result(
+        self: Box<Self>,
+        agg_data: &AggregationsSegmentCtx,
+        results: &mut IntermediateAggregationResults,
+    ) -> crate::Result<()> {
+        let name = agg_data.get_term_req_data(self.accessor_idx).name.clone();
+
+        let entries: Vec<(u64, u32)> = self.term_buckets.entries.into_iter().collect();
+        let bucket = super::into_intermediate_bucket_result(
+            self.accessor_idx,
+            entries,
+            self.term_buckets.sub_aggs,
+            agg_data,
+        )?;
+        results.push(name, IntermediateAggregationResult::Bucket(bucket))?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        self.collect_block(&[doc], agg_data)
+    }
+
+    #[inline]
+    fn collect_block(
+        &mut self,
+        docs: &[crate::DocId],
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        let mut req_data = agg_data.take_term_req_data(self.accessor_idx);
+
+        let mem_pre = self.get_memory_consumption();
+
+        if let Some(missing) = req_data.missing_value_for_accessor {
+            req_data.column_block_accessor.fetch_block_with_missing(
+                docs,
+                &req_data.accessor,
+                missing,
+            );
+        } else {
+            req_data
+                .column_block_accessor
+                .fetch_block(docs, &req_data.accessor);
+        }
+
+        for term_id in req_data.column_block_accessor.iter_vals() {
+            if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
+                if !allowed_bs.contains(term_id as u32) {
+                    continue;
+                }
+            }
+            let entry = self.term_buckets.entries.entry(term_id).or_default();
+            *entry += 1;
+        }
+        // has subagg
+        if let Some(blueprint) = req_data.sub_aggregation_blueprint.as_ref() {
+            for (doc, term_id) in req_data
+                .column_block_accessor
+                .iter_docid_vals(docs, &req_data.accessor)
+            {
+                if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
+                    if !allowed_bs.contains(term_id as u32) {
+                        continue;
+                    }
+                }
+                let sub_aggregations = self
+                    .term_buckets
+                    .sub_aggs
+                    .entry(term_id)
+                    .or_insert_with(|| blueprint.clone());
+                sub_aggregations.collect(doc, agg_data)?;
+            }
+        }
+
+        let mem_delta = self.get_memory_consumption() - mem_pre;
+        if mem_delta > 0 {
+            agg_data
+                .context
+                .limits
+                .add_memory_consumed(mem_delta as u64)?;
+        }
+        agg_data.put_back_term_req_data(self.accessor_idx, req_data);
+
+        Ok(())
+    }
+
+    fn flush(&mut self, agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
+        self.term_buckets.force_flush(agg_data)?;
+        Ok(())
+    }
+}
+
+impl SegmentTermCollector {
+    pub fn from_req_and_validate(
+        req_data: &mut AggregationsSegmentCtx,
+        node: &AggRefNode,
+    ) -> crate::Result<Self> {
+        let terms_req_data = req_data.get_term_req_data(node.idx_in_req_data);
+        let column_type = terms_req_data.column_type;
+        let accessor_idx = node.idx_in_req_data;
+        if column_type == ColumnType::Bytes {
+            return Err(TantivyError::InvalidArgument(format!(
+                "terms aggregation is not supported for column type {column_type:?}"
+            )));
+        }
+        let term_buckets = TermBuckets::default();
+
+        // Validate sub aggregation exists
+        if let OrderTarget::SubAggregation(sub_agg_name) = &terms_req_data.req.order.target {
+            let (agg_name, _agg_property) = get_agg_name_and_property(sub_agg_name);
+
+            node.get_sub_agg(agg_name, &req_data.per_request)
+                .ok_or_else(|| {
+                    TantivyError::InvalidArgument(format!(
+                        "could not find aggregation with name {agg_name} in metric \
+                         sub_aggregations"
+                    ))
+                })?;
+        }
+
+        let has_sub_aggregations = !node.children.is_empty();
+        let blueprint = if has_sub_aggregations {
+            let sub_aggregation = build_segment_agg_collectors(req_data, &node.children)?;
+            Some(sub_aggregation)
+        } else {
+            None
+        };
+        let terms_req_data = req_data.get_term_req_data_mut(node.idx_in_req_data);
+        terms_req_data.sub_aggregation_blueprint = blueprint;
+
+        Ok(SegmentTermCollector {
+            term_buckets,
+            accessor_idx,
+        })
+    }
+
+    fn get_memory_consumption(&self) -> usize {
+        let self_mem = std::mem::size_of::<Self>();
+        let term_buckets_mem = self.term_buckets.get_memory_consumption();
+        self_mem + term_buckets_mem
+    }
+}

--- a/src/aggregation/bucket/term_agg/low_cardinality_impl.rs
+++ b/src/aggregation/bucket/term_agg/low_cardinality_impl.rs
@@ -1,0 +1,228 @@
+use std::vec;
+
+use rustc_hash::FxHashMap;
+
+use crate::aggregation::agg_data::{
+    build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
+};
+use crate::aggregation::bucket::{get_agg_name_and_property, OrderTarget};
+use crate::aggregation::intermediate_agg_result::{
+    IntermediateAggregationResult, IntermediateAggregationResults,
+};
+use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
+use crate::{DocId, TantivyError};
+
+const MAX_BATCH_SIZE: usize = 1_024;
+
+#[derive(Debug, Clone)]
+struct LowCardTermBuckets {
+    entries: Box<[u32]>,
+    sub_aggs: Vec<Box<dyn SegmentAggregationCollector>>,
+    doc_buffers: Box<[Vec<DocId>]>,
+}
+
+impl LowCardTermBuckets {
+    pub fn with_num_buckets(
+        num_buckets: usize,
+        sub_aggs_blueprint_opt: Option<&Box<dyn SegmentAggregationCollector>>,
+    ) -> Self {
+        let sub_aggs = sub_aggs_blueprint_opt
+            .as_ref()
+            .map(|blueprint| {
+                std::iter::repeat_with(|| blueprint.clone_box())
+                    .take(num_buckets)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        Self {
+            entries: vec![0; num_buckets].into_boxed_slice(),
+            sub_aggs,
+            doc_buffers: std::iter::repeat_with(|| Vec::with_capacity(MAX_BATCH_SIZE))
+                .take(num_buckets)
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }
+    }
+
+    fn get_memory_consumption(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.entries.len() * std::mem::size_of::<u32>()
+            + self.doc_buffers.len()
+                * (std::mem::size_of::<Vec<DocId>>()
+                    + std::mem::size_of::<DocId>() * MAX_BATCH_SIZE)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LowCardSegmentTermCollector {
+    term_buckets: LowCardTermBuckets,
+    accessor_idx: usize,
+}
+
+impl LowCardSegmentTermCollector {
+    pub fn from_req_and_validate(
+        req_data: &mut AggregationsSegmentCtx,
+        node: &AggRefNode,
+    ) -> crate::Result<Self> {
+        let terms_req_data = req_data.get_term_req_data(node.idx_in_req_data);
+        let accessor_idx = node.idx_in_req_data;
+        let cardinality = terms_req_data
+            .accessor
+            .max_value()
+            .max(terms_req_data.missing_value_for_accessor.unwrap_or(0))
+            + 1;
+        assert!(cardinality <= super::LOW_CARDINALITY_THRESHOLD);
+
+        // Validate sub aggregation exists
+        if let OrderTarget::SubAggregation(sub_agg_name) = &terms_req_data.req.order.target {
+            let (agg_name, _agg_property) = get_agg_name_and_property(sub_agg_name);
+
+            node.get_sub_agg(agg_name, &req_data.per_request)
+                .ok_or_else(|| {
+                    TantivyError::InvalidArgument(format!(
+                        "could not find aggregation with name {agg_name} in metric \
+                         sub_aggregations"
+                    ))
+                })?;
+        }
+
+        let has_sub_aggregations = !node.children.is_empty();
+        let blueprint = if has_sub_aggregations {
+            let sub_aggregation = build_segment_agg_collectors(req_data, &node.children)?;
+            Some(sub_aggregation)
+        } else {
+            None
+        };
+        let terms_req_data = req_data.get_term_req_data_mut(node.idx_in_req_data);
+
+        let term_buckets =
+            LowCardTermBuckets::with_num_buckets(cardinality as usize, blueprint.as_ref());
+
+        terms_req_data.sub_aggregation_blueprint = blueprint;
+
+        Ok(LowCardSegmentTermCollector {
+            term_buckets,
+            accessor_idx,
+        })
+    }
+
+    fn get_memory_consumption(&self) -> usize {
+        let self_mem = std::mem::size_of::<Self>();
+        let term_buckets_mem = self.term_buckets.get_memory_consumption();
+        self_mem + term_buckets_mem
+    }
+}
+
+impl SegmentAggregationCollector for LowCardSegmentTermCollector {
+    fn add_intermediate_aggregation_result(
+        self: Box<Self>,
+        agg_data: &AggregationsSegmentCtx,
+        results: &mut IntermediateAggregationResults,
+    ) -> crate::Result<()> {
+        let name = agg_data.get_term_req_data(self.accessor_idx).name.clone();
+        let sub_aggs: FxHashMap<u64, Box<dyn SegmentAggregationCollector>> = self
+            .term_buckets
+            .sub_aggs
+            .into_iter()
+            .enumerate()
+            .filter(|(bucket_id, _sub_agg)| self.term_buckets.entries[*bucket_id] > 0)
+            .map(|(bucket_id, sub_agg)| (bucket_id as u64, sub_agg))
+            .collect();
+        let entries: Vec<(u64, u32)> = self
+            .term_buckets
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count > 0)
+            .map(|(bucket_id, count)| (bucket_id as u64, *count))
+            .collect();
+
+        let bucket =
+            super::into_intermediate_bucket_result(self.accessor_idx, entries, sub_aggs, agg_data)?;
+        results.push(name, IntermediateAggregationResult::Bucket(bucket))?;
+        Ok(())
+    }
+
+    fn collect_block(
+        &mut self,
+        docs: &[crate::DocId],
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        if docs.len() > MAX_BATCH_SIZE {
+            for batch in docs.chunks(MAX_BATCH_SIZE) {
+                self.collect_block(batch, agg_data)?;
+            }
+        }
+
+        let mut req_data = agg_data.take_term_req_data(self.accessor_idx);
+
+        let mem_pre = self.get_memory_consumption();
+
+        if let Some(missing) = req_data.missing_value_for_accessor {
+            req_data.column_block_accessor.fetch_block_with_missing(
+                docs,
+                &req_data.accessor,
+                missing,
+            );
+        } else {
+            req_data
+                .column_block_accessor
+                .fetch_block(docs, &req_data.accessor);
+        }
+
+        // has subagg
+        if req_data.sub_aggregation_blueprint.is_some() {
+            for (doc, term_id) in req_data
+                .column_block_accessor
+                .iter_docid_vals(docs, &req_data.accessor)
+            {
+                if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
+                    if !allowed_bs.contains(term_id as u32) {
+                        continue;
+                    }
+                }
+                self.term_buckets.doc_buffers[term_id as usize].push(doc);
+            }
+            for (bucket_id, docs) in self.term_buckets.doc_buffers.iter_mut().enumerate() {
+                self.term_buckets.entries[bucket_id] += docs.len() as u32;
+                self.term_buckets.sub_aggs[bucket_id].collect_block(&docs[..], agg_data)?;
+                docs.clear();
+            }
+        } else {
+            for term_id in req_data.column_block_accessor.iter_vals() {
+                if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
+                    if !allowed_bs.contains(term_id as u32) {
+                        continue;
+                    }
+                }
+                self.term_buckets.entries[term_id as usize] += 1;
+            }
+        }
+
+        let mem_delta = self.get_memory_consumption() - mem_pre;
+        if mem_delta > 0 {
+            agg_data
+                .context
+                .limits
+                .add_memory_consumed(mem_delta as u64)?;
+        }
+        agg_data.put_back_term_req_data(self.accessor_idx, req_data);
+
+        Ok(())
+    }
+
+    fn collect(
+        &mut self,
+        doc: crate::DocId,
+        agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        self.collect_block(&[doc], agg_data)
+    }
+
+    fn flush(&mut self, agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
+        for sub_aggregations in &mut self.term_buckets.sub_aggs.iter_mut() {
+            sub_aggregations.as_mut().flush(agg_data)?;
+        }
+        Ok(())
+    }
+}

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1,3 +1,6 @@
+mod default_impl;
+mod low_cardinality_impl;
+
 use std::fmt::Debug;
 use std::io;
 use std::net::Ipv6Addr;
@@ -12,19 +15,23 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use super::{CustomOrder, Order, OrderTarget};
-use crate::aggregation::agg_data::{
-    build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
-};
-use crate::aggregation::agg_limits::MemoryConsumption;
+use crate::aggregation::agg_data::{AggRefNode, AggregationsSegmentCtx};
 use crate::aggregation::agg_req::Aggregations;
+use crate::aggregation::bucket::term_agg::default_impl::SegmentTermCollector;
+use crate::aggregation::bucket::term_agg::low_cardinality_impl::LowCardSegmentTermCollector;
 use crate::aggregation::intermediate_agg_result::{
-    IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
-    IntermediateKey, IntermediateTermBucketEntry, IntermediateTermBucketResult,
+    IntermediateAggregationResults, IntermediateBucketResult, IntermediateKey,
+    IntermediateTermBucketEntry, IntermediateTermBucketResult,
 };
 use crate::aggregation::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::{format_date, Key};
 use crate::error::DataCorruption;
 use crate::TantivyError;
+
+pub(crate) fn get_agg_name_and_property(name: &str) -> (&str, &str) {
+    let (agg_name, agg_property) = name.split_once('.').unwrap_or((name, ""));
+    (agg_name, agg_property)
+}
 
 /// Contains all information required by the SegmentTermCollector to perform the
 /// terms aggregation on a segment.
@@ -331,415 +338,34 @@ impl TermsAggregationInternal {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-/// Container to store term_ids/or u64 values and their buckets.
-struct TermBuckets {
-    pub(crate) entries: FxHashMap<u64, u32>,
-    pub(crate) sub_aggs: FxHashMap<u64, Box<dyn SegmentAggregationCollector>>,
-}
+const LOW_CARDINALITY_THRESHOLD: u64 = 10;
 
-impl TermBuckets {
-    fn get_memory_consumption(&self) -> usize {
-        let sub_aggs_mem = self.sub_aggs.memory_consumption();
-        let buckets_mem = self.entries.memory_consumption();
-        sub_aggs_mem + buckets_mem
+pub(crate) fn build_segment_aggregation_collector(
+    req: &mut AggregationsSegmentCtx,
+    node: &AggRefNode,
+) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    let terms_req_data = req.get_term_req_data(node.idx_in_req_data);
+    let column_type = terms_req_data.column_type;
+    if column_type == ColumnType::Bytes {
+        return Err(TantivyError::InvalidArgument(format!(
+            "terms aggregation is not supported for column type {column_type:?}"
+        )));
     }
 
-    fn force_flush(&mut self, agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
-        for sub_aggregations in &mut self.sub_aggs.values_mut() {
-            sub_aggregations.as_mut().flush(agg_data)?;
-        }
-        Ok(())
-    }
-}
+    let cardinality = terms_req_data
+        .accessor
+        .max_value()
+        .max(terms_req_data.missing_value_for_accessor.unwrap_or(0u64))
+        .saturating_add(1);
 
-/// The collector puts values from the fast field into the correct buckets and does a conversion to
-/// the correct datatype.
-#[derive(Clone, Debug)]
-pub struct SegmentTermCollector {
-    /// The buckets containing the aggregation data.
-    term_buckets: TermBuckets,
-    accessor_idx: usize,
-}
-
-pub(crate) fn get_agg_name_and_property(name: &str) -> (&str, &str) {
-    let (agg_name, agg_property) = name.split_once('.').unwrap_or((name, ""));
-    (agg_name, agg_property)
-}
-
-impl SegmentAggregationCollector for SegmentTermCollector {
-    fn add_intermediate_aggregation_result(
-        self: Box<Self>,
-        agg_data: &AggregationsSegmentCtx,
-        results: &mut IntermediateAggregationResults,
-    ) -> crate::Result<()> {
-        let name = agg_data.get_term_req_data(self.accessor_idx).name.clone();
-
-        let bucket = self.into_intermediate_bucket_result(agg_data)?;
-        results.push(name, IntermediateAggregationResult::Bucket(bucket))?;
-
-        Ok(())
-    }
-
-    #[inline]
-    fn collect(
-        &mut self,
-        doc: crate::DocId,
-        agg_data: &mut AggregationsSegmentCtx,
-    ) -> crate::Result<()> {
-        self.collect_block(&[doc], agg_data)
-    }
-
-    #[inline]
-    fn collect_block(
-        &mut self,
-        docs: &[crate::DocId],
-        agg_data: &mut AggregationsSegmentCtx,
-    ) -> crate::Result<()> {
-        let mut req_data = agg_data.take_term_req_data(self.accessor_idx);
-
-        let mem_pre = self.get_memory_consumption();
-
-        if let Some(missing) = req_data.missing_value_for_accessor {
-            req_data.column_block_accessor.fetch_block_with_missing(
-                docs,
-                &req_data.accessor,
-                missing,
-            );
-        } else {
-            req_data
-                .column_block_accessor
-                .fetch_block(docs, &req_data.accessor);
-        }
-
-        for term_id in req_data.column_block_accessor.iter_vals() {
-            if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
-                if !allowed_bs.contains(term_id as u32) {
-                    continue;
-                }
-            }
-            let entry = self.term_buckets.entries.entry(term_id).or_default();
-            *entry += 1;
-        }
-        // has subagg
-        if let Some(blueprint) = req_data.sub_aggregation_blueprint.as_ref() {
-            for (doc, term_id) in req_data
-                .column_block_accessor
-                .iter_docid_vals(docs, &req_data.accessor)
-            {
-                if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
-                    if !allowed_bs.contains(term_id as u32) {
-                        continue;
-                    }
-                }
-                let sub_aggregations = self
-                    .term_buckets
-                    .sub_aggs
-                    .entry(term_id)
-                    .or_insert_with(|| blueprint.clone());
-                sub_aggregations.collect(doc, agg_data)?;
-            }
-        }
-
-        let mem_delta = self.get_memory_consumption() - mem_pre;
-        if mem_delta > 0 {
-            agg_data
-                .context
-                .limits
-                .add_memory_consumed(mem_delta as u64)?;
-        }
-        agg_data.put_back_term_req_data(self.accessor_idx, req_data);
-
-        Ok(())
-    }
-
-    fn flush(&mut self, agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
-        self.term_buckets.force_flush(agg_data)?;
-        Ok(())
-    }
-}
-
-impl SegmentTermCollector {
-    fn get_memory_consumption(&self) -> usize {
-        let self_mem = std::mem::size_of::<Self>();
-        let term_buckets_mem = self.term_buckets.get_memory_consumption();
-        self_mem + term_buckets_mem
-    }
-
-    pub(crate) fn from_req_and_validate(
-        req_data: &mut AggregationsSegmentCtx,
-        node: &AggRefNode,
-    ) -> crate::Result<Self> {
-        let terms_req_data = req_data.get_term_req_data(node.idx_in_req_data);
-        let column_type = terms_req_data.column_type;
-        let accessor_idx = node.idx_in_req_data;
-        if column_type == ColumnType::Bytes {
-            return Err(TantivyError::InvalidArgument(format!(
-                "terms aggregation is not supported for column type {column_type:?}"
-            )));
-        }
-        let term_buckets = TermBuckets::default();
-
-        // Validate sub aggregation exists
-        if let OrderTarget::SubAggregation(sub_agg_name) = &terms_req_data.req.order.target {
-            let (agg_name, _agg_property) = get_agg_name_and_property(sub_agg_name);
-
-            node.get_sub_agg(agg_name, &req_data.per_request)
-                .ok_or_else(|| {
-                    TantivyError::InvalidArgument(format!(
-                        "could not find aggregation with name {agg_name} in metric \
-                         sub_aggregations"
-                    ))
-                })?;
-        }
-
-        let has_sub_aggregations = !node.children.is_empty();
-        let blueprint = if has_sub_aggregations {
-            let sub_aggregation = build_segment_agg_collectors(req_data, &node.children)?;
-            Some(sub_aggregation)
-        } else {
-            None
-        };
-        let terms_req_data = req_data.get_term_req_data_mut(node.idx_in_req_data);
-        terms_req_data.sub_aggregation_blueprint = blueprint;
-
-        Ok(SegmentTermCollector {
-            term_buckets,
-            accessor_idx,
-        })
-    }
-
-    #[inline]
-    pub(crate) fn into_intermediate_bucket_result(
-        mut self,
-        agg_data: &AggregationsSegmentCtx,
-    ) -> crate::Result<IntermediateBucketResult> {
-        let term_req = agg_data.get_term_req_data(self.accessor_idx);
-        let mut entries: Vec<(u64, u32)> = self.term_buckets.entries.into_iter().collect();
-
-        let order_by_sub_aggregation =
-            matches!(term_req.req.order.target, OrderTarget::SubAggregation(_));
-
-        match &term_req.req.order.target {
-            OrderTarget::Key => {
-                // We rely on the fact, that term ordinals match the order of the strings
-                // TODO: We could have a special collector, that keeps only TOP n results at any
-                // time.
-                if term_req.req.order.order == Order::Desc {
-                    entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.0));
-                } else {
-                    entries.sort_unstable_by_key(|bucket| bucket.0);
-                }
-            }
-            OrderTarget::SubAggregation(_name) => {
-                // don't sort and cut off since it's hard to make assumptions on the quality of the
-                // results when cutting off du to unknown nature of the sub_aggregation (possible
-                // to check).
-            }
-            OrderTarget::Count => {
-                if term_req.req.order.order == Order::Desc {
-                    entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.1));
-                } else {
-                    entries.sort_unstable_by_key(|bucket| bucket.1);
-                }
-            }
-        }
-
-        let (term_doc_count_before_cutoff, sum_other_doc_count) = if order_by_sub_aggregation {
-            (0, 0)
-        } else {
-            cut_off_buckets(&mut entries, term_req.req.segment_size as usize)
-        };
-
-        let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> = Default::default();
-        dict.reserve(entries.len());
-
-        let mut into_intermediate_bucket_entry =
-            |id, doc_count| -> crate::Result<IntermediateTermBucketEntry> {
-                let intermediate_entry = if term_req.sub_aggregation_blueprint.as_ref().is_some() {
-                    let mut sub_aggregation_res = IntermediateAggregationResults::default();
-                    self.term_buckets
-                        .sub_aggs
-                        .remove(&id)
-                        .unwrap_or_else(|| {
-                            panic!("Internal Error: could not find subaggregation for id {id}")
-                        })
-                        .add_intermediate_aggregation_result(agg_data, &mut sub_aggregation_res)?;
-
-                    IntermediateTermBucketEntry {
-                        doc_count,
-                        sub_aggregation: sub_aggregation_res,
-                    }
-                } else {
-                    IntermediateTermBucketEntry {
-                        doc_count,
-                        sub_aggregation: Default::default(),
-                    }
-                };
-                Ok(intermediate_entry)
-            };
-
-        if term_req.column_type == ColumnType::Str {
-            let fallback_dict = Dictionary::empty();
-            let term_dict = term_req
-                .str_dict_column
-                .as_ref()
-                .map(|el| el.dictionary())
-                .unwrap_or_else(|| &fallback_dict);
-            let mut buffer = Vec::new();
-
-            // special case for missing key
-            if let Some(index) = entries.iter().position(|value| value.0 == u64::MAX) {
-                let entry = entries[index];
-                let intermediate_entry = into_intermediate_bucket_entry(entry.0, entry.1)?;
-                let missing_key = term_req
-                    .req
-                    .missing
-                    .as_ref()
-                    .expect("Found placeholder term_id but `missing` is None");
-                match missing_key {
-                    Key::Str(missing) => {
-                        buffer.clear();
-                        buffer.extend_from_slice(missing.as_bytes());
-                        dict.insert(
-                            IntermediateKey::Str(
-                                String::from_utf8(buffer.to_vec())
-                                    .expect("could not convert to String"),
-                            ),
-                            intermediate_entry,
-                        );
-                    }
-                    Key::F64(val) => {
-                        dict.insert(IntermediateKey::F64(*val), intermediate_entry);
-                    }
-                    Key::U64(val) => {
-                        dict.insert(IntermediateKey::U64(*val), intermediate_entry);
-                    }
-                    Key::I64(val) => {
-                        dict.insert(IntermediateKey::I64(*val), intermediate_entry);
-                    }
-                }
-
-                entries.swap_remove(index);
-            }
-
-            // Sort by term ord
-            entries.sort_unstable_by_key(|bucket| bucket.0);
-            let mut idx = 0;
-            term_dict.sorted_ords_to_term_cb(
-                entries.iter().map(|(term_id, _)| *term_id),
-                |term| {
-                    let entry = entries[idx];
-                    let intermediate_entry = into_intermediate_bucket_entry(entry.0, entry.1)
-                        .map_err(io::Error::other)?;
-                    dict.insert(
-                        IntermediateKey::Str(
-                            String::from_utf8(term.to_vec()).expect("could not convert to String"),
-                        ),
-                        intermediate_entry,
-                    );
-                    idx += 1;
-                    Ok(())
-                },
-            )?;
-
-            if term_req.req.min_doc_count == 0 {
-                // TODO: Handle rev streaming for descending sorting by keys
-                let mut stream = term_dict.stream()?;
-                let empty_sub_aggregation =
-                    IntermediateAggregationResults::empty_from_req(&term_req.sug_aggregations);
-                while stream.advance() {
-                    if dict.len() >= term_req.req.segment_size as usize {
-                        break;
-                    }
-
-                    // Respect allowed filters if present
-                    if let Some(allowed_bs) = term_req.allowed_term_ids.as_ref() {
-                        if !allowed_bs.contains(stream.term_ord() as u32) {
-                            continue;
-                        }
-                    }
-
-                    let key = IntermediateKey::Str(
-                        std::str::from_utf8(stream.key())
-                            .map_err(|utf8_err| DataCorruption::comment_only(utf8_err.to_string()))?
-                            .to_string(),
-                    );
-
-                    dict.entry(key.clone())
-                        .or_insert_with(|| IntermediateTermBucketEntry {
-                            doc_count: 0,
-                            sub_aggregation: empty_sub_aggregation.clone(),
-                        });
-                }
-            }
-        } else if term_req.column_type == ColumnType::DateTime {
-            for (val, doc_count) in entries {
-                let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
-                let val = i64::from_u64(val);
-                let date = format_date(val)?;
-                dict.insert(IntermediateKey::Str(date), intermediate_entry);
-            }
-        } else if term_req.column_type == ColumnType::Bool {
-            for (val, doc_count) in entries {
-                let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
-                let val = bool::from_u64(val);
-                dict.insert(IntermediateKey::Bool(val), intermediate_entry);
-            }
-        } else if term_req.column_type == ColumnType::IpAddr {
-            let compact_space_accessor = term_req
-                .accessor
-                .values
-                .clone()
-                .downcast_arc::<CompactSpaceU64Accessor>()
-                .map_err(|_| {
-                    TantivyError::AggregationError(
-                        crate::aggregation::AggregationError::InternalError(
-                            "Type mismatch: Could not downcast to CompactSpaceU64Accessor"
-                                .to_string(),
-                        ),
-                    )
-                })?;
-
-            for (val, doc_count) in entries {
-                let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
-                let val: u128 = compact_space_accessor.compact_to_u128(val as u32);
-                let val = Ipv6Addr::from_u128(val);
-                dict.insert(IntermediateKey::IpAddr(val), intermediate_entry);
-            }
-        } else {
-            for (val, doc_count) in entries {
-                let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
-                if term_req.column_type == ColumnType::U64 {
-                    dict.insert(IntermediateKey::U64(val), intermediate_entry);
-                } else if term_req.column_type == ColumnType::I64 {
-                    dict.insert(IntermediateKey::I64(i64::from_u64(val)), intermediate_entry);
-                } else {
-                    let val = f64::from_u64(val);
-                    let val: NumericalValue = val.into();
-
-                    match val.normalize() {
-                        NumericalValue::U64(val) => {
-                            dict.insert(IntermediateKey::U64(val), intermediate_entry);
-                        }
-                        NumericalValue::I64(val) => {
-                            dict.insert(IntermediateKey::I64(val), intermediate_entry);
-                        }
-                        NumericalValue::F64(val) => {
-                            dict.insert(IntermediateKey::F64(val), intermediate_entry);
-                        }
-                    }
-                };
-            }
-        };
-
-        Ok(IntermediateBucketResult::Terms {
-            buckets: IntermediateTermBucketResult {
-                entries: dict,
-                sum_other_doc_count,
-                doc_count_error_upper_bound: term_doc_count_before_cutoff,
-            },
-        })
+    if cardinality <= LOW_CARDINALITY_THRESHOLD {
+        Ok(Box::new(
+            LowCardSegmentTermCollector::from_req_and_validate(req, node)?,
+        ))
+    } else {
+        Ok(Box::new(SegmentTermCollector::from_req_and_validate(
+            req, node,
+        )?))
     }
 }
 
@@ -773,6 +399,232 @@ pub(crate) fn cut_off_buckets<T: GetDocCount + Debug>(
 
     entries.truncate(num_elem);
     (term_doc_count_before_cutoff, sum_other_doc_count)
+}
+
+fn into_intermediate_bucket_result(
+    accessor_idx: usize,
+    mut entries: Vec<(u64, u32)>,
+    mut sub_aggs: FxHashMap<u64, Box<dyn SegmentAggregationCollector>>,
+    agg_data: &AggregationsSegmentCtx,
+) -> crate::Result<IntermediateBucketResult> {
+    let term_req = agg_data.get_term_req_data(accessor_idx);
+
+    let order_by_sub_aggregation =
+        matches!(term_req.req.order.target, OrderTarget::SubAggregation(_));
+
+    match &term_req.req.order.target {
+        OrderTarget::Key => {
+            // We rely on the fact, that term ordinals match the order of the strings
+            // TODO: We could have a special collector, that keeps only TOP n results at any
+            // time.
+            if term_req.req.order.order == Order::Desc {
+                entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.0));
+            } else {
+                entries.sort_unstable_by_key(|bucket| bucket.0);
+            }
+        }
+        OrderTarget::SubAggregation(_name) => {
+            // don't sort and cut off since it's hard to make assumptions on the quality of the
+            // results when cutting off du to unknown nature of the sub_aggregation (possible
+            // to check).
+        }
+        OrderTarget::Count => {
+            if term_req.req.order.order == Order::Desc {
+                entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.1));
+            } else {
+                entries.sort_unstable_by_key(|bucket| bucket.1);
+            }
+        }
+    }
+
+    let (term_doc_count_before_cutoff, sum_other_doc_count) = if order_by_sub_aggregation {
+        (0, 0)
+    } else {
+        cut_off_buckets(&mut entries, term_req.req.segment_size as usize)
+    };
+
+    let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> = Default::default();
+    dict.reserve(entries.len());
+
+    let mut into_intermediate_bucket_entry =
+        |id, doc_count| -> crate::Result<IntermediateTermBucketEntry> {
+            let intermediate_entry = if term_req.sub_aggregation_blueprint.as_ref().is_some() {
+                let mut sub_aggregation_res = IntermediateAggregationResults::default();
+                sub_aggs
+                    .remove(&id)
+                    .unwrap_or_else(|| {
+                        panic!("Internal Error: could not find subaggregation for id {id}")
+                    })
+                    .add_intermediate_aggregation_result(agg_data, &mut sub_aggregation_res)?;
+
+                IntermediateTermBucketEntry {
+                    doc_count,
+                    sub_aggregation: sub_aggregation_res,
+                }
+            } else {
+                IntermediateTermBucketEntry {
+                    doc_count,
+                    sub_aggregation: Default::default(),
+                }
+            };
+            Ok(intermediate_entry)
+        };
+
+    if term_req.column_type == ColumnType::Str {
+        let fallback_dict = Dictionary::empty();
+        let term_dict = term_req
+            .str_dict_column
+            .as_ref()
+            .map(|el| el.dictionary())
+            .unwrap_or_else(|| &fallback_dict);
+        let mut buffer = Vec::new();
+
+        // special case for missing key
+        if let Some(index) = entries.iter().position(|value| value.0 == u64::MAX) {
+            let entry = entries[index];
+            let intermediate_entry = into_intermediate_bucket_entry(entry.0, entry.1)?;
+            let missing_key = term_req
+                .req
+                .missing
+                .as_ref()
+                .expect("Found placeholder term_id but `missing` is None");
+            match missing_key {
+                Key::Str(missing) => {
+                    buffer.clear();
+                    buffer.extend_from_slice(missing.as_bytes());
+                    dict.insert(
+                        IntermediateKey::Str(
+                            String::from_utf8(buffer.to_vec())
+                                .expect("could not convert to String"),
+                        ),
+                        intermediate_entry,
+                    );
+                }
+                Key::F64(val) => {
+                    dict.insert(IntermediateKey::F64(*val), intermediate_entry);
+                }
+                Key::U64(val) => {
+                    dict.insert(IntermediateKey::U64(*val), intermediate_entry);
+                }
+                Key::I64(val) => {
+                    dict.insert(IntermediateKey::I64(*val), intermediate_entry);
+                }
+            }
+
+            entries.swap_remove(index);
+        }
+
+        // Sort by term ord
+        entries.sort_unstable_by_key(|bucket| bucket.0);
+        let mut idx = 0;
+        term_dict.sorted_ords_to_term_cb(entries.iter().map(|(term_id, _)| *term_id), |term| {
+            let entry = entries[idx];
+            let intermediate_entry =
+                into_intermediate_bucket_entry(entry.0, entry.1).map_err(io::Error::other)?;
+            dict.insert(
+                IntermediateKey::Str(
+                    String::from_utf8(term.to_vec()).expect("could not convert to String"),
+                ),
+                intermediate_entry,
+            );
+            idx += 1;
+            Ok(())
+        })?;
+
+        if term_req.req.min_doc_count == 0 {
+            // TODO: Handle rev streaming for descending sorting by keys
+            let mut stream = term_dict.stream()?;
+            let empty_sub_aggregation =
+                IntermediateAggregationResults::empty_from_req(&term_req.sug_aggregations);
+            while stream.advance() {
+                if dict.len() >= term_req.req.segment_size as usize {
+                    break;
+                }
+
+                // Respect allowed filters if present
+                if let Some(allowed_bs) = term_req.allowed_term_ids.as_ref() {
+                    if !allowed_bs.contains(stream.term_ord() as u32) {
+                        continue;
+                    }
+                }
+
+                let key = IntermediateKey::Str(
+                    std::str::from_utf8(stream.key())
+                        .map_err(|utf8_err| DataCorruption::comment_only(utf8_err.to_string()))?
+                        .to_string(),
+                );
+
+                dict.entry(key.clone())
+                    .or_insert_with(|| IntermediateTermBucketEntry {
+                        doc_count: 0,
+                        sub_aggregation: empty_sub_aggregation.clone(),
+                    });
+            }
+        }
+    } else if term_req.column_type == ColumnType::DateTime {
+        for (val, doc_count) in entries {
+            let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
+            let val = i64::from_u64(val);
+            let date = format_date(val)?;
+            dict.insert(IntermediateKey::Str(date), intermediate_entry);
+        }
+    } else if term_req.column_type == ColumnType::Bool {
+        for (val, doc_count) in entries {
+            let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
+            let val = bool::from_u64(val);
+            dict.insert(IntermediateKey::Bool(val), intermediate_entry);
+        }
+    } else if term_req.column_type == ColumnType::IpAddr {
+        let compact_space_accessor = term_req
+            .accessor
+            .values
+            .clone()
+            .downcast_arc::<CompactSpaceU64Accessor>()
+            .map_err(|_| {
+                TantivyError::AggregationError(crate::aggregation::AggregationError::InternalError(
+                    "Type mismatch: Could not downcast to CompactSpaceU64Accessor".to_string(),
+                ))
+            })?;
+
+        for (val, doc_count) in entries {
+            let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
+            let val: u128 = compact_space_accessor.compact_to_u128(val as u32);
+            let val = Ipv6Addr::from_u128(val);
+            dict.insert(IntermediateKey::IpAddr(val), intermediate_entry);
+        }
+    } else {
+        for (val, doc_count) in entries {
+            let intermediate_entry = into_intermediate_bucket_entry(val, doc_count)?;
+            if term_req.column_type == ColumnType::U64 {
+                dict.insert(IntermediateKey::U64(val), intermediate_entry);
+            } else if term_req.column_type == ColumnType::I64 {
+                dict.insert(IntermediateKey::I64(i64::from_u64(val)), intermediate_entry);
+            } else {
+                let val = f64::from_u64(val);
+                let val: NumericalValue = val.into();
+
+                match val.normalize() {
+                    NumericalValue::U64(val) => {
+                        dict.insert(IntermediateKey::U64(val), intermediate_entry);
+                    }
+                    NumericalValue::I64(val) => {
+                        dict.insert(IntermediateKey::I64(val), intermediate_entry);
+                    }
+                    NumericalValue::F64(val) => {
+                        dict.insert(IntermediateKey::F64(val), intermediate_entry);
+                    }
+                }
+            };
+        }
+    };
+
+    Ok(IntermediateBucketResult::Terms {
+        buckets: IntermediateTermBucketResult {
+            entries: dict,
+            sum_other_doc_count,
+            doc_count_error_upper_bound: term_doc_count_before_cutoff,
+        },
+    })
 }
 
 #[cfg(test)]

--- a/src/aggregation/segment_agg_result.rs
+++ b/src/aggregation/segment_agg_result.rs
@@ -17,11 +17,14 @@ pub trait SegmentAggregationCollector: CollectorClone + Debug {
         results: &mut IntermediateAggregationResults,
     ) -> crate::Result<()>;
 
+    #[inline]
     fn collect(
         &mut self,
         doc: crate::DocId,
         agg_data: &mut AggregationsSegmentCtx,
-    ) -> crate::Result<()>;
+    ) -> crate::Result<()> {
+        self.collect_block(&[doc], agg_data)
+    }
 
     fn collect_block(
         &mut self,


### PR DESCRIPTION
```
full
average_u64                                    Memory: 14.6 KB (-3.99%)      Avg: 3.0508ms (-1.76%)      Median: 3.0487ms (-1.66%)      [3.0179ms .. 3.1047ms]
average_f64                                    Memory: 15.2 KB (+1.35%)      Avg: 3.0690ms (-1.71%)      Median: 3.0630ms (-1.60%)      [3.0358ms .. 3.1176ms]
average_f64_u64                                Memory: 16.1 KB (-0.07%)      Avg: 5.7340ms (-1.19%)      Median: 5.7343ms (-1.20%)      [5.6917ms .. 5.7909ms]
stats_f64                                      Memory: 14.9 KB (-1.35%)      Avg: 3.0819ms (-1.39%)      Median: 3.0614ms (-1.86%)      [3.0374ms .. 3.3795ms]
extendedstats_f64                              Memory: 15.9 KB (+4.02%)      Avg: 4.2102ms (-1.64%)      Median: 4.2114ms (-1.58%)      [4.1824ms .. 4.2429ms]
percentiles_f64                                Memory: 18.8 KB (+1.09%)      Avg: 9.2446ms (-0.67%)      Median: 9.2376ms (-0.49%)      [9.1785ms .. 9.4246ms]
terms_few                                      Memory: 44.6 KB (+58.57%)     Avg: 1.2191ms (-44.23%)     Median: 1.2187ms (-43.97%)     [1.1976ms .. 1.2798ms]
terms_many                                     Memory: 6.9 MB                Avg: 6.0674ms (-0.41%)      Median: 6.0655ms (-0.21%)      [6.0142ms .. 6.1415ms]
terms_many_top_1000                            Memory: 6.9 MB                Avg: 7.4657ms (-0.85%)      Median: 7.4636ms (-0.70%)      [7.3812ms .. 7.5786ms]
terms_many_order_by_term                       Memory: 6.9 MB                Avg: 7.5183ms (+0.67%)      Median: 7.5085ms (+0.74%)      [7.4549ms .. 7.5971ms]
terms_many_with_top_hits                       Memory: 58.3 MB (+0.00%)      Avg: 116.7791ms (-3.91%)    Median: 116.0409ms (-2.31%)    [114.6284ms .. 127.4939ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB (+0.00%)      Avg: 42.0682ms (-0.06%)     Median: 42.0087ms (+0.94%)     [40.7962ms .. 43.1809ms]
terms_few_with_avg_sub_agg                     Memory: 49.4 KB (+52.66%)     Avg: 4.8933ms (-56.94%)     Median: 4.8748ms (-57.00%)     [4.8341ms .. 5.1475ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB (+0.00%)      Avg: 57.3985ms (-2.31%)     Median: 57.4960ms (-1.98%)     [55.6649ms .. 58.9360ms]
cardinality_agg                                Memory: 3.6 MB (+0.01%)       Avg: 17.7989ms (-1.25%)     Median: 17.7810ms (-1.09%)     [17.6340ms .. 18.4213ms]
terms_few_with_cardinality_agg                 Memory: 10.7 MB (+0.15%)      Avg: 58.4421ms (-18.69%)    Median: 58.3662ms (-18.81%)    [58.0734ms .. 59.7106ms]
range_agg                                      Memory: 16.9 KB (+0.76%)      Avg: 3.8291ms (+0.01%)      Median: 3.8194ms (-0.14%)      [3.7784ms .. 4.1001ms]
range_agg_with_avg_sub_agg                     Memory: 31.1 KB               Avg: 11.1946ms (+0.59%)     Median: 11.1789ms (+0.66%)     [11.0385ms .. 11.4301ms]
range_agg_with_term_agg_few                    Memory: 44.6 KB (+0.82%)      Avg: 13.1112ms (-19.31%)    Median: 13.1009ms (-19.29%)    [12.9639ms .. 13.3869ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB                Avg: 25.3815ms (+1.71%)     Median: 25.3259ms (+1.54%)     [25.1107ms .. 26.0863ms]
histogram                                      Memory: 17.1 KB (+2.32%)      Avg: 4.9235ms (+0.10%)      Median: 4.9114ms (+0.09%)      [4.8593ms .. 5.3280ms]
histogram_hard_bounds                          Memory: 14.9 KB (-0.07%)      Avg: 3.6403ms (+0.10%)      Median: 3.6417ms (+0.21%)      [3.5666ms .. 3.7564ms]
histogram_with_avg_sub_agg                     Memory: 48.6 KB               Avg: 13.5582ms (-0.39%)     Median: 13.5334ms (-0.37%)     [13.4553ms .. 13.8149ms]
histogram_with_term_agg_few                    Memory: 327.1 KB (+5.20%)     Avg: 20.6369ms (-16.62%)    Median: 20.5814ms (-16.80%)    [20.3953ms .. 21.2581ms]
avg_and_range_with_avg_sub_agg                 Memory: 26.0 KB               Avg: 13.8213ms (-0.37%)     Median: 13.8107ms (-0.02%)     [13.6845ms .. 14.0757ms]
filter_agg_all_query_count_agg                 Memory: 143.0 KB (+0.23%)     Avg: 4.1072ms (-0.89%)      Median: 4.0903ms (-1.23%)      [4.0594ms .. 4.2343ms]
filter_agg_term_query_count_agg                Memory: 143.2 KB (+0.11%)     Avg: 6.0480ms (-0.86%)      Median: 6.0400ms (-0.94%)      [6.0062ms .. 6.1131ms]
filter_agg_all_query_with_sub_aggs             Memory: 176.5 KB (+10.31%)    Avg: 7.9455ms (-11.76%)     Median: 7.9465ms (-11.35%)     [7.8607ms .. 8.0782ms]
filter_agg_term_query_with_sub_aggs            Memory: 176.8 KB (+10.28%)    Avg: 9.9094ms (-9.41%)      Median: 9.9077ms (-9.44%)      [9.8323ms .. 10.0519ms]
dense
average_u64                                    Memory: 15.8 KB (+1.33%)      Avg: 7.0480ms (-0.27%)      Median: 7.0497ms (+0.05%)      [6.9508ms .. 7.2386ms]
average_f64                                    Memory: 15.7 KB (+1.34%)      Avg: 7.0524ms (-0.31%)      Median: 7.0436ms (-0.18%)      [6.9740ms .. 7.2850ms]
average_f64_u64                                Memory: 16.5 KB (-5.04%)      Avg: 13.7122ms (+0.08%)     Median: 13.6938ms (+0.12%)     [13.5879ms .. 14.1215ms]
stats_f64                                      Memory: 15.7 KB (+1.35%)      Avg: 7.0457ms (-0.67%)      Median: 7.0557ms (-0.24%)      [6.9405ms .. 7.1831ms]
extendedstats_f64                              Memory: 15.2 KB (-1.34%)      Avg: 8.2221ms (-0.17%)      Median: 8.2210ms (-0.01%)      [8.1386ms .. 8.3727ms]
percentiles_f64                                Memory: 20.6 KB (+10.06%)     Avg: 13.4113ms (-0.05%)     Median: 13.4164ms (-0.12%)     [13.1609ms .. 13.7109ms]
terms_few                                      Memory: 46.1 KB (+57.11%)     Avg: 5.1973ms (-15.96%)     Median: 5.1985ms (-15.61%)     [5.1286ms .. 5.3017ms]
terms_many                                     Memory: 6.9 MB (-0.00%)       Avg: 9.9211ms (-0.37%)      Median: 9.9253ms (-0.29%)      [9.7566ms .. 10.1282ms]
terms_many_top_1000                            Memory: 6.9 MB (+0.01%)       Avg: 11.3574ms (-0.58%)     Median: 11.3427ms (-0.37%)     [11.2001ms .. 11.7556ms]
terms_many_order_by_term                       Memory: 6.9 MB (+0.01%)       Avg: 11.3631ms (+0.02%)     Median: 11.3575ms (+0.03%)     [11.2772ms .. 11.5882ms]
terms_many_with_top_hits                       Memory: 58.3 MB               Avg: 125.8157ms (-2.65%)    Median: 124.1982ms (-1.65%)    [122.3125ms .. 144.8179ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB               Avg: 50.5648ms (-0.37%)     Median: 50.5186ms (-0.05%)     [49.6939ms .. 51.7677ms]
terms_few_with_avg_sub_agg                     Memory: 51.0 KB (+50.04%)     Avg: 13.1931ms (-27.03%)    Median: 13.1831ms (-27.04%)    [13.0104ms .. 13.5547ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB               Avg: 62.8202ms (-1.85%)     Median: 62.8818ms (-0.81%)     [60.8043ms .. 69.2145ms]
cardinality_agg                                Memory: 3.6 MB (+0.01%)       Avg: 22.0994ms (+0.03%)     Median: 22.0713ms (-0.05%)     [21.7556ms .. 22.6779ms]
terms_few_with_cardinality_agg                 Memory: 10.7 MB (+0.16%)      Avg: 66.8574ms (-19.16%)    Median: 66.7978ms (-19.10%)    [66.5918ms .. 67.3981ms]
range_agg                                      Memory: 16.6 KB (-0.97%)      Avg: 7.8137ms (-0.63%)      Median: 7.8000ms (-0.81%)      [7.6968ms .. 7.9776ms]
range_agg_with_avg_sub_agg                     Memory: 32.0 KB (-0.15%)      Avg: 18.6801ms (-0.30%)     Median: 18.6765ms (-0.14%)     [18.4958ms .. 18.9187ms]
range_agg_with_term_agg_few                    Memory: 46.0 KB (+0.23%)      Avg: 22.9019ms (-8.09%)     Median: 22.8825ms (-7.92%)     [22.6982ms .. 23.4651ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB                Avg: 34.6593ms (-1.13%)     Median: 34.5548ms (-1.26%)     [34.3437ms .. 35.4808ms]
histogram                                      Memory: 16.6 KB (-0.78%)      Avg: 8.9698ms (-0.03%)      Median: 8.9672ms (-0.04%)      [8.8210ms .. 9.3060ms]
histogram_hard_bounds                          Memory: 14.4 KB (-0.06%)      Avg: 7.6827ms (+0.06%)      Median: 7.6786ms (-0.18%)      [7.5580ms .. 7.9086ms]
histogram_with_avg_sub_agg                     Memory: 49.7 KB (+2.10%)      Avg: 20.7250ms (+0.10%)     Median: 20.7150ms (+0.08%)     [20.5604ms .. 21.1799ms]
histogram_with_term_agg_few                    Memory: 326.5 KB (+4.52%)     Avg: 31.6320ms (-5.16%)     Median: 31.5311ms (-5.45%)     [31.3277ms .. 32.2873ms]
avg_and_range_with_avg_sub_agg                 Memory: 28.4 KB               Avg: 25.1747ms (+0.13%)     Median: 25.1689ms (+0.14%)     [24.9726ms .. 25.6567ms]
filter_agg_all_query_count_agg                 Memory: 143.5 KB (+0.11%)     Avg: 8.0714ms (-2.04%)      Median: 8.0645ms (-2.35%)      [7.9397ms .. 8.2170ms]
filter_agg_term_query_count_agg                Memory: 143.7 KB (-0.11%)     Avg: 10.0321ms (-2.17%)     Median: 10.0216ms (-2.21%)     [9.8851ms .. 10.2335ms]
filter_agg_all_query_with_sub_aggs             Memory: 180.1 KB (+10.08%)    Avg: 19.8842ms (-5.66%)     Median: 19.8556ms (-5.43%)     [19.6532ms .. 20.1294ms]
filter_agg_term_query_with_sub_aggs            Memory: 180.4 KB (+10.06%)    Avg: 21.8772ms (-4.80%)     Median: 21.8365ms (-4.99%)     [21.5432ms .. 23.2766ms]
sparse
average_u64                                    Memory: 14.9 KB (+2.87%)     Avg: 13.5040ms (+0.59%)    Median: 13.5120ms (+0.77%)    [13.3594ms .. 13.6659ms]
average_f64                                    Memory: 14.5 KB (+1.46%)     Avg: 13.5369ms (+0.92%)    Median: 13.5387ms (+1.00%)    [13.3388ms .. 13.6916ms]
average_f64_u64                                Memory: 15.3 KB (-1.34%)     Avg: 25.2631ms (+0.01%)    Median: 25.2495ms (+0.00%)    [25.0352ms .. 25.5092ms]
stats_f64                                      Memory: 14.3 KB (-1.43%)     Avg: 13.5315ms (+0.96%)    Median: 13.5283ms (+0.96%)    [13.3098ms .. 14.0294ms]
extendedstats_f64                              Memory: 15.3 KB (-1.32%)     Avg: 13.5979ms (+0.83%)    Median: 13.5696ms (+0.77%)    [13.4893ms .. 14.1565ms]
percentiles_f64                                Memory: 17.3 KB              Avg: 13.5666ms (+1.93%)    Median: 13.6005ms (+2.61%)    [13.2688ms .. 13.8748ms]
terms_few                                      Memory: 44.3 KB (+59.18%)    Avg: 12.9959ms (-0.07%)    Median: 12.9999ms (+0.22%)    [12.8801ms .. 13.2084ms]
terms_many                                     Memory: 1.8 MB               Avg: 13.8632ms (+0.52%)    Median: 13.8462ms (+0.73%)    [13.6880ms .. 14.7008ms]
terms_many_top_1000                            Memory: 2.6 MB               Avg: 15.0279ms (+0.21%)    Median: 15.0179ms (+0.28%)    [14.8341ms .. 15.3752ms]
terms_many_order_by_term                       Memory: 1.8 MB               Avg: 14.0755ms (+0.52%)    Median: 14.0499ms (+0.49%)    [13.9252ms .. 14.2633ms]
terms_many_with_top_hits                       Memory: 13.1 MB              Avg: 21.4009ms (+1.29%)    Median: 21.3449ms (+1.25%)    [21.2132ms .. 23.2369ms]
terms_many_with_avg_sub_agg                    Memory: 5.5 MB               Avg: 17.8164ms (+1.32%)    Median: 17.8089ms (+1.36%)    [17.6268ms .. 18.0634ms]
terms_few_with_avg_sub_agg                     Memory: 49.1 KB (+50.82%)    Avg: 15.6510ms (+4.50%)    Median: 15.6351ms (+4.52%)    [15.5050ms .. 15.8590ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 5.4 MB               Avg: 24.8504ms (+0.24%)    Median: 24.8505ms (+0.34%)    [24.6384ms .. 25.0750ms]
cardinality_agg                                Memory: 897.0 KB (-0.03%)    Avg: 19.5818ms (+1.07%)    Median: 19.5591ms (+1.03%)    [19.4225ms .. 19.7502ms]
terms_few_with_cardinality_agg                 Memory: 697.6 KB (+2.38%)    Avg: 24.1427ms (+0.89%)    Median: 24.1294ms (+1.06%)    [23.8632ms .. 24.6982ms]
range_agg                                      Memory: 16.3 KB (+1.52%)     Avg: 13.1293ms (+1.43%)    Median: 13.1312ms (+1.50%)    [12.9513ms .. 13.4651ms]
range_agg_with_avg_sub_agg                     Memory: 30.8 KB              Avg: 15.2375ms (+1.22%)    Median: 15.2281ms (+1.25%)    [15.0915ms .. 15.4494ms]
range_agg_with_term_agg_few                    Memory: 44.5 KB (+0.23%)     Avg: 15.6812ms (+0.63%)    Median: 15.6757ms (+0.60%)    [15.5124ms .. 15.8433ms]
range_agg_with_term_agg_many                   Memory: 1.8 MB               Avg: 16.8552ms (+0.55%)    Median: 16.8785ms (+1.00%)    [16.6837ms .. 17.0199ms]
histogram                                      Memory: 14.5 KB (-0.98%)     Avg: 13.2816ms (+1.13%)    Median: 13.2603ms (+0.98%)    [13.1202ms .. 13.6802ms]
histogram_hard_bounds                          Memory: 13.3 KB (-3.90%)     Avg: 13.1991ms (+0.78%)    Median: 13.2095ms (+0.94%)    [12.9917ms .. 13.3665ms]
histogram_with_avg_sub_agg                     Memory: 35.0 KB              Avg: 15.3435ms (+0.59%)    Median: 15.3093ms (+0.41%)    [15.1723ms .. 15.7266ms]
histogram_with_term_agg_few                    Memory: 208.7 KB (+7.97%)    Avg: 16.2157ms (+0.16%)    Median: 16.2050ms (+0.07%)    [15.9353ms .. 16.6587ms]
avg_and_range_with_avg_sub_agg                 Memory: 25.5 KB              Avg: 26.7929ms (+0.08%)    Median: 26.6929ms (-0.30%)    [26.5385ms .. 29.0739ms]
filter_agg_all_query_count_agg                 Memory: 148.8 KB (+0.11%)    Avg: 14.5666ms (+0.58%)    Median: 14.5754ms (+0.79%)    [14.4290ms .. 14.6500ms]
filter_agg_term_query_count_agg                Memory: 149.4 KB (+0.60%)    Avg: 16.5702ms (+0.22%)    Median: 16.5583ms (+0.32%)    [16.4979ms .. 16.7022ms]
filter_agg_all_query_with_sub_aggs             Memory: 182.0 KB (+9.96%)    Avg: 36.2756ms (-0.50%)    Median: 36.2861ms (-0.45%)    [35.9944ms .. 36.6088ms]
filter_agg_term_query_with_sub_aggs            Memory: 182.4 KB (+9.94%)    Avg: 38.2756ms (-0.84%)    Median: 38.2944ms (-0.59%)    [38.0310ms .. 38.5341ms]
multivalue
average_u64                                    Memory: 16.3 KB (-1.26%)     Avg: 9.8335ms (-0.89%)      Median: 9.8203ms (-0.96%)      [9.7217ms .. 9.9623ms]
average_f64                                    Memory: 15.9 KB              Avg: 9.9459ms (+0.02%)      Median: 9.8312ms (-0.68%)      [9.7588ms .. 10.9194ms]
average_f64_u64                                Memory: 19.0 KB (+1.10%)     Avg: 19.7735ms (+1.74%)     Median: 19.4124ms (-0.19%)     [19.1188ms .. 20.5549ms]
stats_f64                                      Memory: 16.3 KB              Avg: 9.8475ms (-0.48%)      Median: 9.8118ms (-0.72%)      [9.7450ms .. 10.0139ms]
extendedstats_f64                              Memory: 16.4 KB              Avg: 11.0289ms (-0.82%)     Median: 10.9819ms (-0.70%)     [10.9179ms .. 11.2424ms]
percentiles_f64                                Memory: 19.3 KB (+1.09%)     Avg: 16.1034ms (-0.97%)     Median: 16.0565ms (-0.76%)     [15.8694ms .. 16.3634ms]
terms_few                                      Memory: 245.1 KB             Avg: 8.7625ms (-10.78%)     Median: 8.7567ms (-10.75%)     [8.6615ms .. 8.9862ms]
terms_many                                     Memory: 6.9 MB               Avg: 12.9207ms (-1.24%)     Median: 12.8752ms (-1.28%)     [12.7160ms .. 14.4581ms]
terms_many_top_1000                            Memory: 6.9 MB               Avg: 14.2669ms (-1.90%)     Median: 14.2423ms (-1.89%)     [14.1139ms .. 14.4531ms]
terms_many_order_by_term                       Memory: 6.9 MB               Avg: 14.3198ms (-1.04%)     Median: 14.3247ms (-0.82%)     [14.1417ms .. 14.4537ms]
terms_many_with_top_hits                       Memory: 58.3 MB              Avg: 130.1138ms (-3.77%)    Median: 129.1064ms (-2.41%)    [126.8724ms .. 144.0012ms]
terms_many_with_avg_sub_agg                    Memory: 20.6 MB              Avg: 61.2090ms (-3.97%)     Median: 61.2108ms (-3.90%)     [60.2882ms .. 62.9905ms]
terms_few_with_avg_sub_agg                     Memory: 246.4 KB             Avg: 20.1034ms (-19.79%)    Median: 20.0655ms (-19.90%)    [19.7849ms .. 21.1579ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 30.1 MB              Avg: 70.7584ms (-3.13%)     Median: 70.5629ms (-3.27%)     [68.9927ms .. 73.3195ms]
cardinality_agg                                Memory: 3.6 MB               Avg: 25.2477ms (+0.54%)     Median: 25.2192ms (+0.55%)     [24.7321ms .. 25.8745ms]
terms_few_with_cardinality_agg                 Memory: 10.8 MB (+0.19%)     Avg: 73.8012ms (-19.12%)    Median: 73.7428ms (-18.97%)    [73.1267ms .. 75.1277ms]
range_agg                                      Memory: 16.9 KB (-0.27%)     Avg: 10.6481ms (-1.38%)     Median: 10.6361ms (-1.35%)     [10.4882ms .. 11.2096ms]
range_agg_with_avg_sub_agg                     Memory: 32.2 KB              Avg: 26.4121ms (-0.68%)     Median: 26.3971ms (-0.66%)     [26.1681ms .. 26.9385ms]
range_agg_with_term_agg_few                    Memory: 247.8 KB             Avg: 30.8323ms (-7.48%)     Median: 30.7082ms (-7.48%)     [30.3838ms .. 32.3952ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB               Avg: 42.1523ms (-2.08%)     Median: 41.9726ms (-1.86%)     [41.3095ms .. 45.3894ms]
histogram                                      Memory: 16.3 KB (-1.85%)     Avg: 11.7599ms (-0.32%)     Median: 11.7056ms (-0.72%)     [11.5768ms .. 12.5521ms]
histogram_hard_bounds                          Memory: 14.5 KB (+1.35%)     Avg: 10.4645ms (-1.10%)     Median: 10.4374ms (-1.22%)     [10.3274ms .. 10.8764ms]
histogram_with_avg_sub_agg                     Memory: 48.9 KB              Avg: 27.5616ms (+0.15%)     Median: 27.4766ms (-0.11%)     [27.1800ms .. 29.0768ms]
histogram_with_term_agg_few                    Memory: 490.6 KB (+4.60%)    Avg: 39.1011ms (-6.04%)     Median: 39.0678ms (-5.98%)     [38.7858ms .. 39.7516ms]
avg_and_range_with_avg_sub_agg                 Memory: 28.8 KB              Avg: 35.7417ms (-0.43%)     Median: 35.6180ms (-0.66%)     [35.2317ms .. 37.2947ms]
filter_agg_all_query_count_agg                 Memory: 144.3 KB (-0.11%)    Avg: 10.9529ms (-1.19%)     Median: 10.9234ms (-1.39%)     [10.8314ms .. 11.5290ms]
filter_agg_term_query_count_agg                Memory: 144.2 KB (-0.22%)    Avg: 12.8865ms (-1.23%)     Median: 12.8782ms (-1.43%)     [12.7635ms .. 13.0549ms]
filter_agg_all_query_with_sub_aggs             Memory: 374.8 KB             Avg: 29.3432ms (-3.57%)     Median: 29.1094ms (-4.30%)     [28.9165ms .. 36.7631ms]
filter_agg_term_query_with_sub_aggs            Memory: 375.2 KB             Avg: 31.0977ms (-3.95%)     Median: 31.0995ms (-3.92%)     [30.8373ms .. 31.5282ms]
```