### PR TITLE
Lazy loading of the first block of RangeDocSet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,3 +176,7 @@ harness = false
 [[bench]]
 name = "and_or_queries"
 harness = false
+
+[[bench]]
+name = "bool_queries"
+harness = false

--- a/benches/bool_queries.rs
+++ b/benches/bool_queries.rs
@@ -1,0 +1,320 @@
+use binggan::{black_box, BenchGroup, BenchRunner};
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use tantivy::collector::{Collector, Count, DocSetCollector, TopDocs};
+use tantivy::query::{Query, QueryParser};
+use tantivy::schema::{Schema, FAST, INDEXED, TEXT};
+use tantivy::{doc, Index, Order, ReloadPolicy, Searcher};
+
+#[derive(Clone)]
+struct BenchIndex {
+    #[allow(dead_code)]
+    index: Index,
+    searcher: Searcher,
+    query_parser: QueryParser,
+}
+
+fn build_shared_indices(num_docs: usize, p_title_a: f32, distribution: &str) -> BenchIndex {
+    // Unified schema
+    let mut schema_builder = Schema::builder();
+    let f_title = schema_builder.add_text_field("title", TEXT);
+    let f_num_rand = schema_builder.add_u64_field("num_rand", INDEXED);
+    let f_num_asc = schema_builder.add_u64_field("num_asc", INDEXED);
+    let f_num_rand_fast = schema_builder.add_u64_field("num_rand_fast", INDEXED | FAST);
+    let f_num_asc_fast = schema_builder.add_u64_field("num_asc_fast", INDEXED | FAST);
+    let schema = schema_builder.build();
+    let index = Index::create_in_ram(schema.clone());
+
+    // Populate index with stable RNG for reproducibility.
+    let mut rng = StdRng::from_seed([7u8; 32]);
+
+    {
+        let mut writer = index.writer_with_num_threads(1, 4_000_000_000).unwrap();
+
+        match distribution {
+            "dense" => {
+                for doc_id in 0..num_docs {
+                    // Always add title to avoid empty documents
+                    let title_token = if rng.gen_bool(p_title_a as f64) {
+                        "a"
+                    } else {
+                        "b"
+                    };
+
+                    let num_rand = rng.gen_range(0u64..1000u64);
+
+                    let num_asc = (doc_id / 10000) as u64;
+
+                    writer
+                        .add_document(doc!(
+                            f_title=>title_token,
+                            f_num_rand=>num_rand,
+                            f_num_asc=>num_asc,
+                            f_num_rand_fast=>num_rand,
+                            f_num_asc_fast=>num_asc,
+                        ))
+                        .unwrap();
+                }
+            }
+            "sparse" => {
+                for doc_id in 0..num_docs {
+                    // Always add title to avoid empty documents
+                    let title_token = if rng.gen_bool(p_title_a as f64) {
+                        "a"
+                    } else {
+                        "b"
+                    };
+
+                    let num_rand = rng.gen_range(0u64..10000000u64);
+
+                    let num_asc = doc_id as u64;
+
+                    writer
+                        .add_document(doc!(
+                            f_title=>title_token,
+                            f_num_rand=>num_rand,
+                            f_num_asc=>num_asc,
+                            f_num_rand_fast=>num_rand,
+                            f_num_asc_fast=>num_asc,
+                        ))
+                        .unwrap();
+                }
+            }
+            _ => {
+                panic!("Unsupported distribution type");
+            }
+        }
+        writer.commit().unwrap();
+    }
+
+    // Prepare reader/searcher once.
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()
+        .unwrap();
+    let searcher = reader.searcher();
+
+    // Build query parser for title field
+    let qp_title = QueryParser::for_index(&index, vec![f_title]);
+
+    BenchIndex {
+        index,
+        searcher,
+        query_parser: qp_title,
+    }
+}
+
+fn main() {
+    // Prepare corpora with varying scenarios
+    let scenarios = vec![
+        (
+            "dense and 99% a".to_string(),
+            10_000_000,
+            0.99,
+            "dense",
+            0,
+            9,
+        ),
+        (
+            "dense and 99% a".to_string(),
+            10_000_000,
+            0.99,
+            "dense",
+            990,
+            999,
+        ),
+        (
+            "sparse and 99% a".to_string(),
+            10_000_000,
+            0.99,
+            "sparse",
+            0,
+            9,
+        ),
+        (
+            "sparse and 99% a".to_string(),
+            10_000_000,
+            0.99,
+            "sparse",
+            9_999_990,
+            9_999_999,
+        ),
+        (
+            "dense and 99.999% a".to_string(),
+            10_000_000,
+            0.99999,
+            "dense",
+            0,
+            9,
+        ),
+        (
+            "dense and 99.999% a".to_string(),
+            10_000_000,
+            0.99999,
+            "dense",
+            990,
+            999,
+        ),
+        (
+            "sparse and 99.999% a".to_string(),
+            10_000_000,
+            0.99999,
+            "sparse",
+            0,
+            9,
+        ),
+        (
+            "sparse and 99.999% a".to_string(),
+            10_000_000,
+            0.99999,
+            "sparse",
+            9_999_990,
+            9_999_999,
+        ),
+    ];
+
+    let mut runner = BenchRunner::new();
+    for (scenario_id, n, p_title_a, num_rand_distribution, range_low, range_high) in scenarios {
+        // Build index for this scenario
+        let bench_index = build_shared_indices(n, p_title_a, num_rand_distribution);
+
+        // Create benchmark group
+        let mut group = runner.new_group();
+
+        // Now set the name (this moves scenario_id)
+        group.set_name(scenario_id);
+
+        // Define all four field types
+        let field_names = ["num_rand", "num_asc", "num_rand_fast", "num_asc_fast"];
+
+        // Define the three terms we want to test with
+        let terms = ["a", "b", "z"];
+
+        // Generate all combinations of terms and field names
+        let mut queries = Vec::new();
+        for &term in &terms {
+            for &field_name in &field_names {
+                let query_str = format!(
+                    "{} AND {}:[{} TO {}]",
+                    term, field_name, range_low, range_high
+                );
+                queries.push((query_str, field_name.to_string()));
+            }
+        }
+
+        let query_str = format!(
+            "{}:[{} TO {}] AND {}:[{} TO {}]",
+            "num_rand_fast", range_low, range_high, "num_asc_fast", range_low, range_high
+        );
+        queries.push((query_str, "num_asc_fast".to_string()));
+
+        // Run all benchmark tasks for each query and its corresponding field name
+        for (query_str, field_name) in queries {
+            run_benchmark_tasks(&mut group, &bench_index, &query_str, &field_name);
+        }
+
+        group.run();
+    }
+}
+
+/// Run all benchmark tasks for a given query string and field name
+fn run_benchmark_tasks(
+    bench_group: &mut BenchGroup,
+    bench_index: &BenchIndex,
+    query_str: &str,
+    field_name: &str,
+) {
+    // Test count
+    add_bench_task(bench_group, bench_index, query_str, Count, "count");
+
+    // Test all results
+    add_bench_task(
+        bench_group,
+        bench_index,
+        query_str,
+        DocSetCollector,
+        "all results",
+    );
+
+    // Test top 100 by the field (if it's a FAST field)
+    if field_name.ends_with("_fast") {
+        // Ascending order
+        {
+            let collector_name = format!("top100_by_{}_asc", field_name);
+            let field_name_owned = field_name.to_string();
+            add_bench_task(
+                bench_group,
+                bench_index,
+                query_str,
+                TopDocs::with_limit(100).order_by_fast_field::<u64>(field_name_owned, Order::Asc),
+                &collector_name,
+            );
+        }
+
+        // Descending order
+        {
+            let collector_name = format!("top100_by_{}_desc", field_name);
+            let field_name_owned = field_name.to_string();
+            add_bench_task(
+                bench_group,
+                bench_index,
+                query_str,
+                TopDocs::with_limit(100).order_by_fast_field::<u64>(field_name_owned, Order::Desc),
+                &collector_name,
+            );
+        }
+    }
+}
+
+fn add_bench_task<C: Collector + 'static>(
+    bench_group: &mut BenchGroup,
+    bench_index: &BenchIndex,
+    query_str: &str,
+    collector: C,
+    collector_name: &str,
+) {
+    let task_name = format!("{}_{}", query_str.replace(" ", "_"), collector_name);
+    let query = bench_index.query_parser.parse_query(query_str).unwrap();
+    let search_task = SearchTask {
+        searcher: bench_index.searcher.clone(),
+        collector,
+        query,
+    };
+    bench_group.register(task_name, move |_| black_box(search_task.run()));
+}
+
+struct SearchTask<C: Collector> {
+    searcher: Searcher,
+    collector: C,
+    query: Box<dyn Query>,
+}
+
+impl<C: Collector> SearchTask<C> {
+    #[inline(never)]
+    pub fn run(&self) -> usize {
+        let result = self.searcher.search(&self.query, &self.collector).unwrap();
+        if let Some(count) = (&result as &dyn std::any::Any).downcast_ref::<usize>() {
+            *count
+        } else if let Some(top_docs) = (&result as &dyn std::any::Any)
+            .downcast_ref::<Vec<(Option<u64>, tantivy::DocAddress)>>()
+        {
+            top_docs.len()
+        } else if let Some(top_docs) =
+            (&result as &dyn std::any::Any).downcast_ref::<Vec<(u64, tantivy::DocAddress)>>()
+        {
+            top_docs.len()
+        } else if let Some(doc_set) = (&result as &dyn std::any::Any)
+            .downcast_ref::<std::collections::HashSet<tantivy::DocAddress>>()
+        {
+            doc_set.len()
+        } else {
+            eprintln!(
+                "Unknown collector result type: {:?}",
+                std::any::type_name::<C::Fruit>()
+            );
+            0
+        }
+    }
+}

