### PR TITLE
feat(indexer): bulk indexing optimizations (merge throttle, stacking, BulkMergePolicy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Tantivy 0.26 (Unreleased)
 - Add `seek_danger` on `DocSet` for more efficient intersections [#2538](https://github.com/quickwit-oss/tantivy/pull/2538) [#2810](https://github.com/quickwit-oss/tantivy/pull/2810)(@PSeitz @stuhood @fulmicoton)
 - Skip column traversal in `RangeDocSet` when query range does not overlap with column bounds [#2783](https://github.com/quickwit-oss/tantivy/pull/2783)(@ChangRui-Ryan)
 - Speed up exclude queries by supporting multiple excluded `DocSet`s without intermediate union [#2825](https://github.com/quickwit-oss/tantivy/pull/2825)(@PSeitz)
+- Improve union performance for non-score unions with `fill_buffer` and optimized `TinySet` [#2863](https://github.com/quickwit-oss/tantivy/pull/2863)(@PSeitz)
 
 Tantivy 0.25
 ================================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.26.0"
+version = "0.25.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]
@@ -57,13 +57,13 @@ measure_time = "0.9.0"
 arc-swap = "1.5.0"
 bon = "3.3.1"
 
-columnar = { version = "0.6", path = "./columnar", package = "tantivy-columnar" }
-sstable = { version = "0.6", path = "./sstable", package = "tantivy-sstable", optional = true }
-stacker = { version = "0.6", path = "./stacker", package = "tantivy-stacker" }
-query-grammar = { version = "0.25.0", path = "./query-grammar", package = "tantivy-query-grammar" }
-tantivy-bitpacker = { version = "0.9", path = "./bitpacker" }
-common = { version = "0.10", path = "./common/", package = "tantivy-common" }
-tokenizer-api = { version = "0.6", path = "./tokenizer-api", package = "tantivy-tokenizer-api" }
+columnar = { version = "0.7", path = "./columnar", package = "tantivy-columnar" }
+sstable = { version = "0.7", path = "./sstable", package = "tantivy-sstable", optional = true }
+stacker = { version = "0.7", path = "./stacker", package = "tantivy-stacker" }
+query-grammar = { version = "0.26.0", path = "./query-grammar", package = "tantivy-query-grammar" }
+tantivy-bitpacker = { version = "0.10", path = "./bitpacker" }
+common = { version = "0.11", path = "./common/", package = "tantivy-common" }
+tokenizer-api = { version = "0.7", path = "./tokenizer-api", package = "tantivy-tokenizer-api" }
 sketches-ddsketch = { version = "0.4", features = ["use_serde"] }
 datasketches = "0.2.0"
 futures-util = { version = "0.3.28", optional = true }

--- a/bitpacker/Cargo.toml
+++ b/bitpacker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-bitpacker"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-columnar"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/quickwit-oss/tantivy"
@@ -12,10 +12,10 @@ categories = ["database-implementations", "data-structures", "compression"]
 itertools = "0.14.0"
 fastdivide = "0.4.0"
 
-stacker = { version= "0.6", path = "../stacker", package="tantivy-stacker"}
-sstable = { version= "0.6", path = "../sstable", package = "tantivy-sstable" }
-common = { version= "0.10", path = "../common", package = "tantivy-common" }
-tantivy-bitpacker = { version= "0.9", path = "../bitpacker/" }
+stacker = { version= "0.7", path = "../stacker", package="tantivy-stacker"}
+sstable = { version= "0.7", path = "../sstable", package = "tantivy-sstable" }
+common = { version= "0.11", path = "../common", package = "tantivy-common" }
+tantivy-bitpacker = { version= "0.10", path = "../bitpacker/" }
 serde = "1.0.152"
 downcast-rs = "2.0.1"
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-common"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Paul Masurel <paul@quickwit.io>", "Pascal Seitz <pascal@quickwit.io>"]
 license = "MIT"
 edition = "2024"

--- a/query-grammar/Cargo.toml
+++ b/query-grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-query-grammar"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Paul Masurel <paul.masurel@gmail.com>"]
 license = "MIT"
 categories = ["database-implementations", "data-structures"]

--- a/src/indexer/bulk_merge_policy.rs
+++ b/src/indexer/bulk_merge_policy.rs
@@ -1,0 +1,174 @@
+use super::merge_policy::{MergeCandidate, MergePolicy};
+use crate::index::SegmentMeta;
+
+/// A merge policy optimized for bulk indexing workloads.
+///
+/// Unlike [`LogMergePolicy`](super::LogMergePolicy), this policy is designed
+/// to minimize merge I/O during heavy indexing by:
+/// - Requiring more segments before triggering a merge (default: 16 vs 8)
+/// - Only merging segments of similar size (logarithmic grouping)
+/// - Setting a higher minimum segment size to avoid merging tiny segments
+///   that will soon be merged again anyway
+///
+/// After bulk indexing is complete, call
+/// [`IndexWriter::merge`](crate::IndexWriter::merge) with all segment IDs
+/// to consolidate into a single segment.
+///
+/// # Example
+/// ```rust,no_run
+/// use tantivy::indexer::BulkIndexingMergePolicy;
+///
+/// let mut policy = BulkIndexingMergePolicy::default();
+/// policy.set_min_num_segments(20);  // even more conservative
+/// ```
+#[derive(Debug, Clone)]
+pub struct BulkIndexingMergePolicy {
+    /// Minimum segments at a level before merge is triggered.
+    min_num_segments: usize,
+    /// Maximum docs in a segment for it to be eligible for merge.
+    max_docs_before_merge: usize,
+    /// Minimum segment size for level grouping.
+    min_layer_size: u32,
+    /// Log base for level grouping.
+    level_log_size: f64,
+}
+
+impl Default for BulkIndexingMergePolicy {
+    fn default() -> Self {
+        BulkIndexingMergePolicy {
+            // High threshold: wait for many segments before merging
+            min_num_segments: 16,
+            // Don't merge very large segments during bulk indexing
+            max_docs_before_merge: 5_000_000,
+            // Larger minimum layer: treat all segments under 50K as same level
+            min_layer_size: 50_000,
+            // Wider level bands to group more segments together
+            level_log_size: 1.0,
+        }
+    }
+}
+
+impl BulkIndexingMergePolicy {
+    /// Set the minimum number of segments required at a level to trigger a merge.
+    pub fn set_min_num_segments(&mut self, min_num_segments: usize) {
+        self.min_num_segments = min_num_segments;
+    }
+
+    /// Set the maximum number of documents in a segment for it to be eligible for merge.
+    pub fn set_max_docs_before_merge(&mut self, max_docs: usize) {
+        self.max_docs_before_merge = max_docs;
+    }
+
+    /// Set the minimum segment size for level grouping.
+    pub fn set_min_layer_size(&mut self, min_layer_size: u32) {
+        self.min_layer_size = min_layer_size;
+    }
+
+    fn clip_min_size(&self, size: u32) -> u32 {
+        std::cmp::max(self.min_layer_size, size)
+    }
+}
+
+impl MergePolicy for BulkIndexingMergePolicy {
+    fn compute_merge_candidates(&self, segments: &[SegmentMeta]) -> Vec<MergeCandidate> {
+        use itertools::Itertools;
+
+        let eligible_segments: Vec<&SegmentMeta> = segments
+            .iter()
+            .filter(|seg| (seg.num_docs() as usize) <= self.max_docs_before_merge)
+            .sorted_by_key(|seg| std::cmp::Reverse(seg.max_doc()))
+            .collect();
+
+        if eligible_segments.is_empty() {
+            return vec![];
+        }
+
+        let mut current_max_log_size = f64::MAX;
+        let mut levels: Vec<Vec<&SegmentMeta>> = vec![];
+
+        for (_, group) in &eligible_segments.into_iter().chunk_by(|segment| {
+            let segment_log_size = f64::from(self.clip_min_size(segment.num_docs())).log2();
+            if segment_log_size < (current_max_log_size - self.level_log_size) {
+                current_max_log_size = segment_log_size;
+            }
+            current_max_log_size
+        }) {
+            levels.push(group.collect());
+        }
+
+        levels
+            .iter()
+            .filter(|level| level.len() >= self.min_num_segments)
+            .map(|segments| MergeCandidate(segments.iter().map(|seg| seg.id()).collect()))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::{SegmentId, SegmentMetaInventory};
+    use once_cell::sync::Lazy;
+
+    static INVENTORY: Lazy<SegmentMetaInventory> = Lazy::new(SegmentMetaInventory::default);
+
+    fn create_segment_meta(num_docs: u32) -> SegmentMeta {
+        INVENTORY.new_segment_meta(SegmentId::generate_random(), num_docs)
+    }
+
+    #[test]
+    fn test_bulk_policy_no_merge_below_threshold() {
+        let policy = BulkIndexingMergePolicy::default();
+        // 15 segments at the same level — still below threshold of 16
+        let segments: Vec<SegmentMeta> = (0..15).map(|_| create_segment_meta(10_000)).collect();
+        let candidates = policy.compute_merge_candidates(&segments);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_policy_merge_at_threshold() {
+        let policy = BulkIndexingMergePolicy::default();
+        // 16 segments at the same level — reaches threshold
+        let segments: Vec<SegmentMeta> = (0..16).map(|_| create_segment_meta(10_000)).collect();
+        let candidates = policy.compute_merge_candidates(&segments);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].0.len(), 16);
+    }
+
+    #[test]
+    fn test_bulk_policy_skips_large_segments() {
+        let policy = BulkIndexingMergePolicy::default();
+        // 20 segments but all above max_docs_before_merge
+        let segments: Vec<SegmentMeta> =
+            (0..20).map(|_| create_segment_meta(6_000_000)).collect();
+        let candidates = policy.compute_merge_candidates(&segments);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_policy_separate_levels() {
+        let policy = BulkIndexingMergePolicy::default();
+        // 16 small + 16 medium — should produce 2 merge candidates
+        let mut segments: Vec<SegmentMeta> =
+            (0..16).map(|_| create_segment_meta(1_000)).collect();
+        segments.extend((0..16).map(|_| create_segment_meta(500_000)));
+        let candidates = policy.compute_merge_candidates(&segments);
+        assert_eq!(candidates.len(), 2);
+    }
+
+    #[test]
+    fn test_bulk_policy_empty() {
+        let policy = BulkIndexingMergePolicy::default();
+        let candidates = policy.compute_merge_candidates(&[]);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn test_bulk_policy_custom_thresholds() {
+        let mut policy = BulkIndexingMergePolicy::default();
+        policy.set_min_num_segments(4);
+        let segments: Vec<SegmentMeta> = (0..4).map(|_| create_segment_meta(10_000)).collect();
+        let candidates = policy.compute_merge_candidates(&segments);
+        assert_eq!(candidates.len(), 1);
+    }
+}

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -492,29 +492,29 @@ impl IndexMerger {
 
         for reader in &self.readers {
             let store_reader = reader.get_store_reader(1)?;
-            if reader.has_deletes()
-                    // If there is not enough data in the store, we avoid stacking in order to
-                    // avoid creating many small blocks in the doc store. Once we have 5 full blocks,
-                    // we start stacking. In the worst case 2/7 of the blocks would be very small.
-                    // [segment 1 - {1 doc}][segment 2 - {fullblock * 5}{1doc}]
-                    // => 5 * full blocks, 2 * 1 document blocks
-                    //
-                    // In a more realistic scenario the segments are of the same size, so 1/6 of
-                    // the doc stores would be on average half full, given total randomness (which
-                    // is not the case here, but not sure how it behaves exactly).
-                    //
-                    // https://github.com/quickwit-oss/tantivy/issues/1053
-                    //
-                    // take 7 in order to not walk over all checkpoints.
-                    || store_reader.block_checkpoints().take(7).count() < 6
-                    || store_reader.decompressor() != store_writer.compressor().into()
-            {
+            let block_count = store_reader.block_checkpoints().take(5).count();
+            let compressor_matches =
+                store_reader.decompressor() == store_writer.compressor().into();
+
+            // Stacking: copy compressed blocks directly without decompression.
+            // Requirements:
+            //   1. No deletes (can't skip deleted docs in stacked blocks)
+            //   2. At least 4 full blocks (avoid accumulating tiny trailing blocks)
+            //   3. Same compressor (no transcoding needed)
+            //
+            // Relaxed from the original threshold of 6 blocks to 4 blocks.
+            // With 4 blocks, worst case is 1/5 undersized blocks, which balances
+            // I/O reduction during bulk indexing against doc store fragmentation.
+            // See: https://github.com/quickwit-oss/tantivy/issues/1053
+            let can_stack = !reader.has_deletes() && block_count >= 4 && compressor_matches;
+
+            if can_stack {
+                store_writer.stack(store_reader)?;
+            } else {
                 for doc_bytes_res in store_reader.iter_raw(reader.alive_bitset()) {
                     let doc_bytes = doc_bytes_res?;
                     store_writer.store_bytes(&doc_bytes)?;
                 }
-            } else {
-                store_writer.stack(store_reader)?;
             }
         }
         Ok(())

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -14,6 +14,7 @@ mod flat_map_with_buffer;
 pub(crate) mod index_writer;
 pub(crate) mod index_writer_status;
 pub(crate) mod indexing_term;
+mod bulk_merge_policy;
 mod log_merge_policy;
 mod merge_index_test;
 mod merge_operation;
@@ -34,6 +35,7 @@ use crossbeam_channel as channel;
 use smallvec::SmallVec;
 
 pub use self::index_writer::{advance_deletes, IndexWriter, IndexWriterOptions};
+pub use self::bulk_merge_policy::BulkIndexingMergePolicy;
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;
 pub use self::merge_policy::{MergeCandidate, MergePolicy, NoMergePolicy};

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -574,6 +574,15 @@ impl SegmentUpdater {
     }
 
     fn consider_merge_options(&self) {
+        // Limit concurrent merge operations (jobs) to avoid I/O starvation.
+        // We count actual merge operations, not segments-in-merge, because
+        // a single wide merge (e.g., 8→1) is only one job on one thread.
+        let active_merge_jobs = self.merge_operations.list().len();
+        let max_concurrent = self.merge_thread_pool.current_num_threads() + 1;
+        if active_merge_jobs >= max_concurrent {
+            return;
+        }
+
         let (mut committed_segments, mut uncommitted_segments) = self.get_mergeable_segments();
         if committed_segments.len() == 1 && committed_segments[0].num_deleted_docs() == 0 {
             committed_segments.clear();
@@ -604,7 +613,9 @@ impl SegmentUpdater {
             });
         merge_candidates.extend(committed_merge_candidates);
 
-        for merge_operation in merge_candidates {
+        // Only start merges up to the concurrency limit
+        let slots_available = max_concurrent.saturating_sub(active_merge_jobs);
+        for merge_operation in merge_candidates.into_iter().take(slots_available) {
             // If a merge cannot be started this is not a fatal error.
             // We do log a warning in `start_merge`.
             drop(self.start_merge(merge_operation));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,8 @@ pub fn version_string() -> &'static str {
 /// Defines tantivy's merging strategy
 pub mod merge_policy {
     pub use crate::indexer::{
-        DefaultMergePolicy, LogMergePolicy, MergeCandidate, MergePolicy, NoMergePolicy,
+        BulkIndexingMergePolicy, DefaultMergePolicy, LogMergePolicy, MergeCandidate, MergePolicy,
+        NoMergePolicy,
     };
 }
 

--- a/sstable/Cargo.toml
+++ b/sstable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-sstable"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/quickwit-oss/tantivy"
@@ -10,10 +10,10 @@ categories = ["database-implementations", "data-structures", "compression"]
 description = "sstables for tantivy"
 
 [dependencies]
-common = {version= "0.10", path="../common", package="tantivy-common"}
+common = {version= "0.11", path="../common", package="tantivy-common"}
 futures-util = "0.3.30"
 itertools = "0.14.0"
-tantivy-bitpacker = { version= "0.9", path="../bitpacker" }
+tantivy-bitpacker = { version= "0.10", path="../bitpacker" }
 tantivy-fst = "0.5"
 # experimental gives us access to Decompressor::upper_bound
 zstd = { version = "0.13", optional = true, features = ["experimental"] }

--- a/stacker/Cargo.toml
+++ b/stacker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-stacker"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 homepage = "https://github.com/quickwit-oss/tantivy"
@@ -9,7 +9,7 @@ description = "term hashmap used for indexing"
 
 [dependencies]
 murmurhash32 = "0.3"
-common = { version = "0.10", path = "../common/", package = "tantivy-common" }
+common = { version = "0.11", path = "../common/", package = "tantivy-common" }
 ahash = { version = "0.8.11", default-features = false, optional = true }
 
 

--- a/tokenizer-api/Cargo.toml
+++ b/tokenizer-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tantivy-tokenizer-api"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT"
 edition = "2021"
 description = "Tokenizer API of tantivy"


### PR DESCRIPTION
## Summary
- **Merge concurrency limit**: `consider_merge_options()` now counts active merge *jobs* (not segments-in-merge) and limits new merges to available thread pool slots
- **Doc store stacking threshold**: relaxed from 6 to 4 blocks, reducing unnecessary recompression I/O during merges
- **`BulkIndexingMergePolicy`**: new merge policy that delays merges during heavy indexing (min_segments=16, min_layer=50K, level_log=1.0)

## Motivation
During bulk indexing of 10M+ documents, background merges saturate I/O (especially on gp3 EBS with 3000 IOPS default), causing indexing throughput to drop from ~7K to ~500 docs/sec. These changes reduce merge pressure during indexing:
1. Merge job limit prevents I/O starvation
2. Relaxed stacking avoids costly recompression
3. BulkIndexingMergePolicy defers most merges until after indexing completes

## Usage
```rust
use tantivy::merge_policy::BulkIndexingMergePolicy;

writer.set_merge_policy(Box::new(BulkIndexingMergePolicy::default()));
// ... bulk indexing ...
writer.commit()?;
// After indexing, force merge to single segment:
let ids = index.searchable_segment_ids()?;
writer.merge(&ids).wait()?;
```

## Test plan
- [x] 6 new tests for BulkIndexingMergePolicy (below threshold, at threshold, large segments, separate levels, empty, custom)
- [x] All existing merge tests pass (LogMergePolicy, merge_index, store merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)