### PR TITLE
Refactor tests from more_asserts crate to assertables crate

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo test *)",
+      "Bash(cargo search *)",
+      "Bash(cargo build *)"
+    ]
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.86"
 exclude = ["benches/*.json", "benches/*.txt"]
 
 [dependencies]
+assertables = "10.0.0"
 oneshot = "0.1.13"
 base64 = "0.22.0"
 byteorder = "1.4.3"

--- a/benches/merge_segments.rs
+++ b/benches/merge_segments.rs
@@ -5,6 +5,7 @@
 // - Output is written to a `NullDirectory` that discards all files except
 //  fieldnorms (needed for merging).
 
+use assertables::assert_gt;
 use std::collections::HashMap;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -153,7 +154,7 @@ fn build_index(
     let schema = schema_builder.build();
     let index = Index::create_in_ram(schema.clone());
 
-    assert!(vocab_size > 0);
+    assert_gt!(vocab_size, 0);
     let total_tokens = num_segments * docs_per_segment * tokens_per_doc;
     let use_unique_terms = vocab_size >= total_tokens;
     let mut rng = StdRng::from_seed([7u8; 32]);

--- a/bitpacker/Cargo.toml
+++ b/bitpacker/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://github.com/quickwit-oss/tantivy"
 
 [dependencies]
 bitpacking = { version = "0.9.2", default-features = false, features = ["bitpacker1x"] }
+assertables = "10"
 
 [dev-dependencies]
 rand = "0.9"

--- a/bitpacker/src/bitpacker.rs
+++ b/bitpacker/src/bitpacker.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::ops::{Range, RangeInclusive};
 
 use bitpacking::{BitPacker as ExternalBitPackerTrait, BitPacker1x};
+use assertables::{assert_le, debug_assert_lt};
 
 pub struct BitPacker {
     mini_buffer: u64,
@@ -115,7 +116,7 @@ impl BitUnpacker {
         let mut bytes: [u8; 8] = [0u8; 8];
         let available_bytes = data.len() - addr;
         // This function is meant to only be called if we did not have 8 bytes to load.
-        debug_assert!(available_bytes < 8);
+        debug_assert_lt!(available_bytes, 8);
         bytes[..available_bytes].copy_from_slice(&data[addr..]);
         let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
         let val_shifted = val_unshifted_unmasked >> bit_shift;
@@ -129,8 +130,8 @@ impl BitUnpacker {
     //
     // This methods panics if `num_bits` is > 32.
     fn get_batch_u32s(&self, start_idx: u32, data: &[u8], output: &mut [u32]) {
-        assert!(
-            self.bit_width() <= 32,
+        assert_le!(
+            self.bit_width(), 32,
             "Bitwidth must be <= 32 to use this method."
         );
 
@@ -139,8 +140,8 @@ impl BitUnpacker {
         // We use `usize` here to avoid overflow issues.
         let end_bit_read = (end_idx as usize) * self.num_bits;
         let end_byte_read = end_bit_read.div_ceil(8);
-        assert!(
-            end_byte_read <= data.len(),
+        assert_le!(
+            end_byte_read, data.len(),
             "Requested index is out of bounds."
         );
 
@@ -312,7 +313,7 @@ mod test {
             (1u64 << num_bits) - 1
         };
         for (i, val) in vals.iter().copied().enumerate() {
-            assert!(val <= max_val);
+            assert_le!(val, max_val);
             assert_eq!(bitunpacker.get(i as u32, &buffer), val);
         }
     }

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["database-implementations", "data-structures", "compression"]
 [dependencies]
 itertools = "0.14.0"
 fastdivide = "0.4.0"
+assertables = "10.0.0"
 
 stacker = { version= "0.7", path = "../stacker", package="tantivy-stacker"}
 sstable = { version= "0.7", path = "../sstable", package = "tantivy-sstable" }
@@ -20,8 +21,8 @@ serde = "1.0.152"
 downcast-rs = "2.0.1"
 
 [dev-dependencies]
+assertables = "10.0.0"
 proptest = "1"
-more-asserts = "0.3.1"
 rand = "0.9"
 binggan = "0.17.0"
 

--- a/columnar/columnar-cli-inspect/Cargo.toml
+++ b/columnar/columnar-cli-inspect/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT"
 tantivy = {path="../..", package="tantivy"}
 columnar = {path="../", package="tantivy-columnar"}
 common = {path="../../common", package="tantivy-common"}
+assertables = "10.0.0"
 
 [workspace]
 members = []

--- a/columnar/columnar-cli-inspect/src/main.rs
+++ b/columnar/columnar-cli-inspect/src/main.rs
@@ -1,3 +1,4 @@
+use assertables::assert_lt;
 use columnar::ColumnarReader;
 use common::file_slice::{FileSlice, WrapFile};
 use std::io;
@@ -36,7 +37,7 @@ pub fn validate_columnar_reader(reader: &ColumnarReader) {
                 let max_ord = str_column.ords().values.iter().max().unwrap_or_default();
                 println!("{col_name:35}  num_vals {num_vals:10} \t num_terms_dict {num_terms_dict:8} max_ord: {max_ord:8}",);
                 for ord in str_column.ords().values.iter() {
-                    assert!(ord < num_terms_dict);
+                    assert_lt!(ord, num_terms_dict);
                 }
             }
         }

--- a/columnar/src/column_index/multivalued_index.rs
+++ b/columnar/src/column_index/multivalued_index.rs
@@ -124,7 +124,7 @@ impl MultiValueIndexV1 {
         let mut cur_doc = docid_start;
         let mut last_doc = None;
 
-        assert!(self.start_index_column.get_val(docid_start) <= ranks[0]);
+        assert_le!(self.start_index_column.get_val(docid_start), ranks[0]);
 
         let mut write_doc_pos = 0;
         for i in 0..ranks.len() {

--- a/columnar/src/column_index/optional_index/mod.rs
+++ b/columnar/src/column_index/optional_index/mod.rs
@@ -422,7 +422,7 @@ impl SerializedBlockMeta {
 
     #[inline]
     fn to_bytes(self) -> [u8; SERIALIZED_BLOCK_META_NUM_BYTES] {
-        assert!(self.num_non_null_rows > 0);
+        assert_gt!(self.num_non_null_rows, 0);
         let mut bytes = [0u8; SERIALIZED_BLOCK_META_NUM_BYTES];
         bytes[0..2].copy_from_slice(&self.block_id.to_le_bytes());
         // We don't store empty blocks, therefore we can subtract 1.

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -63,7 +63,7 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     ///
     /// May panic if `idx` is greater than the column length.
     fn get_vals(&self, indexes: &[u32], output: &mut [T]) {
-        assert!(indexes.len() == output.len());
+        assert_eq!(indexes.len(), output.len());
         let out_and_idx_chunks = output.chunks_exact_mut(4).zip(indexes.chunks_exact(4));
         for (out_x4, idx_x4) in out_and_idx_chunks {
             out_x4[0] = self.get_val(idx_x4[0]);
@@ -91,7 +91,7 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     ///
     /// May panic if `idx` is greater than the column length.
     fn get_vals_opt(&self, indexes: &[u32], output: &mut [Option<T>]) {
-        assert!(indexes.len() == output.len());
+        assert_eq!(indexes.len(), output.len());
         let out_and_idx_chunks = output.chunks_exact_mut(4).zip(indexes.chunks_exact(4));
         for (out_x4, idx_x4) in out_and_idx_chunks {
             out_x4[0] = Some(self.get_val(idx_x4[0]));

--- a/columnar/src/column_values/u128_based/compact_space/build_compact_space.rs
+++ b/columnar/src/column_values/u128_based/compact_space/build_compact_space.rs
@@ -126,7 +126,7 @@ pub fn get_compact_space(
         compact_space_builder.add_blanks(blank_collector.drain().map(|blank| blank.blank_range()));
     }
 
-    assert!(amplitude_bits <= 32);
+    assert_le!(amplitude_bits, 32);
 
     // special case, when we don't collected any blanks because:
     // * the data is empty (early exit)
@@ -247,6 +247,6 @@ mod tests {
     fn test_worst_case_scenario() {
         let vals: BTreeSet<u128> = (0..8).map(|i| i * ((1u128 << 34) / 8)).collect();
         let compact_space = get_compact_space(&vals, vals.len() as u32, COST_PER_BLANK_IN_BITS);
-        assert!(compact_space.amplitude_compact_space() < u32::MAX as u128);
+        assert_lt!(compact_space.amplitude_compact_space(), u32::MAX as u128);
     }
 }

--- a/columnar/src/column_values/u128_based/compact_space/mod.rs
+++ b/columnar/src/column_values/u128_based/compact_space/mod.rs
@@ -191,8 +191,8 @@ impl CompactSpaceCompressor {
             get_compact_space(&values_sorted, total_num_values, COST_PER_BLANK_IN_BITS);
         let amplitude_compact_space = compact_space.amplitude_compact_space();
 
-        assert!(
-            amplitude_compact_space <= u64::MAX as u128,
+        assert_le!(
+            amplitude_compact_space, u64::MAX as u128,
             "case unsupported."
         );
 
@@ -403,7 +403,7 @@ impl ColumnValues<u128> for CompactSpaceDecompressor {
         let position_range = position_range.start..position_range.end.min(self.num_vals());
         let from_value = *value_range.start();
         let to_value = *value_range.end();
-        assert!(to_value >= from_value);
+        assert_ge!(to_value, from_value);
         let compact_from = self.u128_to_compact(from_value);
         let compact_to = self.u128_to_compact(to_value);
 

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -35,7 +35,7 @@ fn test_empty_column_i64() {
         assert_eq!(col.min_value(), i64::MIN);
         assert_eq!(col.max_value(), i64::MIN);
     }
-    assert!(num_acceptable_codecs > 0);
+    assert_gt!(num_acceptable_codecs, 0);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_empty_column_u64() {
         assert_eq!(col.min_value(), u64::MIN);
         assert_eq!(col.max_value(), u64::MIN);
     }
-    assert!(num_acceptable_codecs > 0);
+    assert_gt!(num_acceptable_codecs, 0);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn test_empty_column_f64() {
         assert!(col.min_value().is_nan());
         assert!(col.max_value().is_nan());
     }
-    assert!(num_acceptable_codecs > 0);
+    assert_gt!(num_acceptable_codecs, 0);
 }
 
 pub(crate) fn create_and_validate<TColumnCodec: ColumnCodec>(
@@ -344,7 +344,7 @@ fn test_fastfield_gcd_i64_with_codec(codec_type: CodecType, num_vals: usize) -> 
         &mut buffer_without_gcd,
     )?;
     let buffer_without_gcd = OwnedBytes::new(buffer_without_gcd);
-    assert!(buffer_without_gcd.len() > buffer.len());
+    assert_len_gt!(buffer_without_gcd, buffer);
 
     Ok(())
 }
@@ -387,7 +387,7 @@ fn test_fastfield_gcd_u64_with_codec(codec_type: CodecType, num_vals: usize) -> 
         &mut buffer_without_gcd,
     )?;
     let buffer_without_gcd = OwnedBytes::new(buffer_without_gcd);
-    assert!(buffer_without_gcd.len() > buffer.len());
+    assert_len_gt!(buffer_without_gcd, buffer);
     Ok(())
 }
 

--- a/columnar/src/columnar/merge/tests.rs
+++ b/columnar/src/columnar/merge/tests.rs
@@ -305,7 +305,7 @@ fn test_merge_columnar_byte() {
 
     let get_bytes_for_row = |row_id| {
         let term_ords: Vec<u64> = vals.term_ords(row_id).collect();
-        assert!(term_ords.len() <= 1);
+        assert_le!(term_ords.len(), 1);
         let mut out = Vec::new();
         if term_ords.len() == 1 {
             vals.ord_to_bytes(term_ords[0], &mut out).unwrap();

--- a/columnar/src/columnar/writer/column_operation.rs
+++ b/columnar/src/columnar/writer/column_operation.rs
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(decode_zig_zag(encoded), val);
         if let Some(abs_val) = val.checked_abs() {
             let abs_val = abs_val as u64;
-            assert!(encoded <= abs_val * 2);
+            assert_le!(encoded, abs_val * 2);
         }
     }
 

--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -17,9 +17,8 @@
 //!       column.
 //!     - [column_values]: Stores the values of a column in a dense format.
 
-#[cfg(test)]
 #[macro_use]
-extern crate more_asserts;
+extern crate assertables;
 
 use std::fmt::Display;
 use std::io;

--- a/columnar/src/utils.rs
+++ b/columnar/src/utils.rs
@@ -9,8 +9,8 @@ const fn compute_mask(num_bits: u8) -> u8 {
 #[inline(always)]
 #[must_use]
 pub(crate) fn select_bits<const START: u8, const END: u8>(code: u8) -> u8 {
-    assert!(START <= END);
-    assert!(END <= 8);
+    assert_le!(START, END);
+    assert_le!(END, 8);
     let num_bits: u8 = END - START;
     let mask: u8 = compute_mask(num_bits);
     (code >> START) & mask
@@ -19,11 +19,11 @@ pub(crate) fn select_bits<const START: u8, const END: u8>(code: u8) -> u8 {
 #[inline(always)]
 #[must_use]
 pub(crate) fn place_bits<const START: u8, const END: u8>(code: u8) -> u8 {
-    assert!(START <= END);
-    assert!(END <= 8);
+    assert_le!(START, END);
+    assert_le!(END, 8);
     let num_bits: u8 = END - START;
     let mask: u8 = compute_mask(num_bits);
-    assert!(code <= mask);
+    assert_le!(code, mask);
     code << START
 }
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,6 +17,7 @@ ownedbytes = { version= "0.9", path="../ownedbytes" }
 async-trait = "0.1"
 time = { version = "0.3.47", features = ["serde-well-known"] }
 serde = { version = "1.0.136", features = ["derive"] }
+assertables = "10.0.0"
 
 [dev-dependencies]
 binggan = "0.17.0"

--- a/common/src/bitset.rs
+++ b/common/src/bitset.rs
@@ -603,7 +603,7 @@ mod tests {
             let mut hashset: HashSet<u32> = HashSet::new();
             let mut bitset = BitSet::with_max_value(max_value);
             for &el in els {
-                assert!(el < max_value);
+                assert_lt!(el, max_value);
                 hashset.insert(el);
                 bitset.insert(el);
             }

--- a/common/src/file_slice.rs
+++ b/common/src/file_slice.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::{fmt, io};
 
+use assertables::{assert_ge, assert_le};
 use async_trait::async_trait;
 use ownedbytes::{OwnedBytes, StableDeref};
 
@@ -166,14 +167,14 @@ fn combine_ranges<R: RangeBounds<usize>>(orig_range: Range<usize>, rel_range: R)
             std::ops::Bound::Excluded(rel_start) => rel_start + 1,
             std::ops::Bound::Unbounded => 0,
         };
-    assert!(start <= orig_range.end);
+    assert_le!(start, orig_range.end);
     let end: usize = match rel_range.end_bound().cloned() {
         std::ops::Bound::Included(rel_end) => orig_range.start + rel_end + 1,
         std::ops::Bound::Excluded(rel_end) => orig_range.start + rel_end,
         std::ops::Bound::Unbounded => orig_range.end,
     };
-    assert!(end >= start);
-    assert!(end <= orig_range.end);
+    assert_ge!(end, start);
+    assert_le!(end, orig_range.end);
     start..end
 }
 
@@ -239,8 +240,8 @@ impl FileSlice {
     ///
     /// This is equivalent to running `file_slice.slice(from, to).read_bytes()`.
     pub fn read_bytes_slice(&self, range: Range<usize>) -> io::Result<OwnedBytes> {
-        assert!(
-            range.end <= self.len(),
+        assert_le!(
+            range.end, self.len(),
             "end of requested range exceeds the fileslice length ({} > {})",
             range.end,
             self.len()
@@ -251,8 +252,8 @@ impl FileSlice {
 
     #[doc(hidden)]
     pub async fn read_bytes_slice_async(&self, byte_range: Range<usize>) -> io::Result<OwnedBytes> {
-        assert!(
-            self.range.start + byte_range.end <= self.range.end,
+        assert_le!(
+            self.range.start + byte_range.end, self.range.end,
             "`to` exceeds the fileslice length"
         );
         self.data

--- a/query-grammar/src/lib.rs
+++ b/query-grammar/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_parse_query_lenient_wrong_query() {
         let (_, errors) = parse_query_lenient("title:");
-        assert!(errors.len() == 1);
+        assert_eq!(errors.len(), 1);
         let json = serde_json::to_string(&errors).unwrap();
         assert_eq!(json, r#"[{"pos":6,"message":"expected word"}]"#);
     }

--- a/src/aggregation/bucket/composite/numeric_types.rs
+++ b/src/aggregation/bucket/composite/numeric_types.rs
@@ -415,8 +415,8 @@ mod num_proj_tests {
         assert_eq!(large_i64 as f64, closest_f64);
         if let ProjectedNumber::Next(val) = num_proj::i64_to_f64(large_i64) {
             // Verify that the returned float is different from the direct cast
-            assert!(val > closest_f64);
-            assert!(val - closest_f64 < 2. * f64::EPSILON * closest_f64);
+            assert_gt!(val, closest_f64);
+            assert_lt!(val - closest_f64, 2. * f64::EPSILON * closest_f64);
         } else {
             panic!("Expected ProjectedNumber::Next for large_i64");
         }
@@ -451,8 +451,8 @@ mod num_proj_tests {
         assert_eq!(large_u64 as f64, closest_f64);
         if let ProjectedNumber::Next(val) = num_proj::u64_to_f64(large_u64) {
             // Verify that the returned float is different from the direct cast
-            assert!(val > closest_f64);
-            assert!(val - closest_f64 < 2. * f64::EPSILON * closest_f64);
+            assert_gt!(val, closest_f64);
+            assert_lt!(val - closest_f64, 2. * f64::EPSILON * closest_f64);
         } else {
             panic!("Expected ProjectedNumber::Next for large_u64");
         }

--- a/src/aggregation/bucket/term_agg.rs
+++ b/src/aggregation/bucket/term_agg.rs
@@ -665,8 +665,8 @@ impl TermAggregationMap for VecTermBucketsNoAgg {
     #[inline(always)]
     fn term_entry(&mut self, term_id: u64, _bucket_id_provider: &mut BucketIdProvider) -> BucketId {
         let term_id_usize = term_id as usize;
-        debug_assert!(
-            term_id_usize < self.buckets.len(),
+        debug_assert_lt!(
+            term_id_usize, self.buckets.len(),
             "term_id {} out of bounds for VecTermBuckets (len={})",
             term_id,
             self.buckets.len()
@@ -722,8 +722,8 @@ impl TermAggregationMap for VecTermBuckets {
     #[inline(always)]
     fn term_entry(&mut self, term_id: u64, _bucket_id_provider: &mut BucketIdProvider) -> BucketId {
         let term_id_usize = term_id as usize;
-        debug_assert!(
-            term_id_usize < self.buckets.len(),
+        debug_assert_lt!(
+            term_id_usize, self.buckets.len(),
             "term_id {} out of bounds for VecTermBuckets (len={})",
             term_id,
             self.buckets.len()

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -1255,7 +1255,7 @@ mod tests {
 
         let bytes = collector.to_sketch_bytes();
         let deserialized = HllSketch::deserialize(&bytes).unwrap();
-        assert!((deserialized.estimate() - 3.0).abs() < 0.01);
+        assert_lt!((deserialized.estimate() - 3.0).abs(), 0.01);
     }
 
     /// Tests that the `missing` parameter correctly counts a single empty document

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -338,7 +338,7 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
 mod tests {
 
     use itertools::Itertools;
-    use more_asserts::{assert_ge, assert_le};
+    use assertables::{assert_ge, assert_le};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use serde_json::Value;

--- a/src/aggregation/metric/top_hits.rs
+++ b/src/aggregation/metric/top_hits.rs
@@ -715,17 +715,17 @@ mod tests {
             order: Order::Asc,
         };
 
-        assert!(small < big);
-        assert!(none < small);
-        assert!(none < big);
+        assert_lt!(small, big);
+        assert_lt!(none, small);
+        assert_lt!(none, big);
 
         let small = invert_order(small);
         let big = invert_order(big);
         let none = invert_order(none);
 
-        assert!(small > big);
-        assert!(none < small);
-        assert!(none < big);
+        assert_gt!(small, big);
+        assert_lt!(none, small);
+        assert_lt!(none, big);
 
         Ok(())
     }
@@ -748,9 +748,9 @@ mod tests {
             doc_value_fields: Default::default(),
         };
 
-        assert!(features_1 < features_2);
+        assert_lt!(features_1, features_2);
 
-        assert!(invert_order_features(features_1.clone()) > invert_order_features(features_2));
+        assert_gt!(invert_order_features(features_1.clone()), invert_order_features(features_2));
 
         Ok(())
     }

--- a/src/collector/sort_key/sort_by_erased_type.rs
+++ b/src/collector/sort_key/sort_by_erased_type.rs
@@ -407,7 +407,7 @@ mod tests {
             .collect();
 
         assert_eq!(values.len(), 2);
-        assert!(values[0] > values[1]);
+        assert_gt!(values[0], values[1]);
 
         // Sort by score ascending (ReverseNoneLower)
         let collector = TopDocs::with_limit(10).order_by((
@@ -425,6 +425,6 @@ mod tests {
             .collect();
 
         assert_eq!(values.len(), 2);
-        assert!(values[0] < values[1]);
+        assert_lt!(values[0], values[1]);
     }
 }

--- a/src/collector/top_score_collector.rs
+++ b/src/collector/top_score_collector.rs
@@ -688,7 +688,7 @@ where
 #[inline(always)]
 fn push_assuming_capacity<T>(el: T, buf: &mut Vec<T>) {
     let prev_len = buf.len();
-    assert!(prev_len < buf.capacity());
+    assert_lt!(prev_len, buf.capacity());
     // This is mimicking the current (non-stabilized) implementation in std.
     // SAFETY: we just checked we have enough capacity.
     unsafe {

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -223,8 +223,8 @@ mod tests {
 
         let counter_val = counter.load(Ordering::SeqCst);
         let other_counter_val = other_counter.load(Ordering::SeqCst);
-        assert!(counter_val >= 30);
-        assert!(other_counter_val >= 30);
+        assert_ge!(counter_val, 30);
+        assert_ge!(other_counter_val, 30);
 
         drop(other_futures);
 
@@ -234,9 +234,9 @@ mod tests {
         }
 
         let counter_val2 = counter.load(Ordering::SeqCst);
-        assert!(counter_val2 >= counter_val + 100 - 6);
+        assert_ge!(counter_val2, counter_val + 100 - 6);
 
         let other_counter_val2 = other_counter.load(Ordering::SeqCst);
-        assert!(other_counter_val2 <= other_counter_val + 6);
+        assert_le!(other_counter_val2, other_counter_val + 6);
     }
 }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -268,8 +268,8 @@ fn garbage_collect_works_as_intended() -> crate::Result<()> {
     let searcher = reader.searcher();
     assert_eq!(searcher.segment_readers().len(), 1);
     assert_eq!(searcher.num_docs(), 8_000);
-    assert!(
-        mem_right_after_merge_finished < mem_right_after_commit,
+    assert_lt!(
+        mem_right_after_merge_finished, mem_right_after_commit,
         "(mem after merge){mem_right_after_merge_finished} is expected < (mem before \
          merge){mem_right_after_commit}"
     );

--- a/src/directory/mmap_directory/mod.rs
+++ b/src/directory/mmap_directory/mod.rs
@@ -674,7 +674,7 @@ mod tests {
 
             reader.reload().unwrap();
             let num_segments = reader.searcher().segment_readers().len();
-            assert!(num_segments <= 4);
+            assert_le!(num_segments, 4);
             let num_components_except_deletes_and_tempstore =
                 crate::index::SegmentComponent::iterator().len() - 1;
             let max_num_mmapped = num_components_except_deletes_and_tempstore * num_segments;

--- a/src/fieldnorm/mod.rs
+++ b/src/fieldnorm/mod.rs
@@ -115,10 +115,10 @@ mod tests {
         let weight = query.weight(EnableScoring::enabled_from_searcher(&searcher))?;
         let mut scorer = weight.scorer(searcher.segment_reader(0), 1.0f32)?;
         assert_eq!(scorer.doc(), 0);
-        assert!((scorer.score() - 0.22920431).abs() < 0.001f32);
+        assert_lt!((scorer.score() - 0.22920431).abs(), 0.001f32);
         assert_eq!(scorer.advance(), 1);
         assert_eq!(scorer.doc(), 1);
-        assert!((scorer.score() - 0.22920431).abs() < 0.001f32);
+        assert_lt!((scorer.score() - 0.22920431).abs(), 0.001f32);
         assert_eq!(scorer.advance(), TERMINATED);
         Ok(())
     }
@@ -144,10 +144,10 @@ mod tests {
         let weight = query.weight(EnableScoring::enabled_from_searcher(&searcher))?;
         let mut scorer = weight.scorer(searcher.segment_reader(0), 1.0f32)?;
         assert_eq!(scorer.doc(), 0);
-        assert!((scorer.score() - 0.22920431).abs() < 0.001f32);
+        assert_lt!((scorer.score() - 0.22920431).abs(), 0.001f32);
         assert_eq!(scorer.advance(), 1);
         assert_eq!(scorer.doc(), 1);
-        assert!((scorer.score() - 0.15136132).abs() < 0.001f32);
+        assert_lt!((scorer.score() - 0.15136132).abs(), 0.001f32);
         assert_eq!(scorer.advance(), TERMINATED);
         Ok(())
     }

--- a/src/functional_test.rs
+++ b/src/functional_test.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 use crate::{doc, schema, Index, IndexWriter, Searcher};
 
 fn check_index_content(searcher: &Searcher, vals: &[u64]) -> crate::Result<()> {
-    assert!(searcher.segment_readers().len() < 20);
+    assert_lt!(searcher.segment_readers().len(), 20);
     assert_eq!(searcher.num_docs() as usize, vals.len());
     for segment_reader in searcher.segment_readers() {
         let store_reader = segment_reader.get_store_reader(1)?;

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -166,8 +166,8 @@ impl SegmentMeta {
     #[doc(hidden)]
     #[must_use]
     pub fn with_delete_meta(self, num_deleted_docs: u32, opstamp: Opstamp) -> SegmentMeta {
-        assert!(
-            num_deleted_docs <= self.max_doc(),
+        assert_le!(
+            num_deleted_docs, self.max_doc(),
             "There cannot be more deleted docs than there are docs."
         );
         let delete_meta = DeleteMeta {

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -209,7 +209,7 @@ fn index_documents<D: Document>(
 
     // this is ensured by the call to peek before starting
     // the worker thread.
-    assert!(max_doc > 0);
+    assert_gt!(max_doc, 0);
 
     let doc_opstamps: Vec<Opstamp> = segment_writer.finalize()?;
 
@@ -1174,7 +1174,7 @@ mod tests {
         index_writer.wait_merging_threads()?;
         reader.reload()?;
         assert_eq!(num_docs_containing("a"), 200);
-        assert!(index.searchable_segments()?.len() < 8);
+        assert_lt!(index.searchable_segments()?.len(), 8);
         Ok(())
     }
 
@@ -1295,7 +1295,7 @@ mod tests {
         let first_commit = index_writer.commit();
         assert!(first_commit.is_ok());
         let first_commit_tstamp = first_commit.unwrap();
-        assert!(first_commit_tstamp > add_tstamp);
+        assert_gt!(first_commit_tstamp, add_tstamp);
 
         // delete_all_documents the index
         let clear_tstamp = index_writer.delete_all_documents().unwrap();

--- a/src/indexer/merger.rs
+++ b/src/indexer/merger.rs
@@ -1576,7 +1576,7 @@ mod tests {
     #[test]
     fn test_max_doc() {
         // this is the first time I write a unit test for a constant.
-        assert!(((super::MAX_DOC_LIMIT - 1) as i32) >= 0);
-        assert!((super::MAX_DOC_LIMIT as i32) < 0);
+        assert_ge!(((super::MAX_DOC_LIMIT - 1) as i32), 0);
+        assert_lt!((super::MAX_DOC_LIMIT as i32), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,9 @@ extern crate log;
 #[macro_use]
 extern crate thiserror;
 
+#[macro_use]
+extern crate assertables;
+
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
 

--- a/src/postings/block_search.rs
+++ b/src/postings/block_search.rs
@@ -49,10 +49,10 @@ mod tests {
 
     fn util_test_search_in_block(block: &[u32], target: u32) {
         let cursor = search_in_block_trivial_but_slow(block, target);
-        assert!(cursor < COMPRESSION_BLOCK_SIZE);
-        assert!(block[cursor] >= target);
+        assert_lt!(cursor, COMPRESSION_BLOCK_SIZE);
+        assert_ge!(block[cursor], target);
         if cursor > 0 {
-            assert!(block[cursor - 1] < target);
+            assert_lt!(block[cursor - 1], target);
         }
         assert_eq!(block.len(), COMPRESSION_BLOCK_SIZE);
         let mut output_buffer = [TERMINATED; COMPRESSION_BLOCK_SIZE];

--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -525,8 +525,8 @@ mod tests {
         for i in &[0, 424, 10000] {
             block_postings.seek(*i);
             let docs = block_postings.docs();
-            assert!(docs[0] <= *i);
-            assert!(docs.last().cloned().unwrap_or(0u32) >= *i);
+            assert_le!(docs[0], *i);
+            assert_ge!(docs.last().cloned().unwrap_or(0u32), *i);
         }
         block_postings.seek(100_000);
         assert_eq!(block_postings.doc(COMPRESSION_BLOCK_SIZE - 1), TERMINATED);

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -363,7 +363,7 @@ pub(crate) mod tests {
         let input: Vec<u32> = (0u32..123u32).map(|i| 4 + i * 7 / 2).collect();
         for offset in &[0u32, 1u32, 2u32] {
             let encoded_data = encoder.compress_vint_sorted(&input, *offset);
-            assert!(encoded_data.len() <= expected_length);
+            assert_lt!(encoded_data.len(), expected_length);
             let mut decoder = BlockDecoder::default();
             let consumed_num_bytes =
                 decoder.uncompress_vint_sorted(encoded_data, *offset, input.len(), PADDING_VALUE);

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -428,7 +428,7 @@ pub(crate) mod tests {
                 .unwrap();
 
             for i in 0..num_docs / 2 - 1 {
-                assert!(segment_postings.seek(i * 2 + 1) > i * 2);
+                assert_gt!(segment_postings.seek(i * 2 + 1), i * 2);
                 assert_eq!(segment_postings.doc(), (i + 1) * 2);
             }
         }
@@ -550,7 +550,7 @@ pub(crate) mod tests {
                 skip_result_unopt, skip_result_opt,
                 "Failed while skipping to {target}"
             );
-            assert!(skip_result_opt >= target);
+            assert_ge!(skip_result_opt, target);
             assert_eq!(skip_result_opt, postings_opt.doc());
             if skip_result_opt == TERMINATED {
                 return;

--- a/src/postings/skip.rs
+++ b/src/postings/skip.rs
@@ -14,8 +14,8 @@ use crate::{DocId, Score, TERMINATED};
 //   (requiring a 6th bit), but the biggest doc_id we can want to encode is TERMINATED-1, which can
 //   be represented on 31b without delta encoding.
 fn encode_bitwidth(bitwidth: u8, delta_1: bool) -> u8 {
-    assert!(
-        bitwidth < 32,
+    assert_lt!(
+        bitwidth, 32,
         "bitwidth needs to be less than 32, but got {}",
         bitwidth
     );

--- a/src/postings/term_info.rs
+++ b/src/postings/term_info.rs
@@ -18,13 +18,13 @@ pub struct TermInfo {
 impl TermInfo {
     pub(crate) fn posting_num_bytes(&self) -> u32 {
         let num_bytes = self.postings_range.len();
-        assert!(num_bytes <= u32::MAX as usize);
+        assert_le!(num_bytes, u32::MAX as usize);
         num_bytes as u32
     }
 
     pub(crate) fn positions_num_bytes(&self) -> u32 {
         let num_bytes = self.positions_range.len();
-        assert!(num_bytes <= u32::MAX as usize);
+        assert_le!(num_bytes, u32::MAX as usize);
         num_bytes as u32
     }
 }

--- a/src/query/bm25.rs
+++ b/src/query/bm25.rs
@@ -50,7 +50,7 @@ impl Bm25StatisticsProvider for Searcher {
 }
 
 pub(crate) fn idf(doc_freq: u64, doc_count: u64) -> Score {
-    assert!(doc_count >= doc_freq, "{doc_count} >= {doc_freq}");
+    assert_ge!(doc_count, doc_freq, "{doc_count} >= {doc_freq}");
     let x = ((doc_count - doc_freq) as Score + 0.5) / (doc_freq as Score + 0.5);
     (1.0 + x).ln()
 }

--- a/src/query/boolean_query/block_wand_union.rs
+++ b/src/query/boolean_query/block_wand_union.rs
@@ -166,7 +166,7 @@ pub fn block_wand(
     {
         debug_assert!(scorers.iter().map(|scorer| scorer.doc()).is_sorted());
         debug_assert_ne!(pivot_doc, TERMINATED);
-        debug_assert!(before_pivot_len < pivot_len);
+        debug_assert_lt!(before_pivot_len, pivot_len);
 
         let block_max_score_upperbound: Score = scorers[..pivot_len]
             .iter_mut()

--- a/src/query/intersection.rs
+++ b/src/query/intersection.rs
@@ -85,7 +85,7 @@ impl<TDocSet: DocSet> Intersection<TDocSet, TDocSet> {
         segment_num_docs: u32,
     ) -> Intersection<TDocSet, TDocSet> {
         let num_docsets = docsets.len();
-        assert!(num_docsets >= 2);
+        assert_ge!(num_docsets, 2);
         docsets.sort_by_key(|docset| docset.cost());
         go_to_first_doc(&mut docsets);
         let left = docsets.remove(0);

--- a/src/query/phrase_query/phrase_query.rs
+++ b/src/query/phrase_query/phrase_query.rs
@@ -46,8 +46,8 @@ impl PhraseQuery {
 
     /// Creates a new `PhraseQuery` given a list of terms, their offsets and a slop
     pub fn new_with_offset_and_slop(mut terms: Vec<(usize, Term)>, slop: u32) -> PhraseQuery {
-        assert!(
-            terms.len() > 1,
+        assert_gt!(
+            terms.len(), 1,
             "A phrase query is required to have strictly more than one term."
         );
         terms.sort_by_key(|&(offset, _)| offset);

--- a/src/query/phrase_query/phrase_scorer.rs
+++ b/src/query/phrase_query/phrase_scorer.rs
@@ -522,7 +522,7 @@ impl<TPostings: Postings> DocSet for PhraseScorer<TPostings> {
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
-        debug_assert!(target >= self.doc());
+        debug_assert_ge!(target, self.doc());
         let doc = self.intersection_docset.seek(target);
         if doc == TERMINATED || self.phrase_match() {
             return doc;
@@ -531,8 +531,8 @@ impl<TPostings: Postings> DocSet for PhraseScorer<TPostings> {
     }
 
     fn seek_danger(&mut self, target: DocId) -> SeekDangerResult {
-        debug_assert!(
-            target >= self.doc(),
+        debug_assert_ge!(
+            target, self.doc(),
             "target ({}) should be greater than or equal to doc ({})",
             target,
             self.doc()

--- a/src/query/phrase_query/regex_phrase_query.rs
+++ b/src/query/phrase_query/regex_phrase_query.rs
@@ -61,8 +61,8 @@ impl RegexPhraseQuery {
         mut terms: Vec<(usize, String)>,
         slop: u32,
     ) -> RegexPhraseQuery {
-        assert!(
-            terms.len() > 1,
+        assert_gt!(
+            terms.len(), 1,
             "A phrase query is required to have strictly more than one term."
         );
         terms.sort_by_key(|&(offset, _)| offset);

--- a/src/query/term_query/term_scorer.rs
+++ b/src/query/term_query/term_scorer.rs
@@ -120,7 +120,7 @@ impl DocSet for TermScorer {
 
     #[inline]
     fn seek(&mut self, target: DocId) -> DocId {
-        debug_assert!(target >= self.doc());
+        debug_assert_ge!(target, self.doc());
         self.postings.seek(target)
     }
 

--- a/src/space_usage/mod.rs
+++ b/src/space_usage/mod.rs
@@ -407,11 +407,11 @@ mod test {
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let searcher_space_usage = searcher.space_usage()?;
-        assert!(searcher_space_usage.total() > 0);
+        assert_gt!(searcher_space_usage.total(), 0);
         assert_eq!(1, searcher_space_usage.segments().len());
 
         let segment = &searcher_space_usage.segments()[0];
-        assert!(segment.total() > 0);
+        assert_gt!(segment.total(), 0);
 
         assert_eq!(4, segment.num_docs());
 
@@ -448,11 +448,11 @@ mod test {
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let searcher_space_usage = searcher.space_usage()?;
-        assert!(searcher_space_usage.total() > 0);
+        assert_gt!(searcher_space_usage.total(), 0);
         assert_eq!(1, searcher_space_usage.segments().len());
 
         let segment = &searcher_space_usage.segments()[0];
-        assert!(segment.total() > 0);
+        assert_gt!(segment.total(), 0);
 
         assert_eq!(4, segment.num_docs());
 
@@ -487,11 +487,11 @@ mod test {
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let searcher_space_usage = searcher.space_usage()?;
-        assert!(searcher_space_usage.total() > 0);
+        assert_gt!(searcher_space_usage.total(), 0);
         assert_eq!(1, searcher_space_usage.segments().len());
 
         let segment = &searcher_space_usage.segments()[0];
-        assert!(segment.total() > 0);
+        assert_gt!(segment.total(), 0);
 
         assert_eq!(4, segment.num_docs());
 
@@ -539,11 +539,11 @@ mod test {
         let reader = index.reader()?;
         let searcher = reader.searcher();
         let searcher_space_usage = searcher.space_usage()?;
-        assert!(searcher_space_usage.total() > 0);
+        assert_gt!(searcher_space_usage.total(), 0);
         assert_eq!(1, searcher_space_usage.segments().len());
 
         let segment_space_usage = &searcher_space_usage.segments()[0];
-        assert!(segment_space_usage.total() > 0);
+        assert_gt!(segment_space_usage.total(), 0);
 
         assert_eq!(2, segment_space_usage.num_docs());
 

--- a/src/tokenizer/ngram_tokenizer.rs
+++ b/src/tokenizer/ngram_tokenizer.rs
@@ -208,7 +208,7 @@ impl<T> StutteringIterator<T>
 where T: Iterator<Item = usize>
 {
     pub fn new(mut underlying: T, min_gram: usize, max_gram: usize) -> StutteringIterator<T> {
-        assert!(min_gram > 0);
+        assert_gt!(min_gram, 0);
         let memory: Vec<usize> = (&mut underlying).take(max_gram + 1).collect();
         if memory.len() <= min_gram {
             // returns an empty iterator

--- a/src/tokenizer/tokenized_string.rs
+++ b/src/tokenizer/tokenized_string.rs
@@ -73,16 +73,16 @@ impl TokenStream for PreTokenizedStream {
     }
 
     fn token(&self) -> &Token {
-        assert!(
-            self.current_token >= 0,
+        assert_ge!(
+            self.current_token, 0,
             "TokenStream not initialized. You should call advance() at least once."
         );
         &self.tokenized_string.tokens[self.current_token as usize]
     }
 
     fn token_mut(&mut self) -> &mut Token {
-        assert!(
-            self.current_token >= 0,
+        assert_ge!(
+            self.current_token, 0,
             "TokenStream not initialized. You should call advance() at least once."
         );
         &mut self.tokenized_string.tokens[self.current_token as usize]

--- a/sstable/Cargo.toml
+++ b/sstable/Cargo.toml
@@ -11,6 +11,7 @@ description = "sstables for tantivy"
 
 [dependencies]
 common = {version= "0.11", path="../common", package="tantivy-common"}
+assertables = "10.0.0"
 futures-util = "0.3.30"
 itertools = "0.14.0"
 tantivy-bitpacker = { version= "0.10", path="../bitpacker" }

--- a/sstable/src/dictionary.rs
+++ b/sstable/src/dictionary.rs
@@ -528,7 +528,7 @@ impl<TSSTable: SSTable> Dictionary<TSSTable> {
                     cb(&bytes);
                 } else {
                     // we checked it was sorted beforehands
-                    debug_assert!(next_ord > ord);
+                    debug_assert_gt!(next_ord, ord);
                     break next_ord;
                 }
             };

--- a/sstable/src/index/mod.rs
+++ b/sstable/src/index/mod.rs
@@ -211,7 +211,7 @@ impl FixedSize for BlockStartAddr {
 /// mutates `left into a shorter byte string left'` that
 /// matches `left <= left' < right`.
 fn find_shorter_str_in_between(left: &mut Vec<u8>, right: &[u8]) {
-    assert!(&left[..] < right);
+    assert_lt!(&left[..], right);
     let common_len = common_prefix_len(left, right);
     if left.len() == common_len {
         return;
@@ -290,9 +290,9 @@ mod tests {
     fn test_find_shorter_str_in_between_aux(left: &[u8], right: &[u8]) {
         let mut left_buf = left.to_vec();
         super::find_shorter_str_in_between(&mut left_buf, right);
-        assert!(left_buf.len() <= left.len());
-        assert!(left <= &left_buf);
-        assert!(&left_buf[..] < right);
+        assert_len_le!(left_buf, left);
+        assert_le!(left, &left_buf);
+        assert_lt!(&left_buf[..], right);
     }
 
     #[test]

--- a/sstable/src/index/v3.rs
+++ b/sstable/src/index/v3.rs
@@ -268,7 +268,7 @@ impl BlockAddrBlockMetadata {
 // TODO move this function to tantivy_common?
 #[inline(always)]
 fn extract_bits(data: &[u8], addr_bits: usize, num_bits: u8) -> u64 {
-    assert!(num_bits <= 56);
+    assert_le!(num_bits, 56);
     let addr_byte = addr_bits / 8;
     let bit_shift = (addr_bits % 8) as u64;
     let val_unshifted_unmasked: u64 = if data.len() >= addr_byte + 8 {

--- a/sstable/src/lib.rs
+++ b/sstable/src/lib.rs
@@ -38,6 +38,9 @@
 use std::io::{self, Write};
 use std::ops::Range;
 
+#[macro_use]
+extern crate assertables;
+
 use merge::ValueMerger;
 
 mod block_match_automaton;

--- a/stacker/Cargo.toml
+++ b/stacker/Cargo.toml
@@ -11,6 +11,7 @@ description = "term hashmap used for indexing"
 murmurhash32 = "0.3"
 common = { version = "0.11", path = "../common/", package = "tantivy-common" }
 ahash = { version = "0.8.11", default-features = false, optional = true }
+assertables = "10.0.0"
 
 
 [[bench]]

--- a/stacker/src/expull.rs
+++ b/stacker/src/expull.rs
@@ -149,8 +149,8 @@ impl ExpUnrolledLinkedList {
         let last_block_len = block_size.saturating_sub(self.remaining_cap as usize);
 
         // Safety check: if remaining_cap > block_size, the metadata is corrupted
-        assert!(
-            self.remaining_cap as usize <= block_size,
+        assert_lt!(
+            self.remaining_cap as usize, block_size,
             "ExpUnrolledLinkedList metadata corruption detected: remaining_cap ({}) > block_size \
              ({}). This indicates a serious bug, please report! (block_num={}, head={:?}, \
              tail={:?})",
@@ -328,8 +328,8 @@ mod tests {
         }
 
         // Verify we allocated many blocks (should be in the thousands)
-        assert!(
-            eull.block_num > 1000,
+        assert_gt!(
+            eull.block_num, 1000,
             "block_num ({}) should be > 1000 for this much data",
             eull.block_num
         );

--- a/stacker/src/fastcpy.rs
+++ b/stacker/src/fastcpy.rs
@@ -77,8 +77,8 @@ fn short_copy(src: &[u8], dst: &mut [u8]) {
 
 #[inline(always)]
 fn double_copy_trick<const SIZE: usize>(src: &[u8], dst: &mut [u8]) {
-    debug_assert!(src.len() >= SIZE);
-    debug_assert!(dst.len() >= SIZE);
+    debug_assert_ge!(src.len(), SIZE);
+    debug_assert_ge!(dst.len(), SIZE);
     dst[0..SIZE].copy_from_slice(&src[0..SIZE]);
     dst[src.len() - SIZE..].copy_from_slice(&src[src.len() - SIZE..]);
 }

--- a/stacker/src/lib.rs
+++ b/stacker/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(all(feature = "unstable", test), feature(test))]
 
+#[macro_use]
+extern crate assertables;
+
 #[cfg(all(test, feature = "unstable"))]
 extern crate test;
 

--- a/stacker/src/memory_arena.rs
+++ b/stacker/src/memory_arena.rs
@@ -201,7 +201,7 @@ impl Page {
         // - 20 bits for the in-page addressing
         // - 12 bits for the page id.
         // This limits us to 2^12 - 1=4095 for the page id.
-        assert!(page_id < 4096);
+        assert_lt!(page_id, 4096);
         Page {
             page_id,
             len: 0,

--- a/stacker/src/shared_arena_hashmap.rs
+++ b/stacker/src/shared_arena_hashmap.rs
@@ -114,7 +114,7 @@ impl<'a> Iterator for Iter<'a> {
 ///
 /// # Panics if n == 0
 fn compute_previous_power_of_two(n: usize) -> usize {
-    assert!(n > 0);
+    assert_gt!(n, 0);
     let msb = (63u32 - (n as u64).leading_zeros()) as u8;
     1 << msb
 }

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -122,3 +122,4 @@ fn test_fail_on_commit_segment() -> tantivy::Result<()> {
     assert!(index_writer.commit().is_err());
     Ok(())
 }
+


### PR DESCRIPTION
Purpose: update test macros from an older crate `more_asserts` to a newer crate `assertables`. This provides more capabilities for semantic testing, and better error messages for diagnoses.

https://crates.io/crates/assertables

Context: I'm using tantivy for search for medical purposes, and when I looked at your Cargo.toml I saw a small bit where I may be able to help. This commit is a tiny first step to ask if the  maintainers may be potentially open using assertables.

Who I am: I'm the author of a drop-in-replacement crate assertables that provides many more assert macros, and has multiple code forges (GitHub, GitLab, Codeberg), and has more widespread licensing options (MIT, BSD, GPL, Apache). I've hand-written every line, no AI. I work at a nonprofit public sector healthcare agency, and I'm seeking to scale up semantic testing because it helps improves readability, maintainability, and security.

The broader purpose: I'm gradually asking a bunch of open source projects to consider using assertables, and ideally if possible providing contructive feedback about more capabilities for testing could help you.

You have tests like this:

    assert!(x > y)

Now you can do:

    assert_gt!(x, y)

You have tests like this:

    assert!(buffer_without_gcd.len() > buffer.len());

Now you can do:

    assert_len_gt!(buffer_without_gcd, buffer);

The crate also makes it easy to import just the tests you want, which I recommend, such as:

    use assertables::{assert_lt, assert_gt};

I know this doesn't sound like much, yet these improvements add up over time, and add up as they reach more projects. I'm aiming to gradually encourage Rust coders to use more semantic tests.

Thank you for your consideration. Happy to chat about it, if you like. My direct personal email is joel@joelparkerhenderson.com (and I know this message is public).