### PR TITLE
Fix closing parenthesis on lenient parser

### DIFF
--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -1192,9 +1192,9 @@ mod test {
 
     #[track_caller]
     fn test_parse_query_to_ast_helper(query: &str, expected: &str) {
-        // let query_strict = parse_to_ast(query).unwrap().1;
-        // let query_strict_str = format!("{query_strict:?}");
-        // assert_eq!(query_strict_str, expected, "strict parser failed");
+        let query_strict = parse_to_ast(query).unwrap().1;
+        let query_strict_str = format!("{query_strict:?}");
+        assert_eq!(query_strict_str, expected, "strict parser failed");
 
         let (query_lenient, errs) = parse_to_ast_lenient(query);
         let query_lenient_str = format!("{query_lenient:?}");

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -560,7 +560,7 @@ fn range_infallible(inp: &str) -> JResult<&str, UserInputLeaf> {
             (
                 (
                     value((), tag(">=")),
-                    map(word_infallible("", false), |(bound, err)| {
+                    map(word_infallible(")", false), |(bound, err)| {
                         (
                             (
                                 bound
@@ -574,7 +574,7 @@ fn range_infallible(inp: &str) -> JResult<&str, UserInputLeaf> {
                 ),
                 (
                     value((), tag("<=")),
-                    map(word_infallible("", false), |(bound, err)| {
+                    map(word_infallible(")", false), |(bound, err)| {
                         (
                             (
                                 UserInputBound::Unbounded,
@@ -588,7 +588,7 @@ fn range_infallible(inp: &str) -> JResult<&str, UserInputLeaf> {
                 ),
                 (
                     value((), tag(">")),
-                    map(word_infallible("", false), |(bound, err)| {
+                    map(word_infallible(")", false), |(bound, err)| {
                         (
                             (
                                 bound
@@ -602,7 +602,7 @@ fn range_infallible(inp: &str) -> JResult<&str, UserInputLeaf> {
                 ),
                 (
                     value((), tag("<")),
-                    map(word_infallible("", false), |(bound, err)| {
+                    map(word_infallible(")", false), |(bound, err)| {
                         (
                             (
                                 UserInputBound::Unbounded,
@@ -1192,9 +1192,9 @@ mod test {
 
     #[track_caller]
     fn test_parse_query_to_ast_helper(query: &str, expected: &str) {
-        let query_strict = parse_to_ast(query).unwrap().1;
-        let query_strict_str = format!("{query_strict:?}");
-        assert_eq!(query_strict_str, expected, "strict parser failed");
+        // let query_strict = parse_to_ast(query).unwrap().1;
+        // let query_strict_str = format!("{query_strict:?}");
+        // assert_eq!(query_strict_str, expected, "strict parser failed");
 
         let (query_lenient, errs) = parse_to_ast_lenient(query);
         let query_lenient_str = format!("{query_lenient:?}");
@@ -1323,6 +1323,11 @@ mod test {
         test_parse_query_to_ast_helper("<a", "{\"*\" TO \"a\"}");
         test_parse_query_to_ast_helper("<=a", "{\"*\" TO \"a\"]");
         test_parse_query_to_ast_helper("<=bsd", "{\"*\" TO \"bsd\"]");
+
+        test_parse_query_to_ast_helper("(<=42)", "{\"*\" TO \"42\"]");
+        test_parse_query_to_ast_helper("(<=42 )", "{\"*\" TO \"42\"]");
+        test_parse_query_to_ast_helper("(age:>5)", "\"age\":{\"5\" TO \"*\"}");
+        test_parse_query_to_ast_helper("(title:bar AND age:>12)", "(+\"title\":bar +\"age\":{\"12\" TO \"*\"})");
     }
 
     #[test]

--- a/query-grammar/src/query_grammar.rs
+++ b/query-grammar/src/query_grammar.rs
@@ -1327,7 +1327,10 @@ mod test {
         test_parse_query_to_ast_helper("(<=42)", "{\"*\" TO \"42\"]");
         test_parse_query_to_ast_helper("(<=42 )", "{\"*\" TO \"42\"]");
         test_parse_query_to_ast_helper("(age:>5)", "\"age\":{\"5\" TO \"*\"}");
-        test_parse_query_to_ast_helper("(title:bar AND age:>12)", "(+\"title\":bar +\"age\":{\"12\" TO \"*\"})");
+        test_parse_query_to_ast_helper(
+            "(title:bar AND age:>12)",
+            "(+\"title\":bar +\"age\":{\"12\" TO \"*\"})",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes:  https://github.com/quickwit-oss/tantivy/issues/2814
This changes fixes the parsing error occurring when parsing an elastic range that's is enclosed in parenthesis.

