### PR TITLE
fix(aggs): top_hits panics with unknown fields

### DIFF
--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -677,7 +677,7 @@ fn build_nodes(
         }
         AggregationVariants::TopHits(top_hits_req) => {
             let mut top_hits = top_hits_req.clone();
-            top_hits.validate_and_resolve_field_names(reader.fast_fields().columnar())?;
+            top_hits.validate_and_resolve_field_names(reader.fast_fields())?;
             let accessors: Vec<(Column<u64>, ColumnType)> = top_hits
                 .field_names()
                 .iter()

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -115,13 +115,17 @@ impl TopHitsAggReqData {
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct TopHitsAggregationReq {
-    sort: Vec<KeyOrder>,
-    size: usize,
-    from: Option<usize>,
+    /// The sort criteria to determine the top hits.
+    pub sort: Vec<KeyOrder>,
+    /// The number of top hits to return.
+    pub size: usize,
+    /// The number of top hits to skip.
+    pub from: Option<usize>,
 
+    /// The list of fast fields to retrieve for each document.
     #[serde(rename = "docvalue_fields")]
     #[serde(default)]
-    doc_value_fields: Vec<String>,
+    pub doc_value_fields: Vec<String>,
 
     // Not supported
     _source: Option<serde_json::Value>,
@@ -132,9 +136,12 @@ pub struct TopHitsAggregationReq {
     version: Option<serde_json::Value>,
 }
 
+/// A field and its associated sort order.
 #[derive(Debug, Clone, PartialEq, Default)]
-struct KeyOrder {
+pub struct KeyOrder {
+    /// The field name.
     field: String,
+    /// The sort order.
     order: Order,
 }
 

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -221,7 +221,7 @@ impl TopHitsAggregationReq {
                 if !field.contains('*') {
                     return reader
                         .iter_columns()?
-                        .find(|(name, _)| name == field)
+                        .find(|(name, _)| &name.replace(JSON_PATH_SEGMENT_SEP_STR, ".") == field)
                         .map(|_| vec![field.to_owned()])
                         .ok_or_else(|| {
                             TantivyError::SchemaError(format!(
@@ -871,12 +871,12 @@ mod tests {
     fn test_aggregation_top_hits(merge_segments: bool) -> crate::Result<()> {
         let docs = vec![
             vec![
-                r#"{ "date": "2015-01-02T00:00:00Z", "text": "bbb", "text2": "bbb", "mixed": { "dyn_arr": [1, "2"] } }"#,
-                r#"{ "date": "2017-06-15T00:00:00Z", "text": "ccc", "text2": "ddd", "mixed": { "dyn_arr": [3, "4"] } }"#,
+                r#"{ "date": "2015-01-02T00:00:00Z", "text": "bbb", "text2": "bbb", "mixed": { "dyn_arr": [1, "2"], "dyn_str": "foo" } }"#,
+                r#"{ "date": "2017-06-15T00:00:00Z", "text": "ccc", "text2": "ddd", "mixed": { "dyn_arr": [3, "4"], "dyn_str": "bar" } }"#,
             ],
             vec![
-                r#"{ "text": "aaa", "text2": "bbb", "date": "2018-01-02T00:00:00Z", "mixed": { "dyn_arr": ["9", 8] } }"#,
-                r#"{ "text": "aaa", "text2": "bbb", "date": "2016-01-02T00:00:00Z", "mixed": { "dyn_arr": ["7", 6] } }"#,
+                r#"{ "text": "aaa", "text2": "bbb", "date": "2018-01-02T00:00:00Z", "mixed": { "dyn_arr": ["9", 8], "dyn_str": "baz" } }"#,
+                r#"{ "text": "aaa", "text2": "bbb", "date": "2016-01-02T00:00:00Z", "mixed": { "dyn_arr": ["7", 6], "dyn_str": "bor" } }"#,
             ],
         ];
 
@@ -894,6 +894,7 @@ mod tests {
                         "date",
                         "tex*",
                         "mixed.*",
+                        "mixed.dyn_str"
                     ],
                 }
             }
@@ -920,6 +921,7 @@ mod tests {
                             "text": [ "ccc" ],
                             "text2": [ "ddd" ],
                             "mixed.dyn_arr": [ 3, "4" ],
+                            "mixed.dyn_str": [ "bar" ],
                         }
                     },
                     {
@@ -929,6 +931,7 @@ mod tests {
                             "text": [ "aaa" ],
                             "text2": [ "bbb" ],
                             "mixed.dyn_arr": [ 6, "7" ],
+                            "mixed.dyn_str": [ "bor" ],
                         }
                     }
                 ]

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -149,9 +149,7 @@ impl Serialize for KeyOrder {
 
 impl<'de> Deserialize<'de> for KeyOrder {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+    where D: Deserializer<'de> {
         let mut key_order = <HashMap<String, Order>>::deserialize(deserializer)?.into_iter();
         let (field, order) = key_order.next().ok_or(serde::de::Error::custom(
             "Expected exactly one key-value pair in sort parameter of top_hits, found none",

--- a/src/fastfield/readers.rs
+++ b/src/fastfield/readers.rs
@@ -30,7 +30,7 @@ impl FastFieldReaders {
         Ok(FastFieldReaders { columnar, schema })
     }
 
-    fn resolve_field(&self, column_name: &str) -> crate::Result<Option<String>> {
+    pub(crate) fn resolve_field(&self, column_name: &str) -> crate::Result<Option<String>> {
         let default_field_opt: Option<Field> = if cfg!(feature = "quickwit") {
             self.schema.get_field("_dynamic").ok()
         } else {


### PR DESCRIPTION
_Related to this comment:_
https://github.com/quickwit-oss/quickwit/pull/6088#issuecomment-3748772985

* The current implementation top hits panics when incorrect fields are specified in `docvalue_fields`. This leads to non-ergonomic errors in quickwit for example when we query non-existent `docvalue_fields`.
* fixes a bug where non-glob fast-fields where incorrectly matched because the dot notation of columns was incorrectly escaped.
* Make allowed fields of `TopHitsAggregationReq` pub so it is possible to instantiate and modify a `TopHitsAggregationReq`.
