### PR TITLE
Make `Language` hashable

### DIFF
--- a/src/tokenizer/stemmer.rs
+++ b/src/tokenizer/stemmer.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::{Token, TokenFilter, TokenStream, Tokenizer};
 
 /// Available stemmer languages.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Copy, Clone, Hash)]
 #[allow(missing_docs)]
 pub enum Language {
     Arabic,


### PR DESCRIPTION
Make Language hashable, which we required to integrate Tantivy with Postgres.

I am raising this PR as we discussed with Pascal regarding some commits in the ParadeDB fork that would benefit upstream.