--- a/src/docset.rs
+++ b/src/docset.rs
@@ -98,6 +98,11 @@ pub trait DocSet: Send {
         self.size_hint() as u64
     }
 
+    /// Returns whether the docset is a range docset.
+    fn is_range(&self) -> bool {
+        false
+    }
+
     /// Returns the number documents matching.
     /// Calling this method consumes the `DocSet`.
     fn count(&mut self, alive_bitset: &AliveBitSet) -> u32 {
@@ -149,6 +154,10 @@ impl DocSet for &mut dyn DocSet {
         (**self).cost()
     }
 
+    fn is_range(&self) -> bool {
+        (**self).is_range()
+    }
+
     fn count(&mut self, alive_bitset: &AliveBitSet) -> u32 {
         (**self).count(alive_bitset)
     }
@@ -187,6 +196,11 @@ impl<TDocSet: DocSet + ?Sized> DocSet for Box<TDocSet> {
     fn cost(&self) -> u64 {
         let unboxed: &TDocSet = self.borrow();
         unboxed.cost()
+    }
+
+    fn is_range(&self) -> bool {
+        let unboxed: &TDocSet = self.borrow();
+        unboxed.is_range()
     }
 
     fn count(&mut self, alive_bitset: &AliveBitSet) -> u32 {

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -127,6 +127,10 @@ impl<TDocSet: DocSet> DocSet for ConstScorer<TDocSet> {
         self.docset.doc()
     }
 
+    fn is_range(&self) -> bool {
+        self.docset.is_range()
+    }
+
     fn size_hint(&self) -> u32 {
         self.docset.size_hint()
     }

--- a/src/query/range_query/fast_field_range_doc_set.rs
+++ b/src/query/range_query/fast_field_range_doc_set.rs
@@ -1,9 +1,10 @@
 use core::fmt::Debug;
+use std::cell::RefCell;
 use std::ops::RangeInclusive;
 
 use columnar::Column;
 
-use crate::{DocId, DocSet, TERMINATED};
+use crate::{DocId, DocSet, COLLECT_BLOCK_BUFFER_LEN, TERMINATED};
 
 /// Helper to have a cursor over a vec of docids
 #[derive(Debug)]
@@ -11,6 +12,7 @@ struct VecCursor {
     docs: Vec<u32>,
     current_pos: usize,
 }
+
 impl VecCursor {
     fn new() -> Self {
         Self {
@@ -18,83 +20,87 @@ impl VecCursor {
             current_pos: 0,
         }
     }
+
     fn next(&mut self) -> Option<u32> {
         self.current_pos += 1;
         self.current()
     }
+
     #[inline]
     fn current(&self) -> Option<u32> {
         self.docs.get(self.current_pos).copied()
     }
+
     fn get_cleared_data(&mut self) -> &mut Vec<u32> {
         self.docs.clear();
         self.current_pos = 0;
         &mut self.docs
     }
+
     fn last_doc(&self) -> Option<u32> {
         self.docs.last().cloned()
     }
+
     fn is_empty(&self) -> bool {
         self.current().is_none()
     }
 }
 
-pub(crate) struct RangeDocSet<T> {
-    /// The range filter on the values.
-    value_range: RangeInclusive<T>,
-    column: Column<T>,
+#[derive(Debug)]
+struct RangeDocSetInner {
     /// The next docid start range to fetch (inclusive).
     next_fetch_start: u32,
     /// Number of docs range checked in a batch.
-    ///
-    /// There are two patterns.
-    /// - We do a full scan. => We can load large chunks. We don't know in advance if seek call
-    ///   will come, so we start with small chunks
-    /// - We load docs, interspersed with seek calls. When there are big jumps in the seek, we
-    ///   should load small chunks. When the seeks are small, we can employ the same strategy as on
-    ///   a full scan.
     fetch_horizon: u32,
     /// Current batch of loaded docs.
     loaded_docs: VecCursor,
     last_seek_pos_opt: Option<u32>,
 }
 
+pub(crate) struct RangeDocSet<T> {
+    /// The range filter on the values.
+    value_range: RangeInclusive<T>,
+    column: Column<T>,
+    /// Inner fields that need mutable access even in immutable methods
+    inner: RefCell<RangeDocSetInner>,
+}
+
 const DEFAULT_FETCH_HORIZON: u32 = 128;
+
 impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> RangeDocSet<T> {
     pub(crate) fn new(value_range: RangeInclusive<T>, column: Column<T>) -> Self {
-        let mut range_docset = Self {
+        Self {
             value_range,
             column,
-            loaded_docs: VecCursor::new(),
-            next_fetch_start: 0,
-            fetch_horizon: DEFAULT_FETCH_HORIZON,
-            last_seek_pos_opt: None,
-        };
-        range_docset.reset_fetch_range();
-        range_docset.fetch_block();
-        range_docset
+            inner: RefCell::new(RangeDocSetInner {
+                next_fetch_start: 0,
+                fetch_horizon: DEFAULT_FETCH_HORIZON,
+                loaded_docs: VecCursor::new(),
+                last_seek_pos_opt: None,
+            }),
+        }
     }
 
-    fn reset_fetch_range(&mut self) {
-        self.fetch_horizon = DEFAULT_FETCH_HORIZON;
+    fn reset_fetch_range(&self, inner: &mut RangeDocSetInner) {
+        inner.fetch_horizon = DEFAULT_FETCH_HORIZON;
     }
 
     /// Returns true if more data could be fetched
-    fn fetch_block(&mut self) {
+    fn fetch_block(&self, inner: &mut RangeDocSetInner) {
         const MAX_HORIZON: u32 = 100_000;
-        while self.loaded_docs.is_empty() {
-            let finished_to_end = self.fetch_horizon(self.fetch_horizon);
+        while inner.loaded_docs.is_empty() {
+            let finished_to_end = self.fetch_horizon(inner, inner.fetch_horizon);
             if finished_to_end {
                 break;
             }
             // Fetch more data, increase horizon. Horizon only gets reset when doing a seek.
-            self.fetch_horizon = (self.fetch_horizon * 2).min(MAX_HORIZON);
+            inner.fetch_horizon = (inner.fetch_horizon * 2).min(MAX_HORIZON);
         }
     }
 
     /// check if the distance between the seek calls is large
-    fn is_last_seek_distance_large(&self, new_seek: DocId) -> bool {
-        if let Some(last_seek_pos) = self.last_seek_pos_opt {
+    fn is_last_seek_distance_large(&self, inner: &RangeDocSetInner, new_seek: DocId) -> bool {
+        if let Some(last_seek_pos) = inner.last_seek_pos_opt {
             (new_seek - last_seek_pos) >= 128
         } else {
             true
@@ -102,29 +108,29 @@ impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> RangeDocSet<T> {
     }
 
     /// Fetches a block for docid range [next_fetch_start .. next_fetch_start + HORIZON]
-    fn fetch_horizon(&mut self, horizon: u32) -> bool {
+    fn fetch_horizon(&self, inner: &mut RangeDocSetInner, horizon: u32) -> bool {
         let mut finished_to_end = false;
 
         let limit = self.column.num_docs();
-        let mut end = self.next_fetch_start + horizon;
+        let mut end = inner.next_fetch_start + horizon;
         if end >= limit {
             end = limit;
             finished_to_end = true;
         }
 
-        let last_doc = self.loaded_docs.last_doc();
-        let doc_buffer: &mut Vec<DocId> = self.loaded_docs.get_cleared_data();
+        let last_doc = inner.loaded_docs.last_doc();
+        let doc_buffer: &mut Vec<DocId> = inner.loaded_docs.get_cleared_data();
         self.column.get_docids_for_value_range(
             self.value_range.clone(),
-            self.next_fetch_start..end,
+            inner.next_fetch_start..end,
             doc_buffer,
         );
         if let Some(last_doc) = last_doc {
-            while self.loaded_docs.current() == Some(last_doc) {
-                self.loaded_docs.next();
+            while inner.loaded_docs.current() == Some(last_doc) {
+                inner.loaded_docs.next();
             }
         }
-        self.next_fetch_start = end;
+        inner.next_fetch_start = end;
 
         finished_to_end
     }
@@ -133,19 +139,30 @@ impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> RangeDocSet<T> {
 impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> DocSet for RangeDocSet<T> {
     #[inline]
     fn advance(&mut self) -> DocId {
-        if let Some(docid) = self.loaded_docs.next() {
+        let mut inner = self.inner.borrow_mut();
+        if inner.next_fetch_start == 0 {
+            // Lazy loading of the first block of docs.
+            self.fetch_block(&mut inner);
+        }
+
+        if let Some(docid) = inner.loaded_docs.next() {
             return docid;
         }
-        if self.next_fetch_start >= self.column.num_docs() {
+        if inner.next_fetch_start >= self.column.num_docs() {
             return TERMINATED;
         }
-        self.fetch_block();
-        self.loaded_docs.current().unwrap_or(TERMINATED)
+        self.fetch_block(&mut inner);
+        inner.loaded_docs.current().unwrap_or(TERMINATED)
     }
 
     #[inline]
     fn doc(&self) -> DocId {
-        self.loaded_docs.current().unwrap_or(TERMINATED)
+        let mut inner = self.inner.borrow_mut();
+        if inner.next_fetch_start == 0 {
+            // Lazy loading of the first block of docs.
+            self.fetch_block(&mut inner);
+        }
+        inner.loaded_docs.current().unwrap_or(TERMINATED)
     }
 
     /// Advances the `DocSet` forward until reaching the target, or going to the
@@ -158,18 +175,40 @@ impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> DocSet for RangeDocSe
     ///
     /// Calling `seek(TERMINATED)` is also legal and is the normal way to consume a `DocSet`.
     fn seek(&mut self, target: DocId) -> DocId {
-        if self.is_last_seek_distance_large(target) {
-            self.reset_fetch_range();
+        let mut inner = self.inner.borrow_mut();
+
+        if target == TERMINATED {
+            // Clear the loaded docs to ensure other methods work correctly.
+            inner.loaded_docs.get_cleared_data();
+            inner.next_fetch_start = target;
+            return TERMINATED;
         }
-        if target > self.next_fetch_start {
-            self.next_fetch_start = target;
+        if inner.next_fetch_start == 0 {
+            inner.next_fetch_start = target;
+            // Lazy loading of the first block of docs.
+            self.fetch_block(&mut inner);
         }
-        let mut doc = self.doc();
-        debug_assert!(doc <= target);
+
+        if self.is_last_seek_distance_large(&inner, target) {
+            self.reset_fetch_range(&mut inner);
+        }
+        if target > inner.next_fetch_start {
+            inner.next_fetch_start = target;
+        }
+
+        let mut doc = inner.loaded_docs.current().unwrap_or(TERMINATED);
         while doc < target {
-            doc = self.advance();
+            // Copy from advance()
+            if let Some(docid) = inner.loaded_docs.next() {
+                doc = docid;
+            } else if inner.next_fetch_start >= self.column.num_docs() {
+                doc = TERMINATED;
+            } else {
+                self.fetch_block(&mut inner);
+                doc = inner.loaded_docs.current().unwrap_or(TERMINATED);
+            }
         }
-        self.last_seek_pos_opt = Some(target);
+        inner.last_seek_pos_opt = Some(target);
         doc
     }
 
@@ -183,6 +222,37 @@ impl<T: Send + Sync + PartialOrd + Copy + Debug + 'static> DocSet for RangeDocSe
         // Advancing the docset is relatively expensive since it scans the column.
         // Keep cost relative to a term query driver; use num_docs as baseline.
         self.column.num_docs() as u64
+    }
+
+    fn is_range(&self) -> bool {
+        true
+    }
+
+    fn fill_buffer(&mut self, buffer: &mut [DocId; COLLECT_BLOCK_BUFFER_LEN]) -> usize {
+        let mut inner = self.inner.borrow_mut();
+        if inner.next_fetch_start == 0 {
+            // Lazy loading of the first block of docs.
+            self.fetch_block(&mut inner);
+        }
+        let mut doc = inner.loaded_docs.current().unwrap_or(TERMINATED);
+        if doc == TERMINATED {
+            return 0;
+        }
+        for (i, buffer_val) in buffer.iter_mut().enumerate() {
+            *buffer_val = doc;
+            if let Some(next_doc) = inner.loaded_docs.next() {
+                doc = next_doc;
+            } else if inner.next_fetch_start >= self.column.num_docs() {
+                return i + 1;
+            } else {
+                self.fetch_block(&mut inner);
+                doc = inner.loaded_docs.current().unwrap_or(TERMINATED);
+                if doc == TERMINATED {
+                    return i + 1;
+                }
+            }
+        }
+        buffer.len()
     }
 }
 


### PR DESCRIPTION
### Optimization for RangeDocSet's Initialization Overhead

**Problem Statement**
The `new` method of `RangeDocSet` always attempts to load at least one `doc id` that meets the range criteria. However, when computing the intersection between another `DocSet` and a `RangeDocSet`, if the other `DocSet` is empty or its first `doc id` has a relatively large value, the significant overhead incurred by the `fetch_block` method called in `RangeDocSet`'s `new` method is completely wasted.

As observed from the newly added `bool_queries` benchmark: in the worst-case scenario, `fetch_block` processing 10 million entries takes about 15 milliseconds — an overhead that is entirely avoidable.

**Optimization Solutions**
1. Removed the invocation of `fetch_block` from the `new` method of `RangeDocSet`, and instead triggers `fetch_block` **on-demand** in other methods of `RangeDocSet`.
2. Modified the `go_to_first_doc` method: it now only performs a `seek` operation on the `Scorer` of `RangeDocSet`, instead of calling the `doc` method immediately upon initialization.

before optimization (compare with after):
<img width="3092" height="282" alt="image" src="https://github.com/user-attachments/assets/cccc6474-835e-48a0-a524-768ffb232244" />

after optimization (compare with before):
<img width="3002" height="276" alt="image" src="https://github.com/user-attachments/assets/93c11651-405e-4ec8-ba84-44d281dc0321" />
