### PR TITLE
fix: Fix hang in rare intersection case

### DIFF
--- a/src/query/intersection.rs
+++ b/src/query/intersection.rs
@@ -305,7 +305,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_intersection_termination() {
         use crate::query::score_combiner::DoNothingCombiner;
         use crate::query::{BufferedUnionScorer, ConstScorer, VecDocSet};

--- a/src/query/union/buffered_union.rs
+++ b/src/query/union/buffered_union.rs
@@ -231,6 +231,10 @@ where
             // processed and removed, so we need to use seek, which uses the regular advance.
             self.seek(target) == target
         } else {
+            if target == TERMINATED {
+                self.seek(TERMINATED);
+                return true;
+            }
             // The docsets are not in the buffered range, so we can use seek_into_the_danger_zone
             // of the underlying docsets
             let is_hit = self

--- a/src/query/union/mod.rs
+++ b/src/query/union/mod.rs
@@ -254,6 +254,28 @@ mod tests {
             vec![1, 2, 3, 7, 8, 9, 99, 100, 101, 500, 20000],
         );
     }
+
+    #[test]
+    fn test_buffered_union_seek_into_danger_zone_terminated() {
+        let scorer1 = ConstScorer::new(VecDocSet::from(vec![1, 2]), 1.0);
+        let scorer2 = ConstScorer::new(VecDocSet::from(vec![2, 3]), 1.0);
+
+        let mut union_scorer = BufferedUnionScorer::build(
+            vec![scorer1, scorer2],
+            || DoNothingCombiner::default(),
+            100,
+        );
+
+        // Advance to end
+        while union_scorer.doc() != TERMINATED {
+            union_scorer.advance();
+        }
+
+        assert_eq!(union_scorer.doc(), TERMINATED);
+
+        // This should return true
+        assert!(union_scorer.seek_into_the_danger_zone(TERMINATED));
+    }
 }
 
 #[cfg(all(test, feature = "unstable"))]


### PR DESCRIPTION
In a rare case demonstrated by the repro on https://github.com/paradedb/paradedb/pull/3989, intersection could enter an infinite loop trying to `seek_into_the_danger_zone(TERMINATED)`.

This change adds two tests reproducing that behavior, and then has `seek_into_the_danger_zone` call `seek` when called with `TERMINATED` to fix both tests.