### PR TITLE
Replace hyperloglogplus with Apache DataSketches HLL (lg_k=11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tantivy-bitpacker = { version = "0.9", path = "./bitpacker" }
 common = { version = "0.10", path = "./common/", package = "tantivy-common" }
 tokenizer-api = { version = "0.6", path = "./tokenizer-api", package = "tantivy-tokenizer-api" }
 sketches-ddsketch = { version = "0.3.0", features = ["use_serde"] }
-hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
+datasketches = "0.2.0"
 futures-util = { version = "0.3.28", optional = true }
 futures-channel = { version = "0.3.28", optional = true }
 fnv = "1.0.7"

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -341,8 +341,7 @@ impl Serialize for CardinalityCollector {
 impl<'de> Deserialize<'de> for CardinalityCollector {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let bytes: Vec<u8> = Deserialize::deserialize(deserializer)?;
-        let sketch =
-            HllSketch::deserialize(&bytes).map_err(serde::de::Error::custom)?;
+        let sketch = HllSketch::deserialize(&bytes).map_err(serde::de::Error::custom)?;
         Ok(Self { sketch, salt: 0 })
     }
 }
@@ -577,8 +576,9 @@ mod tests {
 
     #[test]
     fn cardinality_collector_serialize_deserialize_binary() {
-        use super::CardinalityCollector;
         use datasketches::hll::HllSketch;
+
+        use super::CardinalityCollector;
 
         let mut collector = CardinalityCollector::default();
         collector.insert("apple");


### PR DESCRIPTION
## What

Switch tantivy's cardinality aggregation from the `hyperloglogplus` crate (HyperLogLog++ with p=16) to the official Apache DataSketches HLL implementation (`datasketches` crate v0.2.0, lg_k=11, Hll4).

## Why

Pomsky currently fabricates **fake HLL sketches** from scalar cardinality estimates (`generate_sketch(count)`). When event query merges these across shards, the fake hashes collide — producing incorrect cardinality. For counts >256, it returns an empty HLL, losing data entirely.

### Why DataSketches over other options

Official crate (datasketches = 0.2.0, released 2026-01-14). 
Binary-compatible with datasketches-java (cross-language tests in the crate). 
Same hash function (MurmurHash3 x64-128, seed=9001). 
Same lg_k=11 as Java Union(LOG2M=11). 
Zero conversion needed — pomsky just forwards raw bytes.


**Logs-backend already supports DataSketches HLL** via the `hll_data_sketch_value` protobuf field (field 10). No changes needed in logs-backend or cloudprem-bridge.

## Changes

- `Cargo.toml`: `hyperloglogplus 0.4.1` → `datasketches 0.2.0`
- `CardinalityCollector`: `HyperLogLogPlus<u64, BuildSaltedHasher>` → `HllSketch(lg_k=11, Hll4)`
- Custom Serde impl using `HllSketch` binary serialization format (for cross-shard transfer)
- New `to_sketch_bytes()` method for external consumers (pomsky will call this)
- Salt preserved via `(salt, value)` tuple hashing for column type disambiguation
- Removed `BuildSaltedHasher` struct
- 4 new unit tests: serde roundtrip, merge, binary format compat, salt differentiation

## Testing

All 169 aggregation tests pass, including 10 cardinality-specific tests (6 existing + 4 new).

## Follow-up PRs

- **pomsky**: Replace `generate_sketch` hack → call `cardinality.to_sketch_bytes()`, return as `hll_data_sketch_value`
- **pomsky**: Delete `generate_sketch` function and its test
