### PR TITLE
docs: add usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ You can also find other bindings on [GitHub](https://github.com/search?q=tantivy
 - [seshat](https://github.com/matrix-org/seshat/): A matrix message database/indexer
 - [tantiny](https://github.com/baygeldin/tantiny): Tiny full-text search for Ruby
 - [lnx](https://github.com/lnx-search/lnx): adaptable, typo tolerant search engine with a REST API
+- [Bichon](https://github.com/rustmailer/bichon): A lightweight, high-performance Rust email archiver with WebUI
 - and [more](https://github.com/search?q=tantivy)!
 
 ### On average, how much faster is Tantivy compared to Lucene?


### PR DESCRIPTION
My project Bichon uses Tantivy to index email metadata, provides multi-dimensional search, and also stores full email bodies in a separate Tantivy index. I hereby request that this project be added to Tantivy’s list of example projects. thanks a lot.