### PR TITLE
Tighten Block-Max in single-scorer

### DIFF
--- a/src/query/boolean_query/block_wand.rs
+++ b/src/query/boolean_query/block_wand.rs
@@ -228,7 +228,7 @@ pub fn block_wand_single_scorer(
     loop {
         // We position the scorer on a block that can reach
         // the threshold.
-        while scorer.block_max_score() < threshold {
+        while scorer.block_max_score() <= threshold {
             let last_doc_in_block = scorer.last_doc_in_block();
             if last_doc_in_block == TERMINATED {
                 return;


### PR DESCRIPTION
In the Block-Max WAND single-scorer, it uses `block_max_score() < threshold`, whereas the multi-term one uses  `block_max_score_upperbound <= threshold`.

As both of these are guarded later on with if s`core > threshold `we can use the more efficient form in single-scorer.

- [Single-scorer block skip (<, should be <=)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L231)
- [Multi-scorer block skip (already <=)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L179)
- [Single-scorer per-doc guard (>)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L246)
- [Multi-scorer per-doc guard (>)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L206_)

This will improve performance when there are many identical scores.