### PR TITLE
feat: Add support for Exists leaf in query parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,10 @@ mod macros;
 mod future_result;
 
 // Re-exports
+pub use columnar;
 pub use common::{ByteCount, DateTime};
-pub use {columnar, query_grammar, time};
+pub use query_grammar;
+pub use time;
 
 pub use crate::error::TantivyError;
 pub use crate::future_result::FutureResult;

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -162,7 +162,7 @@ impl fmt::Debug for LogicalLiteral {
                 ref pattern,
                 ref field,
             } => write!(formatter, "Regex({field:?}, {pattern:?})"),
-            LogicalLiteral::Exists { ref field } => write!(formatter, "exists:{field}"),
+            LogicalLiteral::Exists { ref field } => write!(formatter, "Exists({field})"),
         }
     }
 }

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -28,6 +28,9 @@ pub enum LogicalLiteral {
         pattern: Arc<Regex>,
         field: Field,
     },
+    Exists {
+        field: String,
+    },
 }
 
 pub enum LogicalAst {
@@ -159,6 +162,7 @@ impl fmt::Debug for LogicalLiteral {
                 ref pattern,
                 ref field,
             } => write!(formatter, "Regex({field:?}, {pattern:?})"),
+            LogicalLiteral::Exists { ref field } => write!(formatter, "exists:{field}"),
         }
     }
 }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -2113,6 +2113,6 @@ mod test {
 
     #[test]
     pub fn test_exists() {
-        test_parse_query_to_logical_ast_helper("title:*", "exists:title", false);
+        test_parse_query_to_logical_ast_helper("title:*", "Exists(title)", false);
     }
 }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -16,8 +16,8 @@ use crate::index::Index;
 use crate::json_utils::convert_to_fast_value_and_append_to_json_term;
 use crate::query::range_query::{is_type_valid_for_fastfield_range_query, RangeQuery};
 use crate::query::{
-    AllQuery, BooleanQuery, BoostQuery, EmptyQuery, FuzzyTermQuery, Occur, PhrasePrefixQuery,
-    PhraseQuery, Query, RegexQuery, TermQuery, TermSetQuery,
+    AllQuery, BooleanQuery, BoostQuery, EmptyQuery, ExistsQuery, FuzzyTermQuery, Occur,
+    PhrasePrefixQuery, PhraseQuery, Query, RegexQuery, TermQuery, TermSetQuery,
 };
 use crate::schema::{
     Facet, FacetParseError, Field, FieldType, IndexRecordOption, IntoIpv6Addr, JsonObjectOptions,
@@ -856,11 +856,9 @@ impl QueryParser {
                 let logical_ast = LogicalAst::Leaf(Box::new(LogicalLiteral::Set { elements }));
                 (Some(logical_ast), errors)
             }
-            UserInputLeaf::Exists { .. } => (
-                None,
-                vec![QueryParserError::UnsupportedQuery(
-                    "Range query need to target a specific field.".to_string(),
-                )],
+            UserInputLeaf::Exists { field } => (
+                Some(LogicalAst::Leaf(Box::new(LogicalLiteral::Exists { field }))),
+                Vec::new(),
             ),
             UserInputLeaf::Regex { field, pattern } => {
                 if !self.regexes_allowed {
@@ -952,6 +950,7 @@ fn convert_literal_to_query(
         LogicalLiteral::Regex { pattern, field } => {
             Box::new(RegexQuery::from_regex(pattern, field))
         }
+        LogicalLiteral::Exists { field } => Box::new(ExistsQuery::new(field, true)),
     }
 }
 
@@ -2110,5 +2109,10 @@ mod test {
             err.to_string(),
             "Unsupported query: Regex queries are not allowed."
         );
+    }
+
+    #[test]
+    pub fn test_exists() {
+        test_parse_query_to_logical_ast_helper("title:*", "exists:title", false);
     }
 }

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -181,6 +181,10 @@ fn trim_ast(logical_ast: LogicalAst) -> Option<LogicalAst> {
 ///   `"2002-10-02T15:00:00.05Z"` or `some_date_field:[2002-10-02T15:00:00Z TO
 ///   2002-10-02T18:00:00Z}`
 ///
+/// * exists query: `field:*` will match documents that contain a non-null value in the specified
+///   field. The field must be configured as a fast field. For JSON fields, values in subpaths also
+///   count as existing.
+///
 /// * all docs query: A plain `*` will match all documents in the index.
 ///
 /// Parts of the queries can be boosted by appending `^boostfactor`.

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -1088,6 +1088,7 @@ mod test {
 
     use super::super::logical_ast::*;
     use super::{QueryParser, QueryParserError};
+    use crate::collector::Count;
     use crate::query::Query;
     use crate::schema::{
         FacetOptions, Field, IndexRecordOption, Schema, Term, TextFieldIndexing, TextOptions, FAST,
@@ -2118,5 +2119,53 @@ mod test {
     #[test]
     pub fn test_exists() {
         test_parse_query_to_logical_ast_helper("title:*", "Exists(title)", false);
+    }
+
+    #[test]
+    fn test_exists_query_with_documents() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let fast = schema_builder.add_u64_field("fast", FAST);
+        let json = schema_builder.add_json_field("json", TEXT | FAST);
+        let not_fast = schema_builder.add_text_field("not_fast", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.add_document(doc!(
+            fast => 1u64,
+            json => json!({"nested": {"value": true}}),
+            not_fast => "present",
+        ))?;
+        index_writer.add_document(doc!(json => json!({"other": 2u64})))?;
+        index_writer.add_document(doc!(json => json!({"nested": null})))?;
+        index_writer.add_document(doc!())?;
+        index_writer.commit()?;
+
+        let query_parser = QueryParser::for_index(&index, Vec::new());
+        let searcher = index.reader()?.searcher();
+
+        let fast_exists = query_parser.parse_query("fast:*")?;
+        assert_eq!(searcher.search(&*fast_exists, &Count)?, 1);
+
+        // JSON exists queries include non-null values in subpaths. The document containing only a
+        // null value and the empty document do not match.
+        let json_exists = query_parser.parse_query("json:*")?;
+        assert_eq!(searcher.search(&*json_exists, &Count)?, 2);
+        let nested_exists = query_parser.parse_query("json.nested:*")?;
+        assert_eq!(searcher.search(&*nested_exists, &Count)?, 1);
+
+        let fast_does_not_exist = query_parser.parse_query("* NOT fast:*")?;
+        assert_eq!(searcher.search(&*fast_does_not_exist, &Count)?, 3);
+
+        let not_fast_exists = query_parser.parse_query("not_fast:*")?;
+        assert_eq!(
+            searcher
+                .search(&*not_fast_exists, &Count)
+                .unwrap_err()
+                .to_string(),
+            "Schema error: 'Field not_fast is not a fast field.'"
+        );
+
+        Ok(())
     }
 }


### PR DESCRIPTION
A while ago the Exists syntax was added to the query grammar: #2170.
It was never added to the query parser and this PR aims to implement this part.