### PR TITLE
Optimize single term BooleanQuery to use BMW

### DIFF
--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -519,6 +519,17 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
+        // When there is a single include clause, delegate directly to the child
+        // weight's for_each_pruning. This ensures that e.g. a BooleanQuery
+        // wrapping a single TermQuery still benefits from block-max WAND
+        // pruning (via TermWeight::for_each_pruning), rather than falling
+        // through to the generic for_each_pruning_scorer loop.
+        if self.scoring_enabled && self.weights.len() == 1 {
+            let (occur, weight) = &self.weights[0];
+            if is_include_occur(*occur) {
+                return weight.for_each_pruning(threshold, reader, callback);
+            }
+        }
         let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
         match scorer {
             SpecializedScorer::TermUnion(term_scorers) => {


### PR DESCRIPTION
When there is a single term, delegate directly to the child weight's `for_each_pruning`. This ensures that a `BooleanQuery` wrapping a single `TermQuery` still benefits from block-max WAND pruning (via `TermWeight::for_each_pruning`), rather than falling through to the generic f`or_each_pruning_scorer` loop.

This isn't hit in Tantivy proper (single term queries are always collapsed to `TermQuery`, but is in pg_search using the `|||` operator, and could be by other future implementations.

If this isn't desired in Tantivy we are happy to just fix in `pg_search` by collapsing in the same way, but it feels like a bit of a footgun atm.