### PR TITLE
Adds fuzzy query support to the QueryParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Tantivy 0.25
 - Fix TopDocs::order_by_string_fast_field for asc order [#2672](https://github.com/quickwit-oss/tantivy/pull/2672)(@stuhood @PSeitz)
 
 ## Features/Improvements
-- Add fuzzy query support via quoted phrase syntax `"term"~N`. When a quoted phrase tokenizes to a single term, `~N` is interpreted as Levenshtein distance (0-2) instead of phrase slop. Bare words with `~` remain literal for backward compatibility.
+- Add fuzzy query support via quoted phrase syntax `"term"~N`. When a quoted phrase tokenizes to a single term, `~N` is interpreted as Levenshtein distance (0-2) instead of phrase slop. Bare words with `~` remain literal for backward compatibility. [#2804](https://github.com/quickwit-oss/tantivy/pull/2804)(@xingtanzjr)
 - add docs/example and Vec<u32> values to sstable [#2660](https://github.com/quickwit-oss/tantivy/pull/2660)(@PSeitz)
 - Add string fast field support to `TopDocs`. [#2642](https://github.com/quickwit-oss/tantivy/pull/2642)(@stuhood)
 - update edition to 2024 [#2620](https://github.com/quickwit-oss/tantivy/pull/2620)(@PSeitz)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Tantivy 0.25
 - Fix TopDocs::order_by_string_fast_field for asc order [#2672](https://github.com/quickwit-oss/tantivy/pull/2672)(@stuhood @PSeitz)
 
 ## Features/Improvements
+- Add fuzzy query support via quoted phrase syntax `"term"~N`. When a quoted phrase tokenizes to a single term, `~N` is interpreted as Levenshtein distance (0-2) instead of phrase slop. Bare words with `~` remain literal for backward compatibility.
 - add docs/example and Vec<u32> values to sstable [#2660](https://github.com/quickwit-oss/tantivy/pull/2660)(@PSeitz)
 - Add string fast field support to `TopDocs`. [#2642](https://github.com/quickwit-oss/tantivy/pull/2642)(@stuhood)
 - update edition to 2024 [#2620](https://github.com/quickwit-oss/tantivy/pull/2620)(@PSeitz)

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -1715,23 +1715,18 @@ mod test {
 
     #[test]
     fn test_slop() {
-        // Phrase slop tests - ~N after quoted phrase means slop
-        // "a b"~ without a number - strict parser fails, lenient parses ~ as separate term
         test_is_parse_err("\"a b\"~", "(*\"a b\" *~)");
         test_is_parse_err("foo:\"a b\"~", "(*\"foo\":\"a b\" *~)");
-        // "a b"~a - 'a' is not a valid slop number, ~a becomes separate term
         test_is_parse_err("\"a b\"~a", "(*\"a b\" *~a)");
         test_is_parse_err(
             "\"a b\"~100000000000000000",
             "(*\"a b\" *~100000000000000000)",
         );
-        // ~4 alone is parsed as a bare word (~ is not reserved)
         test_parse_query_to_ast_helper("\"a b\"^2 ~4", "(*(\"a b\")^2 *~4)");
         test_parse_query_to_ast_helper("\"a b\"~4^2", "(\"a b\"~4)^2");
-        // ~ inside quotes is still allowed
         test_parse_query_to_ast_helper("\"~Document\"", "\"~Document\"");
-        // ~ at start of unquoted word is valid (parsed as literal)
         test_parse_query_to_ast_helper("~Document", "~Document");
+        test_parse_query_to_ast_helper("a~2", "a~2");
         test_parse_query_to_ast_helper("\"a b\"~0", "\"a b\"");
         test_parse_query_to_ast_helper("\"a b\"~1", "\"a b\"~1");
         test_parse_query_to_ast_helper("\"a b\"~3", "\"a b\"~3");

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -234,6 +234,7 @@ fn term_or_phrase(inp: &str) -> IResult<&str, UserInputLeaf> {
                 delimiter,
                 slop,
                 prefix,
+                fuzzy: None,
             }
             .into()
         },
@@ -253,17 +254,7 @@ fn term_or_phrase_infallible(inp: &str) -> JResult<&str, Option<UserInputLeaf>> 
                         delimiter,
                         slop,
                         prefix,
-                    }
-                    .into(),
-                )
-            } else if slop != 0 {
-                Some(
-                    UserInputLiteral {
-                        field_name: None,
-                        phrase: "".to_string(),
-                        delimiter: Delimiter::None,
-                        slop,
-                        prefix,
+                        fuzzy: None,
                     }
                     .into(),
                 )
@@ -1724,23 +1715,44 @@ mod test {
 
     #[test]
     fn test_slop() {
+        // Phrase slop tests - ~N after quoted phrase means slop
+        // "a b"~ without a number - strict parser fails, lenient parses ~ as separate term
         test_is_parse_err("\"a b\"~", "(*\"a b\" *~)");
         test_is_parse_err("foo:\"a b\"~", "(*\"foo\":\"a b\" *~)");
+        // "a b"~a - 'a' is not a valid slop number, ~a becomes separate term
         test_is_parse_err("\"a b\"~a", "(*\"a b\" *~a)");
         test_is_parse_err(
             "\"a b\"~100000000000000000",
             "(*\"a b\" *~100000000000000000)",
         );
+        // ~4 alone is parsed as a bare word (~ is not reserved)
         test_parse_query_to_ast_helper("\"a b\"^2 ~4", "(*(\"a b\")^2 *~4)");
         test_parse_query_to_ast_helper("\"a b\"~4^2", "(\"a b\"~4)^2");
+        // ~ inside quotes is still allowed
         test_parse_query_to_ast_helper("\"~Document\"", "\"~Document\"");
+        // ~ at start of unquoted word is valid (parsed as literal)
         test_parse_query_to_ast_helper("~Document", "~Document");
-        test_parse_query_to_ast_helper("a~2", "a~2");
         test_parse_query_to_ast_helper("\"a b\"~0", "\"a b\"");
         test_parse_query_to_ast_helper("\"a b\"~1", "\"a b\"~1");
         test_parse_query_to_ast_helper("\"a b\"~3", "\"a b\"~3");
         test_parse_query_to_ast_helper("foo:\"a b\"~300", "\"foo\":\"a b\"~300");
         test_parse_query_to_ast_helper("\"a b\"~300^2", "(\"a b\"~300)^2");
+    }
+
+    #[test]
+    fn test_fuzzy() {
+        // With ~ allowed in bare words, word~1 is parsed as literal "word~1"
+        // To get fuzzy, you need quoted form: "word"~1
+        // At grammar level, "word"~1 is parsed as phrase with slop=1
+        // The conversion to FuzzyTermQuery happens in QueryParser when tokenization yields 1 term
+        test_parse_query_to_ast_helper("\"word\"~1", "\"word\"~1");
+        test_parse_query_to_ast_helper("\"word\"~2", "\"word\"~2");
+        test_parse_query_to_ast_helper("foo:\"bar\"~1", "\"foo\":\"bar\"~1");
+        // Fuzzy with boost
+        test_parse_query_to_ast_helper("\"word\"~1^2", "(\"word\"~1)^2");
+        // Bare word with ~ is parsed as literal term (backward compatible)
+        test_parse_query_to_ast_helper("word~1", "word~1");
+        test_parse_query_to_ast_helper("C~Users~Documents", "C~Users~Documents");
     }
 
     #[test]

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -234,7 +234,6 @@ fn term_or_phrase(inp: &str) -> IResult<&str, UserInputLeaf> {
                 delimiter,
                 slop,
                 prefix,
-                fuzzy: None,
             }
             .into()
         },
@@ -254,7 +253,6 @@ fn term_or_phrase_infallible(inp: &str) -> JResult<&str, Option<UserInputLeaf>> 
                         delimiter,
                         slop,
                         prefix,
-                        fuzzy: None,
                     }
                     .into(),
                 )

--- a/query-grammar/src/user_input_ast.rs
+++ b/query-grammar/src/user_input_ast.rs
@@ -136,12 +136,6 @@ pub struct UserInputLiteral {
     pub delimiter: Delimiter,
     pub slop: u32,
     pub prefix: bool,
-    /// Reserved for future use. Currently not used.
-    /// Fuzzy matching is now determined at query parse time based on slop and tokenization:
-    /// - If slop > 0 and tokenization produces a single term, it becomes a FuzzyTermQuery.
-    /// - If slop > 0 and tokenization produces multiple terms, it remains a PhraseQuery with slop.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fuzzy: Option<u8>,
 }
 
 impl fmt::Debug for UserInputLiteral {
@@ -357,7 +351,6 @@ mod tests {
             delimiter: Delimiter::None,
             slop: 0,
             prefix: false,
-            fuzzy: None,
         };
         let ast = UserInputAst::Leaf(Box::new(UserInputLeaf::Literal(literal)));
         let json = serde_json::to_string(&ast).unwrap();
@@ -423,7 +416,8 @@ mod tests {
                         phrase: "hello".to_string(),
                         delimiter: Delimiter::None,
                         slop: 0,
-                        prefix: false,                        fuzzy: None,                    }))),
+                        prefix: false,
+                    }))),
                 ),
             ])),
             2.5.into(),
