### PR TITLE
Use a strict comparison in TopNComputer

### DIFF
--- a/src/collector/sort_key/order.rs
+++ b/src/collector/sort_key/order.rs
@@ -21,9 +21,9 @@ pub trait Comparator<T>: Send + Sync + std::fmt::Debug + Default {
         // TopNComputer sorts in descending order of the SortKey by default: we apply that ordering
         // here to ease comparison in testing.
         self.compare(&rhs.sort_key, &lhs.sort_key).then_with(|| {
-            // In case of a tie on the feature, we always sort by ascending `DocAddress` in order
-            // to ensure a stable sorting of the documents. See the TopNComputer docs for more
-            // information.
+            // In case of a tie on the sort key, we always sort by ascending `DocAddress` in order
+            // to ensure a stable sorting of the documents, regardless of the sort key's order.
+            // See the TopNComputer docs for more information.
             lhs.doc.cmp(&rhs.doc)
         })
     }
@@ -47,8 +47,8 @@ impl<T: PartialOrd> Comparator<T> for NaturalComparator {
 /// first.
 ///
 /// The ReverseComparator does not necessarily imply that the sort order is reversed compared
-/// to the NaturalComparator. In presence of a tie, both version will retain the documents based on
-/// descending `DocId`/`DocAddress`.
+/// to the NaturalComparator. In presence of a tie on the sort key, documents will always be
+/// sorted by ascending `DocId`/`DocAddress` in TopN results, regardless of the comparator.
 #[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 pub struct ReverseComparator;
 

--- a/src/collector/sort_key/order.rs
+++ b/src/collector/sort_key/order.rs
@@ -12,7 +12,7 @@ pub trait Comparator<T>: Send + Sync + std::fmt::Debug + Default {
     fn compare(&self, lhs: &T, rhs: &T) -> Ordering;
     /// Return the order between two ComparableDoc values.
     #[inline(always)]
-    fn compare_doc<D: PartialOrd>(
+    fn compare_doc<D: Ord>(
         &self,
         lhs: &ComparableDoc<T, D>,
         rhs: &ComparableDoc<T, D>,
@@ -21,7 +21,7 @@ pub trait Comparator<T>: Send + Sync + std::fmt::Debug + Default {
             // In case of a tie on the feature, we always sort by descending `DocAddress` in order
             // to ensure a stable sorting of the documents. See the TopNComputer docs for more
             // information.
-            rhs.doc.partial_cmp(&lhs.doc).unwrap_or(Ordering::Equal)
+            rhs.doc.cmp(&lhs.doc)
         })
     }
 }

--- a/src/collector/sort_key/order.rs
+++ b/src/collector/sort_key/order.rs
@@ -44,7 +44,8 @@ impl<T: PartialOrd> Comparator<T> for NaturalComparator {
 /// first.
 ///
 /// The ReverseComparator does not necessarily imply that the sort order is reversed compared
-/// to the NaturalComparator. In presence of a tie, both version will retain the higher doc ids.
+/// to the NaturalComparator. In presence of a tie, both version will retain the documents based on
+/// descending `DocId`/`DocAddress`.
 #[derive(Debug, Copy, Clone, Default, Serialize, Deserialize)]
 pub struct ReverseComparator;
 

--- a/src/collector/sort_key/order.rs
+++ b/src/collector/sort_key/order.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
 
-use crate::collector::{ComparableDoc, SegmentSortKeyComputer, SortKeyComputer};
+use crate::collector::{SegmentSortKeyComputer, SortKeyComputer};
 use crate::schema::Schema;
 use crate::{DocId, Order, Score};
 
@@ -10,23 +10,6 @@ use crate::{DocId, Order, Score};
 pub trait Comparator<T>: Send + Sync + std::fmt::Debug + Default {
     /// Return the order between two values.
     fn compare(&self, lhs: &T, rhs: &T) -> Ordering;
-    /// Return the order between two ComparableDoc values, using the semantics which are
-    /// implemented by TopNComputer.
-    #[inline(always)]
-    fn compare_doc<D: Ord>(
-        &self,
-        lhs: &ComparableDoc<T, D>,
-        rhs: &ComparableDoc<T, D>,
-    ) -> Ordering {
-        // TopNComputer sorts in descending order of the SortKey by default: we apply that ordering
-        // here to ease comparison in testing.
-        self.compare(&rhs.sort_key, &lhs.sort_key).then_with(|| {
-            // In case of a tie on the sort key, we always sort by ascending `DocAddress` in order
-            // to ensure a stable sorting of the documents, regardless of the sort key's order.
-            // See the TopNComputer docs for more information.
-            lhs.doc.cmp(&rhs.doc)
-        })
-    }
 }
 
 /// With the natural comparator, the top k collector will return

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -6,17 +6,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ComparableDoc<T, D> {
     /// The feature of the document. In practice, this is
-    /// is any type that implements `PartialOrd`.
+    /// is a type which can be compared with a `Comparator<T>`.
     pub sort_key: T,
-    /// The document address. In practice, this is any
-    /// type that implements `PartialOrd`, and is guaranteed
-    /// to be unique for each document.
+    /// The document address. In practice, this is either a `DocId` or `DocAddress`.
     pub doc: D,
 }
 
 impl<T: std::fmt::Debug, D: std::fmt::Debug> std::fmt::Debug for ComparableDoc<T, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct(format!("ComparableDoc").as_str())
+        f.debug_struct("ComparableDoc")
             .field("feature", &self.sort_key)
             .field("doc", &self.doc)
             .finish()

--- a/src/collector/top_collector.rs
+++ b/src/collector/top_collector.rs
@@ -1,17 +1,10 @@
-use std::cmp::Ordering;
-
 use serde::{Deserialize, Serialize};
 
 /// Contains a feature (field, score, etc.) of a document along with the document address.
 ///
-/// It guarantees stable sorting: in case of a tie on the feature, the document
-/// address is used.
-///
-/// The REVERSE_ORDER generic parameter controls whether the by-feature order
-/// should be reversed, which is useful for achieving for example largest-first
-/// semantics without having to wrap the feature in a `Reverse`.
-#[derive(Clone, Default, Serialize, Deserialize)]
-pub struct ComparableDoc<T, D, const REVERSE_ORDER: bool = false> {
+/// Used only by TopNComputer, which implements the actual comparison via a `Comparator`.
+#[derive(Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ComparableDoc<T, D> {
     /// The feature of the document. In practice, this is
     /// is any type that implements `PartialOrd`.
     pub sort_key: T,
@@ -20,45 +13,12 @@ pub struct ComparableDoc<T, D, const REVERSE_ORDER: bool = false> {
     /// to be unique for each document.
     pub doc: D,
 }
-impl<T: std::fmt::Debug, D: std::fmt::Debug, const R: bool> std::fmt::Debug
-    for ComparableDoc<T, D, R>
-{
+
+impl<T: std::fmt::Debug, D: std::fmt::Debug> std::fmt::Debug for ComparableDoc<T, D> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct(format!("ComparableDoc<_, _ {R}").as_str())
+        f.debug_struct(format!("ComparableDoc").as_str())
             .field("feature", &self.sort_key)
             .field("doc", &self.doc)
             .finish()
     }
 }
-
-impl<T: PartialOrd, D: PartialOrd, const R: bool> PartialOrd for ComparableDoc<T, D, R> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<T: PartialOrd, D: PartialOrd, const R: bool> Ord for ComparableDoc<T, D, R> {
-    #[inline]
-    fn cmp(&self, other: &Self) -> Ordering {
-        let by_feature = self
-            .sort_key
-            .partial_cmp(&other.sort_key)
-            .map(|ord| if R { ord.reverse() } else { ord })
-            .unwrap_or(Ordering::Equal);
-
-        let lazy_by_doc_address = || self.doc.partial_cmp(&other.doc).unwrap_or(Ordering::Equal);
-
-        // In case of a tie on the feature, we sort by ascending
-        // `DocAddress` in order to ensure a stable sorting of the
-        // documents.
-        by_feature.then_with(lazy_by_doc_address)
-    }
-}
-
-impl<T: PartialOrd, D: PartialOrd, const R: bool> PartialEq for ComparableDoc<T, D, R> {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl<T: PartialOrd, D: PartialOrd, const R: bool> Eq for ComparableDoc<T, D, R> {}

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -25,7 +25,7 @@ use crate::{DocAddress, DocId, Order, Score, SegmentReader};
 ///
 /// This collector guarantees a stable sorting in case of a tie on the
 /// document score/sort key: The document address (`DocAddress`) is used as a tie breaker.
-/// It is always sorted in descending order, regardless of the `Order` used for the sort key.
+/// In case of a tie on the sort key, documents are always sorted by ascending `DocAddress`.
 ///
 /// ```rust
 /// use tantivy::collector::TopDocs;
@@ -499,13 +499,13 @@ where
 ///
 /// For TopN == 0, it will be relative expensive.
 ///
-/// The TopNComputer will tiebreak using `Reverse<D>`:
-/// i.e., the `DocId|DocAddress` are always sorted in descending order, regardless of the
-/// `Comparator` used for the `Score` type.
+/// The TopNComputer will tiebreak by using ascending `D` (DocId or DocAddress):
+/// i.e., in case of a tie on the sort key, the `DocId|DocAddress` are always sorted in
+/// ascending order, regardless of the `Comparator` used for the `Score` type.
 ///
 /// NOTE: Items must be `push`ed to the TopNComputer in ascending `DocId|DocAddress` order, as the
 /// threshold used to eliminate docs does not include the `DocId` or `DocAddress`: this provides
-/// the `Reverse<DocId|DocAddress>` behavior without additional comparisons.
+/// the ascending `DocId|DocAddress` tie-breaking behavior without additional comparisons.
 #[derive(Serialize, Deserialize)]
 #[serde(from = "TopNComputerDeser<Score, D, C>")]
 pub struct TopNComputer<Score, D, C> {

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -23,10 +23,9 @@ use crate::{DocAddress, DocId, Order, Score, SegmentReader};
 /// The theoretical complexity for collecting the top `K` out of `N` documents
 /// is `O(N + K)`.
 ///
-/// This collector does not guarantee a stable sorting in case of a tie on the
-/// document score, for stable sorting `PartialOrd` needs to resolve on other fields
-/// like docid in case of score equality.
-/// Only then, it is suitable for pagination.
+/// This collector guarantees a stable sorting in case of a tie on the
+/// document score/sort key: The document address (`DocAddress`) is used as a tie breaker.
+/// It is always sorted in descending order, regardless of the `Order` used for the sort key.
 ///
 /// ```rust
 /// use tantivy::collector::TopDocs;
@@ -500,10 +499,9 @@ where
 ///
 /// For TopN == 0, it will be relative expensive.
 ///
-/// When using the natural comparator, the top N computer returns the top N elements in
-/// descending order, as expected for a top N. The TopNComputer will tiebreak using `Reverse<D>`:
-/// i.e., the `DocId|DocAddress` are always sorted in descending order, and the `Comparator` type
-/// is only applied to the `Score` type.
+/// The TopNComputer will tiebreak using `Reverse<D>`:
+/// i.e., the `DocId|DocAddress` are always sorted in descending order, regardless of the
+/// `Comparator` used for the `Score` type.
 ///
 /// NOTE: Items must be `push`ed to the TopNComputer in ascending `DocId|DocAddress` order, as the
 /// threshold used to eliminate docs does not include the `DocId` or `DocAddress`: this provides

--- a/src/indexer/delete_queue.rs
+++ b/src/indexer/delete_queue.rs
@@ -23,13 +23,18 @@ struct InnerDeleteQueue {
     last_block: Weak<Block>,
 }
 
+/// The delete queue is a linked list storing delete operations.
+///
+/// Several consumers can hold a reference to it. Delete operations
+/// get dropped/gc'ed when no more consumers are holding a reference
+/// to them.
 #[derive(Clone)]
 pub struct DeleteQueue {
     inner: Arc<RwLock<InnerDeleteQueue>>,
 }
 
 impl DeleteQueue {
-    // Creates a new delete queue.
+    /// Creates a new empty delete queue.
     pub fn new() -> DeleteQueue {
         DeleteQueue {
             inner: Arc::default(),
@@ -58,10 +63,10 @@ impl DeleteQueue {
         block
     }
 
-    // Creates a new cursor that makes it possible to
-    // consume future delete operations.
-    //
-    // Past delete operations are not accessible.
+    /// Creates a new cursor that makes it possible to
+    /// consume future delete operations.
+    ///
+    /// Past delete operations are not accessible.
     pub fn cursor(&self) -> DeleteCursor {
         let last_block = self.get_last_block();
         let operations_len = last_block.operations.len();
@@ -71,7 +76,7 @@ impl DeleteQueue {
         }
     }
 
-    // Appends a new delete operations.
+    /// Appends a new delete operations.
     pub fn push(&self, delete_operation: DeleteOperation) {
         self.inner
             .write()
@@ -169,6 +174,7 @@ struct Block {
     next: NextBlock,
 }
 
+/// As we process delete operations, keeps track of our position.
 #[derive(Clone)]
 pub struct DeleteCursor {
     block: Arc<Block>,

--- a/src/indexer/operation.rs
+++ b/src/indexer/operation.rs
@@ -5,14 +5,20 @@ use crate::Opstamp;
 
 /// Timestamped Delete operation.
 pub struct DeleteOperation {
+    /// Operation stamp.
+    /// It is used to check whether the delete operation
+    /// applies to an added document operation.
     pub opstamp: Opstamp,
+    /// Weight is used to define the set of documents to be deleted.
     pub target: Box<dyn Weight>,
 }
 
 /// Timestamped Add operation.
 #[derive(Eq, PartialEq, Debug)]
 pub struct AddOperation<D: Document = TantivyDocument> {
+    /// Operation stamp.
     pub opstamp: Opstamp,
+    /// Document to be added.
     pub document: D,
 }
 


### PR DESCRIPTION
As discussed in #2775, this change switches (back) to a strict comparison on the threshold in `TopNComputer`.

To do this safely, we document the invariant that documents must be pushed to the `TopNComputer` in ascending `DocId`/`DocAddress` order, and that the output of `TopNComputer` will sort in ascending `DocId`/`DocAddress` order for duplicate `SortKey`s.

Fixes #2775.