### PR TITLE
Update binggan requirement from 0.16.0 to 0.16.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ typetag = "0.2.21"
 winapi = "0.3.9"
 
 [dev-dependencies]
-binggan = "0.16.0"
+binggan = "0.16.1"
 rand = "0.9"
 maplit = "1.0.2"
 matches = "0.1.9"

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -23,7 +23,7 @@ downcast-rs = "2.0.1"
 proptest = "1"
 more-asserts = "0.3.1"
 rand = "0.9"
-binggan = "0.16.0"
+binggan = "0.16.1"
 
 [[bench]]
 name = "bench_merge"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -19,6 +19,6 @@ time = { version = "0.3.47", features = ["serde-well-known"] }
 serde = { version = "1.0.136", features = ["derive"] }
 
 [dev-dependencies]
-binggan = "0.16.0"
+binggan = "0.16.1"
 proptest = "1.0.0"
 rand = "0.9"

--- a/stacker/Cargo.toml
+++ b/stacker/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.9"
 zipf = "7.0.0"
 rustc-hash = "2.1.0"
 proptest = "1.2.0"
-binggan = { version = "0.16.0" }
+binggan = { version = "0.16.1" }
 rand_distr = "0.5"
 
 [features]


### PR DESCRIPTION
## Summary
- Bumps `binggan` dev-dependency from 0.16.0 to 0.16.1 across all subcrates (`tantivy`, `tantivy-common`, `tantivy-columnar`, `tantivy-stacker`)

## Test plan
- [ ] CI passes with the updated dependency