### PR TITLE
Optimize term aggregation with low cardinality + some refactoring

### DIFF
--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -59,6 +59,8 @@ fn bench_agg(mut group: InputGroup<Index>) {
     register!(group, terms_many_order_by_term);
     register!(group, terms_many_with_top_hits);
     register!(group, terms_many_with_avg_sub_agg);
+    register!(group, terms_few_with_avg_sub_agg);
+
     register!(group, terms_many_json_mixed_type_with_avg_sub_agg);
 
     register!(group, cardinality_agg);
@@ -220,6 +222,19 @@ fn terms_many_with_avg_sub_agg(index: &Index) {
     });
     execute_agg(index, agg_req);
 }
+
+fn terms_few_with_avg_sub_agg(index: &Index) {
+    let agg_req = json!({
+        "my_texts": {
+            "terms": { "field": "text_few_terms" },
+            "aggs": {
+                "average_f64": { "avg": { "field": "score_f64" } }
+            }
+        },
+    });
+    execute_agg(index, agg_req);
+}
+
 fn terms_many_json_mixed_type_with_avg_sub_agg(index: &Index) {
     let agg_req = json!({
         "my_texts": {

--- a/src/aggregation/accessor_helpers.rs
+++ b/src/aggregation/accessor_helpers.rs
@@ -16,15 +16,16 @@ use crate::index::SegmentReader;
 /// That way we can use it the same way as if it would come from the fastfield.
 pub(crate) fn get_missing_val_as_u64_lenient(
     column_type: ColumnType,
+    column_max_value: u64,
     missing: &Key,
     field_name: &str,
 ) -> crate::Result<Option<u64>> {
     let missing_val = match missing {
-        Key::Str(_) if column_type == ColumnType::Str => Some(u64::MAX),
+        Key::Str(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
         // Allow fallback to number on text fields
-        Key::F64(_) if column_type == ColumnType::Str => Some(u64::MAX),
-        Key::U64(_) if column_type == ColumnType::Str => Some(u64::MAX),
-        Key::I64(_) if column_type == ColumnType::Str => Some(u64::MAX),
+        Key::F64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::U64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
+        Key::I64(_) if column_type == ColumnType::Str => Some(column_max_value + 1),
         Key::F64(val) if column_type.numerical_type().is_some() => {
             f64_to_fastfield_u64(*val, &column_type)
         }

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -900,7 +900,7 @@ fn build_terms_or_cardinality_nodes(
         let missing_value_for_accessor = if use_special_missing_agg {
             None
         } else if let Some(m) = missing.as_ref() {
-            get_missing_val_as_u64_lenient(column_type, m, field_name)?
+            get_missing_val_as_u64_lenient(column_type, accessor.max_value(), m, field_name)?
         } else {
             None
         };

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -12,7 +12,7 @@ use crate::aggregation::agg_req::{Aggregation, AggregationVariants, Aggregations
 use crate::aggregation::bucket::{
     FilterAggReqData, HistogramAggReqData, HistogramBounds, IncludeExcludeParam,
     MissingTermAggReqData, RangeAggReqData, SegmentFilterCollector, SegmentHistogramCollector,
-    SegmentRangeCollector, SegmentTermCollector, TermMissingAgg, TermsAggReqData, TermsAggregation,
+    SegmentRangeCollector, TermMissingAgg, TermsAggReqData, TermsAggregation,
     TermsAggregationInternal,
 };
 use crate::aggregation::metric::{
@@ -373,9 +373,7 @@ pub(crate) fn build_segment_agg_collector(
     node: &AggRefNode,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
     match node.kind {
-        AggKind::Terms => Ok(Box::new(SegmentTermCollector::from_req_and_validate(
-            req, node,
-        )?)),
+        AggKind::Terms => crate::aggregation::bucket::build_segment_term_collector(req, node),
         AggKind::MissingTerm => {
             let req_data = &mut req.per_request.missing_term_req_data[node.idx_in_req_data];
             if req_data.accessors.is_empty() {
@@ -498,7 +496,7 @@ pub(crate) fn build_aggregations_data_from_req(
     };
 
     for (name, agg) in aggs.iter() {
-        let nodes = build_nodes(name, agg, reader, segment_ordinal, &mut data)?;
+        let nodes = build_nodes(name, agg, reader, segment_ordinal, &mut data, true)?;
         data.per_request.agg_tree.extend(nodes);
     }
     Ok(data)
@@ -510,6 +508,7 @@ fn build_nodes(
     reader: &SegmentReader,
     segment_ordinal: SegmentOrdinal,
     data: &mut AggregationsSegmentCtx,
+    is_top_level: bool,
 ) -> crate::Result<Vec<AggRefNode>> {
     use AggregationVariants::*;
     match &req.agg {
@@ -596,6 +595,7 @@ fn build_nodes(
             data,
             &req.sub_aggregation,
             TermsOrCardinalityRequest::Terms(terms_req.clone()),
+            is_top_level,
         ),
         Cardinality(card_req) => build_terms_or_cardinality_nodes(
             agg_name,
@@ -606,6 +606,7 @@ fn build_nodes(
             data,
             &req.sub_aggregation,
             TermsOrCardinalityRequest::Cardinality(card_req.clone()),
+            is_top_level,
         ),
         Average(AverageAggregation { field, missing, .. })
         | Max(MaxAggregation { field, missing, .. })
@@ -771,7 +772,14 @@ fn build_children(
 ) -> crate::Result<Vec<AggRefNode>> {
     let mut children = Vec::new();
     for (name, agg) in aggs.iter() {
-        children.extend(build_nodes(name, agg, reader, segment_ordinal, data)?);
+        children.extend(build_nodes(
+            name,
+            agg,
+            reader,
+            segment_ordinal,
+            data,
+            false,
+        )?);
     }
     Ok(children)
 }
@@ -835,6 +843,7 @@ fn build_terms_or_cardinality_nodes(
     data: &mut AggregationsSegmentCtx,
     sub_aggs: &Aggregations,
     req: TermsOrCardinalityRequest,
+    is_top_level: bool,
 ) -> crate::Result<Vec<AggRefNode>> {
     let mut nodes = Vec::new();
 
@@ -924,6 +933,7 @@ fn build_terms_or_cardinality_nodes(
                     sub_aggregation_blueprint: None,
                     sug_aggregations: sub_aggs.clone(),
                     allowed_term_ids,
+                    is_top_level,
                 });
                 (idx_in_req_data, AggKind::Terms)
             }

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -735,7 +735,7 @@ fn build_nodes(
             // Build the query and evaluator upfront
             let schema = reader.schema();
             let tokenizers = &data.context.tokenizers;
-            let query = filter_req.parse_query(&schema, tokenizers)?;
+            let query = filter_req.parse_query(schema, tokenizers)?;
             let evaluator = crate::aggregation::bucket::DocumentQueryEvaluator::new(
                 query,
                 schema.clone(),

--- a/src/aggregation/agg_limits.rs
+++ b/src/aggregation/agg_limits.rs
@@ -35,6 +35,7 @@ pub struct AggregationLimitsGuard {
     /// Allocated memory with this guard.
     allocated_with_the_guard: u64,
 }
+
 impl Clone for AggregationLimitsGuard {
     fn clone(&self) -> Self {
         Self {
@@ -70,7 +71,7 @@ impl AggregationLimitsGuard {
     /// *memory_limit*
     /// memory_limit is defined in bytes.
     /// Aggregation fails when the estimated memory consumption of the aggregation is higher than
-    /// memory_limit.     
+    /// memory_limit.
     /// memory_limit will default to `DEFAULT_MEMORY_LIMIT` (500MB)
     ///
     /// *bucket_limit*

--- a/src/aggregation/bucket/filter.rs
+++ b/src/aggregation/bucket/filter.rs
@@ -639,16 +639,14 @@ pub struct IntermediateFilterBucketResult {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
     use serde_json::{json, Value};
 
     use super::*;
     use crate::aggregation::agg_req::Aggregations;
     use crate::aggregation::agg_result::AggregationResults;
     use crate::aggregation::{AggContextParams, AggregationCollector};
-    use crate::query::{AllQuery, QueryParser, TermQuery};
-    use crate::schema::{IndexRecordOption, Schema, Term, FAST, INDEXED, STORED, TEXT};
+    use crate::query::{AllQuery, TermQuery};
+    use crate::schema::{IndexRecordOption, Schema, Term, FAST, INDEXED, TEXT};
     use crate::{doc, Index, IndexWriter};
 
     // Test helper functions

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -683,7 +683,7 @@ impl<SubAgg: Debug + Clone + SegmentAggregationCollector + 'static> TermAggregat
             term_id,
             self.buckets.len()
         );
-        &mut self.buckets[term_id_usize as usize]
+        unsafe { self.buckets.get_unchecked_mut(term_id_usize) }
     }
 
     #[inline(always)]

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -787,10 +787,7 @@ where
                 bucket.count += 1;
             }
         } else {
-            let Some(sub_aggregation_blueprint) = req_data
-                .sub_aggregation_blueprint
-                .as_ref()
-                .map(|sub_agg| &**sub_agg)
+            let Some(sub_aggregation_blueprint) = req_data.sub_aggregation_blueprint.as_deref()
             else {
                 return Err(TantivyError::InternalError(
                     "Could not find sub-aggregation blueprint".to_string(),

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -483,6 +483,7 @@ pub(crate) fn build_segment_term_collector(
     //
     // It will create an extra bucket if we don't have such a missing value,
     // but will enable the optimization on more use cases.
+    // TODO: Assign the next free value instead of `u64::MAX` for missing term
     let col_max_value = terms_req_data.accessor.max_value();
     let max_term: usize = col_max_value
         .saturating_add(1u64) // we want saturating here to deal with col max = u64::MAX

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -632,6 +632,13 @@ impl<
     }
 }
 
+/// An optimized term map implementation for a compact set of term ordinals.
+///
+/// When built for `num_terms`, this implementation will accept term ordinals
+/// between `0..num_terms - 2` and u64::MAX.
+///
+/// This is because we shift the term ordinal by wrapping_sub in order to deal
+/// with u64::MAX as it is used as a placeholder for missing terms.
 #[derive(Clone, Debug)]
 struct VecTermBuckets<SubAgg> {
     buckets: Vec<Bucket<SubAgg>>,

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -480,6 +480,7 @@ pub(crate) fn build_segment_term_collector(
 
     // - use a Vec instead of a hashmap for our aggregation.
     // - buffer aggregation of our child aggregations (in any)
+    #[allow(clippy::collapsible_else_if)]
     if can_use_vec && max_term < MAX_NUM_TERMS_FOR_VEC {
         if has_sub_aggregations {
             let sub_agg_blueprint = &req_data

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -3,7 +3,12 @@ use super::segment_agg_result::SegmentAggregationCollector;
 use crate::aggregation::agg_data::AggregationsSegmentCtx;
 use crate::DocId;
 
+#[cfg(test)]
 pub(crate) const DOC_BLOCK_SIZE: usize = 64;
+
+#[cfg(not(test))]
+pub(crate) const DOC_BLOCK_SIZE: usize = 256;
+
 pub(crate) type DocBlock = [DocId; DOC_BLOCK_SIZE];
 
 /// BufAggregationCollector buffers documents before calling collect_block().

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -15,7 +15,7 @@ pub(crate) struct BufAggregationCollector {
 }
 
 impl std::fmt::Debug for BufAggregationCollector {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         f.debug_struct("SegmentAggregationResultsCollector")
             .field("staged_docs", &&self.staged_docs[..self.num_staged_docs])
             .field("num_staged_docs", &self.num_staged_docs)

--- a/src/aggregation/buf_collector.rs
+++ b/src/aggregation/buf_collector.rs
@@ -66,7 +66,6 @@ impl SegmentAggregationCollector for BufAggregationCollector {
         agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         self.collector.collect_block(docs, agg_data)?;
-
         Ok(())
     }
 

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -181,6 +181,7 @@ mod tests_mmap {
         let field_name_out = ".";
         test_json_field_name(field_name_in, field_name_out);
     }
+
     #[test]
     fn test_json_field_dot() {
         // Test when field name contains a '.'

--- a/src/query/term_query/term_query.rs
+++ b/src/query/term_query/term_query.rs
@@ -101,7 +101,7 @@ impl TermQuery {
             EnableScoring::Enabled {
                 statistics_provider,
                 ..
-            } => Bm25Weight::for_terms(statistics_provider, &[self.term.clone()])?,
+            } => Bm25Weight::for_terms(statistics_provider, std::slice::from_ref(&self.term))?,
             EnableScoring::Disabled { .. } => {
                 Bm25Weight::new(Explanation::new("<no score>", 1.0f32), 1.0f32)
             }


### PR DESCRIPTION
This PR refactors the term aggregation, and adds a specialization for top-level low cardinality term aggregation.

For low cardinality terms, we use a Vec instead of a HashMap.
Also, we buffer its subaggregation.

```
full
average_u64                                    Memory: 14.6 KB (-1.40%)     Avg: 6.5158ms (-4.04%)       Median: 6.3642ms (-6.80%)       [6.2729ms .. 9.2047ms]
average_f64                                    Memory: 14.7 KB (+1.43%)     Avg: 6.7132ms (-6.61%)       Median: 6.6603ms (-6.81%)       [6.4731ms .. 7.5090ms]
average_f64_u64                                Memory: 15.5 KB (-3.87%)     Avg: 11.3741ms (-6.17%)      Median: 11.2942ms (-5.83%)      [11.0417ms .. 12.2220ms]
stats_f64                                      Memory: 14.7 KB (+1.43%)     Avg: 6.6910ms (-6.26%)       Median: 6.5546ms (-8.15%)       [6.4561ms .. 7.7337ms]
extendedstats_f64                              Memory: 14.8 KB (+1.42%)     Avg: 6.8366ms (-6.19%)       Median: 6.7776ms (-7.04%)       [6.6215ms .. 7.7942ms]
percentiles_f64                                Memory: 18.6 KB (+2.29%)     Avg: 7.0779ms (-5.25%)       Median: 7.0263ms (-5.52%)       [6.8485ms .. 7.4692ms]
terms_few                                      Memory: 28.3 KB (-0.14%)     Avg: 2.2710ms (-28.48%)      Median: 2.2692ms (-28.35%)      [2.2031ms .. 2.3742ms]
terms_many                                     Memory: 6.9 MB (-0.00%)      Avg: 8.7191ms (-8.14%)       Median: 8.6536ms (-7.70%)       [7.7448ms .. 10.1253ms]
terms_many_top_1000                            Memory: 6.9 MB (-0.00%)      Avg: 10.5071ms (-8.66%)      Median: 10.3833ms (-9.08%)      [9.4739ms .. 11.8208ms]
terms_many_order_by_term                       Memory: 6.9 MB (-0.00%)      Avg: 9.8817ms (-9.59%)       Median: 9.8088ms (-9.64%)       [9.2777ms .. 11.2073ms]
terms_many_with_top_hits                       Memory: 58.4 MB (+0.06%)     Avg: 279.6319ms (-10.70%)    Median: 270.2543ms (-13.80%)    [253.4201ms .. 361.1889ms]
terms_many_with_avg_sub_agg                    Memory: 20.7 MB (+0.18%)     Avg: 42.6150ms (-23.51%)     Median: 41.1625ms (-24.59%)     [39.4524ms .. 59.5105ms]
terms_few_with_avg_sub_agg                     Memory: 38.5 KB              Avg: 7.2512ms (-0.62%)       Median: 7.1766ms (+0.71%)       [6.9613ms .. 7.9199ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 28.1 MB (-6.49%)     Avg: 61.3550ms (-21.47%)     Median: 59.6056ms (-22.67%)     [57.4583ms .. 78.9567ms]
cardinality_agg                                Memory: 3.6 MB (+0.00%)      Avg: 23.8106ms (-1.70%)      Median: 23.6025ms (-1.19%)      [21.6100ms .. 26.2298ms]
terms_few_with_cardinality_agg                 Memory: 10.6 MB (+0.08%)     Avg: 75.2054ms (-24.44%)     Median: 74.9113ms (-23.55%)     [70.2385ms .. 82.0756ms]
range_agg                                      Memory: 16.5 KB (-1.49%)     Avg: 4.0442ms (+2.04%)       Median: 4.0679ms (+3.07%)       [3.8155ms .. 4.2804ms]
range_agg_with_avg_sub_agg                     Memory: 31.2 KB              Avg: 14.9745ms (+0.39%)      Median: 14.9881ms (+1.83%)      [14.3262ms .. 16.9562ms]
range_agg_with_term_agg_few                    Memory: 44.5 KB (-0.07%)     Avg: 25.7781ms (-3.64%)      Median: 25.6100ms (-3.81%)      [24.9738ms .. 27.7147ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.02%)      Avg: 38.4783ms (+1.01%)      Median: 37.2467ms (-0.79%)      [35.3930ms .. 46.0715ms]
histogram                                      Memory: 16.9 KB (-0.11%)     Avg: 4.2242ms (-0.62%)       Median: 4.1772ms (-0.68%)       [4.0673ms .. 4.6024ms]
histogram_hard_bounds                          Memory: 14.9 KB (+1.04%)     Avg: 2.2716ms (-2.87%)       Median: 2.2563ms (-1.66%)       [2.1843ms .. 2.4941ms]
histogram_with_avg_sub_agg                     Memory: 48.5 KB              Avg: 18.0632ms (-0.30%)      Median: 17.8326ms (-0.96%)      [17.6112ms .. 19.3128ms]
histogram_with_term_agg_few                    Memory: 304.4 KB (-1.25%)    Avg: 30.5143ms (-4.18%)      Median: 30.3272ms (-4.48%)      [29.9023ms .. 31.8588ms]
avg_and_range_with_avg_sub_agg                 Memory: 26.1 KB              Avg: 19.4363ms (+0.06%)      Median: 19.2507ms (-0.62%)      [18.8937ms .. 21.1320ms]
filter_agg_all_query_count_agg                 Memory: 142.6 KB (-0.60%)    Avg: 5.9861ms (-0.15%)       Median: 5.8832ms (-0.74%)       [5.7942ms .. 7.4545ms]
filter_agg_term_query_count_agg                Memory: 143.0 KB (+0.02%)    Avg: 9.2758ms (+0.67%)       Median: 9.2511ms (+0.95%)       [9.0213ms .. 9.7857ms]
filter_agg_all_query_with_sub_aggs             Memory: 159.8 KB             Avg: 13.8221ms (+1.27%)      Median: 13.6622ms (+1.03%)      [13.2820ms .. 17.0558ms]
filter_agg_term_query_with_sub_aggs            Memory: 160.2 KB             Avg: 17.0833ms (+1.20%)      Median: 17.0105ms (+0.88%)      [16.5132ms .. 18.1024ms]
dense
average_u64                                    Memory: 15.8 KB (-1.30%)     Avg: 10.2824ms (+1.84%)     Median: 10.2262ms (+1.75%)     [9.8439ms .. 11.3228ms]
average_f64                                    Memory: 15.4 KB (-2.63%)     Avg: 10.5628ms (+2.47%)     Median: 10.3928ms (+1.37%)     [9.9900ms .. 11.8220ms]
average_f64_u64                                Memory: 17.1 KB (+2.49%)     Avg: 18.8446ms (+2.19%)     Median: 18.7020ms (+1.72%)     [18.0854ms .. 20.1288ms]
stats_f64                                      Memory: 15.4 KB (+1.37%)     Avg: 10.5806ms (+2.74%)     Median: 10.5096ms (+2.29%)     [9.9893ms .. 11.3142ms]
extendedstats_f64                              Memory: 15.5 KB              Avg: 10.7276ms (+1.99%)     Median: 10.7054ms (+2.43%)     [10.2027ms .. 11.3977ms]
percentiles_f64                                Memory: 19.1 KB (+2.23%)     Avg: 10.8812ms (+0.42%)     Median: 10.7264ms (-0.42%)     [10.5700ms .. 11.5850ms]
terms_few                                      Memory: 29.4 KB (-0.14%)     Avg: 6.0150ms (-11.30%)     Median: 5.8968ms (-11.16%)     [5.7585ms .. 8.0698ms]
terms_many                                     Memory: 6.9 MB (-0.00%)      Avg: 12.4593ms (+1.79%)     Median: 12.1105ms (+0.98%)     [11.4023ms .. 15.4853ms]
terms_many_top_1000                            Memory: 6.9 MB (-0.00%)      Avg: 14.3325ms (-0.25%)     Median: 13.7460ms (-0.96%)     [13.2009ms .. 17.7954ms]
terms_many_order_by_term                       Memory: 6.9 MB (-0.00%)      Avg: 13.6011ms (-0.15%)     Median: 13.2284ms (-0.01%)     [12.7700ms .. 16.3156ms]
terms_many_with_top_hits                       Memory: 58.4 MB (+0.06%)     Avg: 309.0460ms (-3.63%)    Median: 309.4367ms (-0.61%)    [274.0947ms .. 387.0190ms]
terms_many_with_avg_sub_agg                    Memory: 20.7 MB (+0.18%)     Avg: 55.1350ms (-15.31%)    Median: 53.4676ms (-17.71%)    [49.4205ms .. 65.5432ms]
terms_few_with_avg_sub_agg                     Memory: 42.2 KB (+17.06%)    Avg: 14.5115ms (-1.20%)     Median: 14.4178ms (-0.82%)     [14.1825ms .. 15.8525ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 28.1 MB (-6.49%)     Avg: 71.4524ms (-12.29%)    Median: 67.8077ms (-15.71%)    [64.6211ms .. 102.5806ms]
cardinality_agg                                Memory: 3.6 MB               Avg: 27.4326ms (-0.05%)     Median: 27.2899ms (+0.00%)     [25.6124ms .. 31.2865ms]
terms_few_with_cardinality_agg                 Memory: 10.6 MB (+0.09%)     Avg: 81.3691ms (-23.52%)    Median: 80.6794ms (-23.81%)    [78.5590ms .. 88.4260ms]
range_agg                                      Memory: 16.9 KB (+1.91%)     Avg: 7.7279ms (+1.13%)      Median: 7.6972ms (+2.52%)      [7.4579ms .. 8.1248ms]
range_agg_with_avg_sub_agg                     Memory: 32.0 KB (-0.10%)     Avg: 22.0951ms (+1.03%)     Median: 22.0173ms (+1.11%)     [21.4341ms .. 23.1675ms]
range_agg_with_term_agg_few                    Memory: 45.9 KB (-0.14%)     Avg: 35.7857ms (-1.62%)     Median: 35.5520ms (-1.58%)     [34.6415ms .. 43.5732ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.01%)      Avg: 48.6016ms (+1.58%)     Median: 47.1277ms (+1.26%)     [44.7256ms .. 54.7474ms]
histogram                                      Memory: 16.7 KB (+0.82%)     Avg: 7.9874ms (+1.38%)      Median: 7.9202ms (+1.57%)      [7.7841ms .. 8.7581ms]
histogram_hard_bounds                          Memory: 14.5 KB (-1.26%)     Avg: 6.0652ms (+1.54%)      Median: 5.9772ms (+0.83%)      [5.8658ms .. 6.6921ms]
histogram_with_avg_sub_agg                     Memory: 48.7 KB              Avg: 28.3311ms (+1.18%)     Median: 28.2764ms (+0.97%)     [27.6539ms .. 29.1178ms]
histogram_with_term_agg_few                    Memory: 305.8 KB (-1.24%)    Avg: 40.5798ms (-0.88%)     Median: 40.4289ms (-1.16%)     [39.8728ms .. 43.7941ms]
avg_and_range_with_avg_sub_agg                 Memory: 28.5 KB              Avg: 30.6364ms (+1.50%)     Median: 30.3936ms (+0.99%)     [29.9963ms .. 37.3940ms]
filter_agg_all_query_count_agg                 Memory: 143.8 KB (-0.24%)    Avg: 9.6906ms (+1.16%)      Median: 9.5933ms (+0.62%)      [9.3027ms .. 10.4269ms]
filter_agg_term_query_count_agg                Memory: 144.0 KB             Avg: 13.0812ms (+1.35%)     Median: 12.9291ms (+0.23%)     [12.6822ms .. 14.9795ms]
filter_agg_all_query_with_sub_aggs             Memory: 163.7 KB (-0.02%)    Avg: 24.6678ms (+1.35%)     Median: 24.4367ms (+0.39%)     [24.1814ms .. 26.5033ms]
filter_agg_term_query_with_sub_aggs            Memory: 164.0 KB (-0.02%)    Avg: 27.9083ms (+0.95%)     Median: 27.8039ms (+0.51%)     [27.4973ms .. 29.3377ms]
sparse
average_u64                                    Memory: 15.1 KB (-1.36%)     Avg: 23.5772ms (+2.62%)     Median: 23.5543ms (+3.28%)    [23.3073ms .. 24.1375ms]
average_f64                                    Memory: 15.3 KB (+4.26%)     Avg: 24.4892ms (+6.34%)     Median: 23.6922ms (+3.61%)    [23.2914ms .. 42.6955ms]
average_f64_u64                                Memory: 16.7 KB (+1.26%)     Avg: 43.6129ms (+0.93%)     Median: 43.5639ms (+1.25%)    [42.9062ms .. 45.8412ms]
stats_f64                                      Memory: 15.1 KB (+1.40%)     Avg: 24.0794ms (+4.46%)     Median: 23.5815ms (+3.40%)    [23.3228ms .. 37.9310ms]
extendedstats_f64                              Memory: 15.3 KB (-5.09%)     Avg: 23.6677ms (+1.49%)     Median: 23.5518ms (+3.32%)    [23.3390ms .. 24.7347ms]
percentiles_f64                                Memory: 18.5 KB (+3.51%)     Avg: 22.9287ms (+1.72%)     Median: 22.9357ms (+4.73%)    [22.1961ms .. 26.2312ms]
terms_few                                      Memory: 28.0 KB (-0.14%)     Avg: 22.5726ms (+0.83%)     Median: 22.6594ms (+4.54%)    [21.9269ms .. 23.3897ms]
terms_many                                     Memory: 1.8 MB (-0.00%)      Avg: 24.7305ms (+4.62%)     Median: 24.9414ms (+6.77%)    [23.2923ms .. 26.3649ms]
terms_many_top_1000                            Memory: 2.6 MB               Avg: 25.5773ms (-0.46%)     Median: 25.5322ms (+0.87%)    [24.3181ms .. 27.2698ms]
terms_many_order_by_term                       Memory: 1.8 MB (-0.00%)      Avg: 24.9759ms (+4.86%)     Median: 25.0315ms (+5.95%)    [23.3456ms .. 26.3786ms]
terms_many_with_top_hits                       Memory: 13.2 MB (+0.68%)     Avg: 33.1252ms (-12.47%)    Median: 32.2732ms (-9.07%)    [31.5559ms .. 40.3420ms]
terms_many_with_avg_sub_agg                    Memory: 5.6 MB (+1.63%)      Avg: 28.0326ms (-8.54%)     Median: 27.6666ms (-4.78%)    [27.0909ms .. 31.4655ms]
terms_few_with_avg_sub_agg                     Memory: 40.8 KB (+17.75%)    Avg: 24.7284ms (-3.00%)     Median: 24.6123ms (-2.72%)    [24.3273ms .. 25.9074ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 5.5 MB (+0.61%)      Avg: 40.0608ms (-9.66%)     Median: 39.5689ms (-8.48%)    [38.8052ms .. 45.2527ms]
cardinality_agg                                Memory: 897.2 KB             Avg: 31.7857ms (-3.71%)     Median: 31.2300ms (+0.25%)    [29.7146ms .. 43.5378ms]
terms_few_with_cardinality_agg                 Memory: 690.7 KB (+1.34%)    Avg: 35.0549ms (-9.68%)     Median: 34.8631ms (-6.86%)    [34.1773ms .. 37.2227ms]
range_agg                                      Memory: 16.4 KB (-2.21%)     Avg: 22.2211ms (+1.17%)     Median: 22.1078ms (+2.38%)    [22.0536ms .. 22.8821ms]
range_agg_with_avg_sub_agg                     Memory: 30.9 KB              Avg: 24.7852ms (+0.30%)     Median: 24.6984ms (+0.66%)    [24.5954ms .. 25.7228ms]
range_agg_with_term_agg_few                    Memory: 44.5 KB (-0.07%)     Avg: 25.0560ms (+0.12%)     Median: 24.9547ms (-0.07%)    [24.8592ms .. 25.7923ms]
range_agg_with_term_agg_many                   Memory: 1.8 MB (-0.01%)      Avg: 27.2258ms (-0.62%)     Median: 26.8993ms (-1.10%)    [26.5540ms .. 34.3941ms]
histogram                                      Memory: 15.1 KB (+0.29%)     Avg: 22.1707ms (+0.62%)     Median: 22.0970ms (+2.14%)    [21.9833ms .. 23.0377ms]
histogram_hard_bounds                          Memory: 13.6 KB (+1.30%)     Avg: 22.0034ms (+0.05%)     Median: 21.9393ms (+0.87%)    [21.8182ms .. 22.4937ms]
histogram_with_avg_sub_agg                     Memory: 35.1 KB              Avg: 25.2296ms (-1.66%)     Median: 25.1220ms (-0.16%)    [25.0452ms .. 25.7504ms]
histogram_with_term_agg_few                    Memory: 189.5 KB (-1.20%)    Avg: 25.6811ms (-2.80%)     Median: 25.5974ms (-1.06%)    [25.4663ms .. 26.1751ms]
avg_and_range_with_avg_sub_agg                 Memory: 25.6 KB              Avg: 44.4362ms (-1.95%)     Median: 44.3294ms (-1.21%)    [44.2434ms .. 45.3871ms]
filter_agg_all_query_count_agg                 Memory: 148.6 KB (-0.22%)    Avg: 23.3328ms (+0.31%)     Median: 23.1579ms (+1.14%)    [22.9942ms .. 24.7540ms]
filter_agg_term_query_count_agg                Memory: 149.9 KB (+0.52%)    Avg: 26.8242ms (+2.49%)     Median: 26.5873ms (+2.75%)    [26.3723ms .. 29.7785ms]
filter_agg_all_query_with_sub_aggs             Memory: 165.6 KB (-0.02%)    Avg: 64.2709ms (+5.99%)     Median: 63.6819ms (+5.26%)    [63.1594ms .. 71.7277ms]
filter_agg_term_query_with_sub_aggs            Memory: 166.0 KB (-0.02%)    Avg: 67.2656ms (+5.47%)     Median: 66.9064ms (+5.25%)    [66.5501ms .. 71.8670ms]
multivalue
average_u64                                    Memory: 16.9 KB (+2.54%)     Avg: 14.2355ms (-0.58%)      Median: 14.2573ms (+0.48%)      [13.9547ms .. 14.7580ms]
average_f64                                    Memory: 16.9 KB (+1.25%)     Avg: 14.3863ms (-0.92%)      Median: 14.3807ms (+0.05%)      [14.1200ms .. 14.8202ms]
average_f64_u64                                Memory: 19.2 KB (-1.08%)     Avg: 26.8061ms (-0.68%)      Median: 26.6164ms (-1.04%)      [26.3075ms .. 30.1038ms]
stats_f64                                      Memory: 16.9 KB (+5.19%)     Avg: 14.4047ms (-0.11%)      Median: 14.3842ms (-0.36%)      [14.1060ms .. 15.6139ms]
extendedstats_f64                              Memory: 16.1 KB (-4.90%)     Avg: 14.5900ms (-0.40%)      Median: 14.5428ms (-0.27%)      [14.2821ms .. 15.6837ms]
percentiles_f64                                Memory: 19.0 KB (+1.11%)     Avg: 15.1642ms (-0.92%)      Median: 15.0570ms (-1.29%)      [14.8128ms .. 16.3302ms]
terms_few                                      Memory: 245.3 KB             Avg: 11.7409ms (-6.58%)      Median: 11.3781ms (-8.81%)      [11.1113ms .. 19.3397ms]
terms_many                                     Memory: 6.9 MB (-0.00%)      Avg: 16.5043ms (-5.36%)      Median: 16.2601ms (-6.35%)      [15.5898ms .. 19.1736ms]
terms_many_top_1000                            Memory: 6.9 MB (-0.00%)      Avg: 18.3395ms (-5.11%)      Median: 17.8170ms (-6.56%)      [17.2963ms .. 23.1764ms]
terms_many_order_by_term                       Memory: 6.9 MB (-0.00%)      Avg: 17.4830ms (-5.24%)      Median: 17.2471ms (-6.23%)      [16.6842ms .. 20.9911ms]
terms_many_with_top_hits                       Memory: 58.4 MB (+0.06%)     Avg: 299.5524ms (-12.05%)    Median: 295.3328ms (-12.04%)    [278.9330ms .. 340.1918ms]
terms_many_with_avg_sub_agg                    Memory: 20.7 MB (+0.18%)     Avg: 85.5326ms (-15.55%)     Median: 83.8032ms (-15.38%)     [80.4304ms .. 113.7576ms]
terms_few_with_avg_sub_agg                     Memory: 246.6 KB             Avg: 23.8882ms (-2.90%)      Median: 23.8811ms (-2.78%)      [23.3636ms .. 24.5123ms]
terms_many_json_mixed_type_with_avg_sub_agg    Memory: 28.1 MB (-6.49%)     Avg: 99.8676ms (-17.35%)     Median: 98.6240ms (-15.27%)     [94.7132ms .. 138.5175ms]
cardinality_agg                                Memory: 3.6 MB               Avg: 31.4237ms (-1.60%)      Median: 31.1947ms (-1.21%)      [29.5091ms .. 41.0415ms]
terms_few_with_cardinality_agg                 Memory: 10.8 MB (+0.09%)     Avg: 88.6341ms (-25.38%)     Median: 87.2858ms (-24.97%)     [85.3117ms .. 100.0008ms]
range_agg                                      Memory: 17.2 KB (+3.95%)     Avg: 11.7529ms (-5.52%)      Median: 11.6871ms (-5.80%)      [11.5370ms .. 12.2447ms]
range_agg_with_avg_sub_agg                     Memory: 32.3 KB              Avg: 36.7023ms (-2.94%)      Median: 36.5607ms (-3.40%)      [36.1542ms .. 38.0726ms]
range_agg_with_term_agg_few                    Memory: 248.0 KB             Avg: 45.3791ms (-5.72%)      Median: 45.0613ms (-6.39%)      [44.4940ms .. 48.7406ms]
range_agg_with_term_agg_many                   Memory: 6.9 MB (-0.00%)      Avg: 56.7314ms (-14.16%)     Median: 55.8189ms (-13.96%)     [53.7634ms .. 76.9432ms]
histogram                                      Memory: 17.1 KB (+1.34%)     Avg: 12.1547ms (-4.70%)      Median: 12.0726ms (-4.96%)      [11.8342ms .. 12.9746ms]
histogram_hard_bounds                          Memory: 14.7 KB (-0.04%)     Avg: 10.6226ms (+2.80%)      Median: 10.1821ms (-0.22%)      [9.8987ms .. 21.2534ms]
histogram_with_avg_sub_agg                     Memory: 48.9 KB              Avg: 41.6826ms (+1.50%)      Median: 40.5168ms (-0.27%)      [40.0311ms .. 74.4000ms]
histogram_with_term_agg_few                    Memory: 462.5 KB (-0.82%)    Avg: 50.1087ms (-2.18%)      Median: 49.7395ms (-2.93%)      [48.8107ms .. 58.2050ms]
avg_and_range_with_avg_sub_agg                 Memory: 29.4 KB (+1.99%)     Avg: 49.3215ms (+0.35%)      Median: 49.1051ms (+0.02%)      [48.4769ms .. 51.9608ms]
filter_agg_all_query_count_agg                 Memory: 144.3 KB (-0.22%)    Avg: 13.9264ms (+0.94%)      Median: 13.8397ms (+1.03%)      [13.5216ms .. 14.5005ms]
filter_agg_term_query_count_agg                Memory: 144.7 KB (+0.17%)    Avg: 17.1563ms (+0.91%)      Median: 17.0727ms (+0.50%)      [16.7697ms .. 17.8726ms]
filter_agg_all_query_with_sub_aggs             Memory: 375.0 KB             Avg: 38.9993ms (+1.69%)      Median: 38.6793ms (+1.08%)      [37.7600ms .. 42.0947ms]
filter_agg_term_query_with_sub_aggs            Memory: 375.3 KB             Avg: 42.4957ms (+2.28%)      Median: 41.8713ms (+0.74%)      [40.5394ms .. 52.6956ms]
```