### PR TITLE
Revert "remove unused columnar api (#2742)"

### DIFF
--- a/columnar/benches/bench_access.rs
+++ b/columnar/benches/bench_access.rs
@@ -43,5 +43,26 @@ fn bench_group(mut runner: InputGroup<Column>) {
         }
         black_box(sum);
     });
+    runner.register("access_first_vals", |column| {
+        let mut sum = 0;
+        const BLOCK_SIZE: usize = 32;
+        let mut docs = vec![0; BLOCK_SIZE];
+        let mut buffer = vec![None; BLOCK_SIZE];
+        for i in (0..NUM_DOCS).step_by(BLOCK_SIZE) {
+            // fill docs
+            #[allow(clippy::needless_range_loop)]
+            for idx in 0..BLOCK_SIZE {
+                docs[idx] = idx as u32 + i;
+            }
+
+            column.first_vals(&docs, &mut buffer);
+            for val in buffer.iter() {
+                let Some(val) = val else { continue };
+                sum += *val;
+            }
+        }
+
+        black_box(sum);
+    });
     runner.run();
 }

--- a/columnar/src/column/mod.rs
+++ b/columnar/src/column/mod.rs
@@ -131,6 +131,8 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         self.index.docids_to_rowids(doc_ids, doc_ids_out, row_ids)
     }
 
+    /// Get an iterator over the values for the provided docid.
+    #[inline]
     pub fn values_for_doc(&self, doc_id: DocId) -> impl Iterator<Item = T> + '_ {
         self.index
             .value_row_ids(doc_id)
@@ -156,15 +158,6 @@ impl<T: PartialOrd + Copy + Debug + Send + Sync + 'static> Column<T> {
         // Convert rows to docids
         self.index
             .select_batch_in_place(selected_docid_range.start, doc_ids);
-    }
-
-    /// Fills the output vector with the (possibly multiple values that are associated_with
-    /// `row_id`.
-    ///
-    /// This method clears the `output` vector.
-    pub fn fill_vals(&self, row_id: RowId, output: &mut Vec<T>) {
-        output.clear();
-        output.extend(self.values_for_doc(row_id));
     }
 
     pub fn first_or_default_col(self, default_value: T) -> Arc<dyn ColumnValues<T>> {

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -726,22 +726,22 @@ mod tests {
             .column_opt::<DateTime>("multi_date")
             .unwrap()
             .unwrap();
-        let mut dates = Vec::new();
+
         {
             assert_eq!(date_fast_field.get_val(0).into_timestamp_nanos(), 1i64);
-            dates_fast_field.fill_vals(0u32, &mut dates);
+            let dates: Vec<DateTime> = dates_fast_field.values_for_doc(0u32).collect();
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_nanos(), 2i64);
             assert_eq!(dates[1].into_timestamp_nanos(), 3i64);
         }
         {
             assert_eq!(date_fast_field.get_val(1).into_timestamp_nanos(), 4i64);
-            dates_fast_field.fill_vals(1u32, &mut dates);
+            let dates: Vec<DateTime> = dates_fast_field.values_for_doc(1u32).collect();
             assert!(dates.is_empty());
         }
         {
             assert_eq!(date_fast_field.get_val(2).into_timestamp_nanos(), 0i64);
-            dates_fast_field.fill_vals(2u32, &mut dates);
+            let dates: Vec<DateTime> = dates_fast_field.values_for_doc(2u32).collect();
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_nanos(), 5i64);
             assert_eq!(dates[1].into_timestamp_nanos(), 6i64);

--- a/src/fastfield/mod.rs
+++ b/src/fastfield/mod.rs
@@ -726,24 +726,22 @@ mod tests {
             .column_opt::<DateTime>("multi_date")
             .unwrap()
             .unwrap();
+        let mut dates = Vec::new();
         {
-            let mut dates = Vec::new();
             assert_eq!(date_fast_field.get_val(0).into_timestamp_nanos(), 1i64);
-            dates.extend(dates_fast_field.values_for_doc(0));
+            dates_fast_field.fill_vals(0u32, &mut dates);
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_nanos(), 2i64);
             assert_eq!(dates[1].into_timestamp_nanos(), 3i64);
         }
         {
-            let mut dates = Vec::new();
             assert_eq!(date_fast_field.get_val(1).into_timestamp_nanos(), 4i64);
-            dates.extend(dates_fast_field.values_for_doc(1));
+            dates_fast_field.fill_vals(1u32, &mut dates);
             assert!(dates.is_empty());
         }
         {
-            let mut dates = Vec::new();
             assert_eq!(date_fast_field.get_val(2).into_timestamp_nanos(), 0i64);
-            dates.extend(dates_fast_field.values_for_doc(2));
+            dates_fast_field.fill_vals(2u32, &mut dates);
             assert_eq!(dates.len(), 2);
             assert_eq!(dates[0].into_timestamp_nanos(), 5i64);
             assert_eq!(dates[1].into_timestamp_nanos(), 6i64);

--- a/src/query/range_query/range_query.rs
+++ b/src/query/range_query/range_query.rs
@@ -268,9 +268,7 @@ mod tests {
     use crate::indexer::NoMergePolicy;
     use crate::query::range_query::fast_field_range_doc_set::RangeDocSet;
     use crate::query::range_query::range_query::InvertedIndexRangeQuery;
-    use crate::query::{
-        AllScorer, BitSetDocSet, ConstScorer, EmptyScorer, EnableScoring, Query, QueryParser,
-    };
+    use crate::query::{AllScorer, ConstScorer, EmptyScorer, EnableScoring, Query, QueryParser};
     use crate::schema::{
         Field, IntoIpv6Addr, Schema, TantivyDocument, FAST, INDEXED, STORED, TEXT,
     };


### PR DESCRIPTION
This reverts commit 8725594d477680460a8c281139e8376c37462fe7.