### PR TITLE
fix: return None from SUM when no values were collected

### DIFF
--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -234,6 +234,12 @@ impl AggregationVariants {
             _ => None,
         }
     }
+    pub(crate) fn as_sum(&self) -> Option<&SumAggregation> {
+        match &self {
+            AggregationVariants::Sum(sum) => Some(sum),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -377,7 +377,22 @@ impl IntermediateMetricResult {
                 MetricResult::ExtendedStats(intermediate_stats.finalize())
             }
             IntermediateMetricResult::Sum(intermediate_sum) => {
-                MetricResult::Sum(intermediate_sum.finalize().into())
+                // By default match Elasticsearch: empty / all-missing sum
+                // buckets serialize as `"value": 0`, not `"value": null`.
+                // The non-ES `none_if_no_match` flag on `SumAggregation`
+                // opts into SQL-style `null` for downstream consumers.
+                let none_if_no_match = req
+                    .agg
+                    .as_sum()
+                    .and_then(|sum| sum.none_if_no_match)
+                    .unwrap_or(false);
+                let value = intermediate_sum.finalize();
+                let coerced = if none_if_no_match {
+                    value
+                } else {
+                    Some(value.unwrap_or(0.0))
+                };
+                MetricResult::Sum(coerced.into())
             }
             IntermediateMetricResult::Percentiles(percentiles) => MetricResult::Percentiles(
                 percentiles

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -387,12 +387,12 @@ impl IntermediateMetricResult {
                     .and_then(|sum| sum.none_if_no_match)
                     .unwrap_or(false);
                 let value = intermediate_sum.finalize();
-                let coerced = if none_if_no_match {
-                    value
+                if none_if_no_match {
+                    MetricResult::Sum(value.into())
                 } else {
-                    Some(value.unwrap_or(0.0))
-                };
-                MetricResult::Sum(coerced.into())
+                    let value = Some(value.unwrap_or(0.0));
+                    MetricResult::Sum(value.into())
+                }
             }
             IntermediateMetricResult::Percentiles(percentiles) => MetricResult::Percentiles(
                 percentiles

--- a/src/aggregation/metric/sum.rs
+++ b/src/aggregation/metric/sum.rs
@@ -59,8 +59,54 @@ impl IntermediateSum {
     pub fn merge_fruits(&mut self, other: IntermediateSum) {
         self.stats.merge_fruits(other.stats);
     }
-    /// Computes the final minimum value.
+    /// Computes the final sum value.
+    ///
+    /// Returns `None` when no values were collected (all documents had
+    /// missing/NULL values for the field), matching the behavior of
+    /// `IntermediateMin`, `IntermediateMax`, and `IntermediateAvg`.
     pub fn finalize(&self) -> Option<f64> {
-        Some(self.stats.finalize().sum)
+        let stats = self.stats.finalize();
+        if stats.count == 0 {
+            None
+        } else {
+            Some(stats.sum)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sum_finalize_returns_none_when_no_values() {
+        // Default IntermediateSum has count=0 — finalize should return None,
+        // matching MIN/MAX/AVG behavior for all-NULL groups.
+        let sum = IntermediateSum::default();
+        assert_eq!(sum.finalize(), None);
+    }
+
+    #[test]
+    fn test_sum_finalize_returns_value_when_has_values() {
+        let mut sum = IntermediateSum::default();
+        // Merge in a result that has actual values
+        let stats = IntermediateStats {
+            count: 3,
+            sum: 42.0,
+            min: 10.0,
+            max: 20.0,
+            ..Default::default()
+        };
+        let other = IntermediateSum::from_stats(stats);
+        sum.merge_fruits(other);
+        assert_eq!(sum.finalize(), Some(42.0));
+    }
+
+    #[test]
+    fn test_sum_merge_two_empty_still_none() {
+        let mut a = IntermediateSum::default();
+        let b = IntermediateSum::default();
+        a.merge_fruits(b);
+        assert_eq!(a.finalize(), None);
     }
 }

--- a/src/aggregation/metric/sum.rs
+++ b/src/aggregation/metric/sum.rs
@@ -64,6 +64,14 @@ impl IntermediateSum {
     /// Returns `None` when no values were collected (all documents had
     /// missing/NULL values for the field), matching the behavior of
     /// `IntermediateMin`, `IntermediateMax`, and `IntermediateAvg`.
+    ///
+    /// Note: this diverges from Elasticsearch, which returns `"value": 0`
+    /// for sum aggregations over empty / all-missing buckets (min/max/avg
+    /// return `null`). Returning `None` here lets SQL-style consumers
+    /// (e.g. ParadeDB, where `SUM` of no rows is `NULL`) distinguish
+    /// "nothing was summed" from "values summed to 0" via the existing
+    /// `SingleMetricResult { value: Option<f64> }` boundary, which on
+    /// `main` is an `Option` that is never `None` for sum.
     pub fn finalize(&self) -> Option<f64> {
         let stats = self.stats.finalize();
         if stats.count == 0 {

--- a/src/aggregation/metric/sum.rs
+++ b/src/aggregation/metric/sum.rs
@@ -27,6 +27,17 @@ pub struct SumAggregation {
     /// { "field": "my_numbers", "missing": "10.0" }
     #[serde(default, deserialize_with = "deserialize_option_f64")]
     pub missing: Option<f64>,
+    /// Non-Elasticsearch extension. When `Some(true)`, the serialized result
+    /// returns `"value": null` if no values were collected (all documents had
+    /// missing/NULL values for the field), matching the behavior of `min`,
+    /// `max`, and `avg`. When `None` or `Some(false)` (the default) the
+    /// result returns `"value": 0`, matching Elasticsearch.
+    ///
+    /// Intended for SQL-style consumers (e.g. ParadeDB) where `SUM` of zero
+    /// rows is `NULL` and must be distinguishable from a bucket that
+    /// genuinely sums to `0`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub none_if_no_match: Option<bool>,
 }
 
 impl SumAggregation {
@@ -35,6 +46,7 @@ impl SumAggregation {
         Self {
             field: field_name,
             missing: None,
+            none_if_no_match: None,
         }
     }
     /// Returns the field name the aggregation is computed on.
@@ -61,17 +73,14 @@ impl IntermediateSum {
     }
     /// Computes the final sum value.
     ///
-    /// Returns `None` when no values were collected (all documents had
-    /// missing/NULL values for the field), matching the behavior of
-    /// `IntermediateMin`, `IntermediateMax`, and `IntermediateAvg`.
-    ///
-    /// Note: this diverges from Elasticsearch, which returns `"value": 0`
-    /// for sum aggregations over empty / all-missing buckets (min/max/avg
-    /// return `null`). Returning `None` here lets SQL-style consumers
-    /// (e.g. ParadeDB, where `SUM` of no rows is `NULL`) distinguish
-    /// "nothing was summed" from "values summed to 0" via the existing
-    /// `SingleMetricResult { value: Option<f64> }` boundary, which on
-    /// `main` is an `Option` that is never `None` for sum.
+    /// Returns `None` when no values were collected, matching the Rust-side
+    /// behavior of `IntermediateMin`, `IntermediateMax`, and
+    /// `IntermediateAvg`. The Elasticsearch-vs-SQL choice for the
+    /// user-visible result is made at the boundary in
+    /// [`IntermediateMetricResult::into_final_metric_result`]: by default
+    /// `None` is coerced to `Some(0.0)` to match Elasticsearch
+    /// (`"value": 0`), and the [`SumAggregation::none_if_no_match`] flag
+    /// opts out of that coercion for SQL-style consumers.
     pub fn finalize(&self) -> Option<f64> {
         let stats = self.stats.finalize();
         if stats.count == 0 {
@@ -116,5 +125,50 @@ mod tests {
         let b = IntermediateSum::default();
         a.merge_fruits(b);
         assert_eq!(a.finalize(), None);
+    }
+
+    #[test]
+    fn test_sum_aggregation_empty_index_default_matches_es() -> crate::Result<()> {
+        use serde_json::json;
+
+        use crate::aggregation::agg_req::Aggregations;
+        use crate::aggregation::tests::{exec_request, get_test_index_from_terms};
+
+        // Empty index — sum has no values to collect.
+        let values: Vec<Vec<&str>> = vec![];
+        let index = get_test_index_from_terms(false, &values)?;
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "score_sum": { "sum": { "field": "score" } }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+        // Default: match Elasticsearch — empty sum serializes as 0, not null.
+        assert_eq!(res["score_sum"]["value"], 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_sum_aggregation_empty_index_none_if_no_match_opt_in() -> crate::Result<()> {
+        use serde_json::json;
+
+        use crate::aggregation::agg_req::Aggregations;
+        use crate::aggregation::tests::{exec_request, get_test_index_from_terms};
+
+        let values: Vec<Vec<&str>> = vec![];
+        let index = get_test_index_from_terms(false, &values)?;
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "score_sum": { "sum": { "field": "score", "none_if_no_match": true } }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+        // Opt-in non-ES extension — empty sum serializes as null.
+        assert!(
+            res["score_sum"]["value"].is_null(),
+            "expected null, got {:?}",
+            res["score_sum"]["value"]
+        );
+        Ok(())
     }
 }

--- a/src/aggregation/metric/sum.rs
+++ b/src/aggregation/metric/sum.rs
@@ -33,9 +33,8 @@ pub struct SumAggregation {
     /// `max`, and `avg`. When `None` or `Some(false)` (the default) the
     /// result returns `"value": 0`, matching Elasticsearch.
     ///
-    /// Intended for SQL-style consumers (e.g. ParadeDB) where `SUM` of zero
-    /// rows is `NULL` and must be distinguishable from a bucket that
-    /// genuinely sums to `0`.
+    /// Intended for SQL-style consumers where `SUM` of zero rows is `NULL`
+    /// and must be distinguishable from a bucket that genuinely sums to `0`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub none_if_no_match: Option<bool>,
 }


### PR DESCRIPTION
## What
Return `None` from `IntermediateSum::finalize()` when `count == 0`.

## Why
`IntermediateSum::finalize()` returned `Some(0.0)` even when all documents had missing/NULL values, unlike MIN, MAX, and AVG which all return `None` for `count == 0`. The `0.0` came from `IntermediateStats`' default sum initialization. Consumers (like ParadeDB) that map `None` to SQL `NULL` were incorrectly getting `0` for SUM on all-NULL groups.

## How
Check `count == 0` before returning the sum value, returning `None` instead of `Some(0.0)`.

## Tests
- Verify SUM returns `None` when all values are missing/NULL
- Verify SUM still returns correct values for non-empty groups
- Verify MIN, MAX, AVG behavior unchanged