### PR TITLE
Make aggregation/collector fields public for tantivy-datafusion

### DIFF
--- a/src/aggregation/agg_result.rs
+++ b/src/aggregation/agg_result.rs
@@ -195,7 +195,8 @@ pub enum BucketEntries<T> {
 }
 
 impl<T> BucketEntries<T> {
-    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
+    /// Iterate over all bucket entries.
+    pub fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = &'a T> + 'a> {
         match self {
             BucketEntries::Vec(vec) => Box::new(vec.iter()),
             BucketEntries::HashMap(map) => Box::new(map.values()),

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -107,8 +107,10 @@ pub enum PercentileValues {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// The entry when requesting percentiles with keyed: false
 pub struct PercentileValuesVecEntry {
-    key: f64,
-    value: f64,
+    /// The percentile key (e.g. 1.0, 5.0, 25.0).
+    pub key: f64,
+    /// The percentile value. `NaN` when there are no values.
+    pub value: f64,
 }
 
 /// Single-metric aggregations use this common result structure.

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -513,7 +513,9 @@ pub struct TopNComputer<Score, D, C> {
     /// The buffer reverses sort order to get top-semantics instead of bottom-semantics
     buffer: Vec<ComparableDoc<Score, D>>,
     top_n: usize,
-    pub(crate) threshold: Option<Score>,
+    /// The current threshold for pruning. Documents with scores at or below
+    /// this value are skipped by `push()`. Updated when the buffer is truncated.
+    pub threshold: Option<Score>,
     comparator: C,
 }
 


### PR DESCRIPTION
## Summary
- Make `BucketEntries::iter()` public for iterating aggregation bucket results
- Make `PercentileValuesVecEntry.key` and `.value` fields public for reading percentile results  
- Make `TopNComputer.threshold` public for Block-WAND score pruning in the inverted index provider

These visibility changes are needed by the [tantivy-datafusion](https://github.com/quickwit-oss/tantivy-datafusion) crate, which provides a DataFusion integration for tantivy search indices.

## Test plan
- [x] `cargo check` passes
- [x] No behavioral changes — only visibility modifiers updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)