@@ -449,7 +443,8 @@ mod tests {
                     phrase: "hello".to_string(),
                     delimiter: Delimiter::None,
                     slop: 0,
-                    prefix: false,                    fuzzy: None,                }))),
+                    prefix: false,
+                }))),
             ),
         ]);
         let json = serde_json::to_string(&clause).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,7 +984,6 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
-                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -995,7 +994,6 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
-                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1006,7 +1004,6 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
-                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1017,7 +1014,6 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
-                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1028,7 +1024,6 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
-                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,6 +984,7 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
+                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -994,6 +995,7 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
+                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1004,6 +1006,7 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
+                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1014,6 +1017,7 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
+                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }
@@ -1024,6 +1028,7 @@ pub mod tests {
                 delimiter: crate::query_grammar::Delimiter::None,
                 slop: 0,
                 prefix: false,
+                fuzzy: None,
             };
             assert_eq!(get_doc_ids(user_input_literal), vec![DocAddress::new(0, 0)]);
         }

--- a/src/query/query_parser/logical_ast.rs
+++ b/src/query/query_parser/logical_ast.rs
@@ -28,6 +28,12 @@ pub enum LogicalLiteral {
         pattern: Arc<Regex>,
         field: Field,
     },
+    /// A fuzzy term query using Levenshtein distance
+    FuzzyTerm {
+        term: Term,
+        distance: u8,
+        transposition_cost_one: bool,
+    },
 }
 
 pub enum LogicalAst {
@@ -159,6 +165,17 @@ impl fmt::Debug for LogicalLiteral {
                 ref pattern,
                 ref field,
             } => write!(formatter, "Regex({field:?}, {pattern:?})"),
+            LogicalLiteral::FuzzyTerm {
+                ref term,
+                distance,
+                transposition_cost_one,
+            } => {
+                write!(formatter, "{term:?}~{distance}")?;
+                if !transposition_cost_one {
+                    write!(formatter, "(transposition_cost=2)")?;
+                }
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds fuzzy query support to the QueryParser using the syntax `"term"~N`, 
where N is the Levenshtein edit distance (0, 1, or 2).

## Motivation
Users have requested Lucene-style fuzzy query syntax. This implementation provides 
fuzzy search capability while maintaining full backward compatibility.

## Design Choices
- **Backward compatible**: Bare words like `word~1` or `C~Users~Documents` continue 
  to be parsed as literal terms (the `~` is NOT a reserved character)
- **Quoted phrase semantic**: `"term"~N` with a single tokenized term → FuzzyTermQuery
- **Multi-term phrase**: `"hello world"~1` → PhraseQuery with slop (existing behavior)
- **Error handling**: Distance > 2 returns `QueryParserError::FuzzyDistanceTooLarge`

## Examples
| Query | Result |
|-------|--------|
| `"hello"~1` | FuzzyTermQuery (distance=1) |
| `"hello"~2` | FuzzyTermQuery (distance=2) |
| `"hello world"~1` | PhraseQuery with slop=1 |
| `hello~1` | TermQuery("hello~1") - literal |
| `"hello"~3` | Error: FuzzyDistanceTooLarge |

## Changes
- Added `FuzzyTerm` variant to `LogicalLiteral`
- Added `FuzzyDistanceTooLarge` error to `QueryParserError`
- Modified `generate_literals_for_str` to detect single-term phrases with slop > 0
- Added comprehensive test cases