### PR TITLE
fix: Prevent panic in SSTable Streamer on IO errors

### DIFF
--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -36,7 +36,7 @@ pub mod column_values;
 mod columnar;
 mod dictionary;
 mod dynamic_column;
-mod iterable;
+pub mod iterable;
 pub(crate) mod utils;
 mod value;
 

--- a/sstable/src/streamer.rs
+++ b/sstable/src/streamer.rs
@@ -205,7 +205,7 @@ where
     /// Before the first call to `.advance()`, the stream
     /// is an uninitialized state.
     pub fn advance(&mut self) -> bool {
-        while self.delta_reader.advance().unwrap() {
+        while self.delta_reader.advance().unwrap_or(false) {
             self.term_ord = Some(
                 self.term_ord
                     .map(|term_ord| term_ord + 1u64)


### PR DESCRIPTION
# Fix: Prevent panic in SSTable Streamer on IO errors

## Summary

- Replace `.unwrap()` with `.unwrap_or(false)` in `Streamer::advance()` so that IO errors (e.g., `UnexpectedEof`) gracefully terminate iteration instead of panicking

## Problem

`Streamer::advance()` in `sstable/src/streamer.rs` calls `self.delta_reader.advance().unwrap()`. When the underlying data becomes unavailable (truncated file, deleted file, corrupted block), `advance()` returns `Err(UnexpectedEof)` and the `.unwrap()` panics.

This is particularly problematic in JNI/FFI contexts where the Streamer may be used on tokio background threads. A panic on a background thread during stack unwinding triggers a double-panic (`fatal runtime error: failed to initiate panic, error 5`), which results in an unconditional `SIGABRT` that kills the entire process.

## Fix

```diff
-        while self.delta_reader.advance().unwrap() {
+        while self.delta_reader.advance().unwrap_or(false) {
```

On IO error, `advance()` now returns `false`, ending iteration cleanly. This matches the existing behavior for end-of-stream (the loop already returns `false` when `advance()` returns `Ok(false)`). Callers that need to distinguish between end-of-stream and IO error should use the `delta_reader` directly.

## Impact

- No behavioral change for valid data (`.unwrap()` on `Ok(true)` / `Ok(false)` is identical to `.unwrap_or(false)`)
- Prevents process abort on corrupted or unavailable SSTable data
- Eliminates a class of double-panic crashes in async/FFI environments

## Test plan

- [ ] Existing `test_sstable_stream` and `test_sstable_search` tests continue to pass
- [ ] Confirm no panic when Streamer encounters truncated/corrupted block data
- [ ] Validate in tantivy4java integration tests that previously crashed with exit code 134 (`SplitQueryParsingComprehensiveTest`)
