### PR TITLE
faster exclude queries

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -43,7 +43,7 @@ pub use self::boost_query::{BoostQuery, BoostWeight};
 pub use self::const_score_query::{ConstScoreQuery, ConstScorer};
 pub use self::disjunction_max_query::DisjunctionMaxQuery;
 pub use self::empty_query::{EmptyQuery, EmptyScorer, EmptyWeight};
-pub use self::exclude::Exclude;
+pub use self::exclude::{Exclude, ExclusionSet};
 pub use self::exist_query::ExistsQuery;
 pub use self::explanation::Explanation;
 #[cfg(test)]


### PR DESCRIPTION
Faster exclude queries with multiple terms.

Changes `Exclude` to be able to exclude multiple DocSets, instead of putting the DocSets into a union.
Use `seek_danger` in `Exclude`.

closes #2822