### PR TITLE
Export fields of the PercentileValuesVecEntry

### DIFF
--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -107,8 +107,11 @@ pub enum PercentileValues {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// The entry when requesting percentiles with keyed: false
 pub struct PercentileValuesVecEntry {
-    key: f64,
-    value: f64,
+    /// Percentile
+    pub key: f64,
+
+    /// Value at the percentile
+    pub value: f64,
 }
 
 /// Single-metric aggregations use this common result structure.


### PR DESCRIPTION
Otherwise, there is no way to access these fields when not using the json serialized form of the aggregation results.

This simple data struct is part of the public api, so its fields should be accessible as well.