### PR TITLE
Buffer up to 2048 doc ids in for_each_docset_buffered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/quickwit-oss/tantivy"
 readme = "README.md"
 keywords = ["search", "information", "retrieval"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.92"
 exclude = ["benches/*.json", "benches/*.txt"]
 
 [dependencies]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -301,11 +301,14 @@ pub trait SegmentCollector: 'static {
     /// The query pushes the scored document to the collector via this method.
     fn collect(&mut self, doc: DocId, score: Score);
 
-    /// The query pushes the scored document to the collector via this method.
+    /// The query pushes the matched documents to the collector via this method.
     /// This method is used when the collector does not require scoring.
     ///
-    /// See [`COLLECT_BLOCK_BUFFER_LEN`](crate::COLLECT_BLOCK_BUFFER_LEN) for the
-    /// buffer size passed to the collector.
+    /// `docs` is a block of matched doc ids. Doc ids are produced in increasing
+    /// order, in windows of [`COLLECT_BLOCK_BUFFER_LEN`](crate::COLLECT_BLOCK_BUFFER_LEN),
+    /// but several windows are accumulated before being flushed here, so the
+    /// block may be larger than `COLLECT_BLOCK_BUFFER_LEN`. Implementations must
+    /// not assume any particular maximum length.
     fn collect_block(&mut self, docs: &[DocId]) {
         for doc in docs {
             self.collect(*doc, 0.0);

--- a/src/docset.rs
+++ b/src/docset.rs
@@ -11,9 +11,14 @@ use crate::DocId;
 /// to compare `[u32; 4]`.
 pub const TERMINATED: DocId = i32::MAX as u32;
 
-/// The collect_block method on `SegmentCollector` uses a buffer of this size.
-/// Passed results to `collect_block` will not exceed this size and will be
-/// exactly this size as long as we can fill the buffer.
+/// Window size used by [`DocSet::fill_buffer`]: a single `fill_buffer` call
+/// writes at most this many doc ids, and exactly this many as long as the
+/// `DocSet` is not exhausted.
+///
+/// Note that this is *not* the maximum length of the slice passed to
+/// `SegmentCollector::collect_block`: the collection loop accumulates several
+/// such windows into a larger buffer before flushing it, so `collect_block`
+/// may receive a block larger than `COLLECT_BLOCK_BUFFER_LEN`.
 pub const COLLECT_BLOCK_BUFFER_LEN: usize = 64;
 
 /// Number of `TinySet` (64-bit) buckets in a block used by [`DocSet::fill_bitset_block`].

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use crate::docset::COLLECT_BLOCK_BUFFER_LEN;
 use crate::index::SegmentReader;
 use crate::postings::FreqReadingOption;
 use crate::query::disjunction::Disjunction;
@@ -531,13 +530,12 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
     ) -> crate::Result<()> {
         let scorer = self.complex_scorer(reader, 1.0, || DoNothingCombiner)?;
         let num_docs = reader.num_docs();
-        let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
 
         match scorer {
             SpecializedScorer::TermUnion(term_scorers) => {
                 let mut union_scorer =
                     BufferedUnionScorer::build(term_scorers, &self.score_combiner_fn, num_docs);
-                for_each_docset_buffered(&mut union_scorer, &mut buffer, callback);
+                for_each_docset_buffered(&mut union_scorer, callback);
             }
             SpecializedScorer::TermIntersection(term_scorers) => {
                 let boxed_scorers: Vec<Box<dyn Scorer>> = term_scorers
@@ -545,10 +543,10 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
                     .map(|term_scorer| Box::new(term_scorer) as Box<dyn Scorer>)
                     .collect();
                 let mut intersection = intersect_scorers(boxed_scorers, num_docs);
-                for_each_docset_buffered(intersection.as_mut(), &mut buffer, callback);
+                for_each_docset_buffered(intersection.as_mut(), callback);
             }
             SpecializedScorer::Other(mut scorer) => {
-                for_each_docset_buffered(scorer.as_mut(), &mut buffer, callback);
+                for_each_docset_buffered(scorer.as_mut(), callback);
             }
         }
         Ok(())

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -1,5 +1,5 @@
 use super::term_scorer::TermScorer;
-use crate::docset::{DocSet, COLLECT_BLOCK_BUFFER_LEN};
+use crate::docset::DocSet;
 use crate::fieldnorm::FieldNormReader;
 use crate::index::SegmentReader;
 use crate::postings::SegmentPostings;
@@ -92,13 +92,11 @@ impl Weight for TermWeight {
     ) -> crate::Result<()> {
         match self.specialized_scorer(reader, 1.0)? {
             TermOrEmptyOrAllScorer::TermScorer(mut term_scorer) => {
-                let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
-                for_each_docset_buffered(&mut term_scorer, &mut buffer, callback);
+                for_each_docset_buffered(&mut term_scorer, callback);
             }
             TermOrEmptyOrAllScorer::Empty => {}
             TermOrEmptyOrAllScorer::AllMatch(mut all_scorer) => {
-                let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
-                for_each_docset_buffered(&mut all_scorer, &mut buffer, callback);
+                for_each_docset_buffered(&mut all_scorer, callback);
             }
         };
 

--- a/src/query/weight.rs
+++ b/src/query/weight.rs
@@ -17,18 +17,56 @@ pub(crate) fn for_each_scorer<TScorer: Scorer + ?Sized>(
     }
 }
 
-/// Iterates through all of the documents matched by the DocSet
-/// `DocSet`.
+/// Number of `COLLECT_BLOCK_BUFFER_LEN`-sized windows accumulated into the large
+/// buffer before it is flushed to the collector via `collect_block`.
+const NUM_WINDOWS_PER_BLOCK: usize = 32;
+/// Size of the buffer accumulated before invoking the callback (2_048 = 32 * 64).
+/// `fill_buffer` keeps writing `COLLECT_BLOCK_BUFFER_LEN`-sized windows; this only
+/// changes how much we accumulate before flushing.
+const LARGE_COLLECT_BUFFER_LEN: usize = COLLECT_BLOCK_BUFFER_LEN * NUM_WINDOWS_PER_BLOCK;
+
+/// Iterates through all of the documents matched by the `DocSet`, flushing
+/// blocks of up to `LARGE_COLLECT_BUFFER_LEN` doc ids to `callback`.
+///
+/// `fill_buffer` only ever writes `COLLECT_BLOCK_BUFFER_LEN` doc ids at a time,
+/// so we accumulate several such windows into a single larger buffer before
+/// handing it to the collector. This amortizes the per-`collect_block` overhead
+/// (virtual dispatch, aggregation setup) over more documents.
 #[inline]
 pub(crate) fn for_each_docset_buffered<T: DocSet + ?Sized>(
     docset: &mut T,
-    buffer: &mut [DocId; COLLECT_BLOCK_BUFFER_LEN],
     mut callback: impl FnMut(&[DocId]),
 ) {
+    // Heap-allocated once per call (i.e. once per segment in the no-score path).
+    // `new_zeroed_slice` zeroes directly on the heap, avoiding a 2_048-element
+    // stack temporary.
+    // SAFETY: an all-zero bit pattern is a valid value for every `DocId` (u32),
+    // so the zeroed slice is fully initialized.
+    let mut buffer: Box<[DocId]> =
+        unsafe { Box::new_zeroed_slice(LARGE_COLLECT_BUFFER_LEN).assume_init() };
     loop {
-        let num_items = docset.fill_buffer(buffer);
-        callback(&buffer[..num_items]);
-        if num_items != buffer.len() {
+        let mut filled = 0;
+        let mut reached_end = false;
+        // Fill the large buffer one `COLLECT_BLOCK_BUFFER_LEN` window at a time.
+        // `chunks_exact_mut` yields windows of exactly `COLLECT_BLOCK_BUFFER_LEN`
+        // because `LARGE_COLLECT_BUFFER_LEN` is a multiple of it (empty remainder).
+        // The windows are contiguous and filled in order, so the doc ids always
+        // occupy the contiguous prefix `buffer[..filled]`.
+        for window in buffer.chunks_exact_mut(COLLECT_BLOCK_BUFFER_LEN) {
+            // SAFETY: each `window` is a slice of exactly `COLLECT_BLOCK_BUFFER_LEN`
+            // elements, so reinterpreting its start pointer as a fixed-size array
+            // reference of that length is valid.
+            let window: &mut [DocId; COLLECT_BLOCK_BUFFER_LEN] =
+                unsafe { &mut *window.as_mut_ptr().cast::<[DocId; COLLECT_BLOCK_BUFFER_LEN]>() };
+            let num_items = docset.fill_buffer(window);
+            filled += num_items;
+            if num_items != COLLECT_BLOCK_BUFFER_LEN {
+                reached_end = true;
+                break;
+            }
+        }
+        callback(&buffer[..filled]);
+        if reached_end {
             break;
         }
     }
@@ -104,9 +142,7 @@ pub trait Weight: Send + Sync + 'static {
         callback: &mut dyn FnMut(&[DocId]),
     ) -> crate::Result<()> {
         let mut docset = self.scorer(reader, 1.0)?;
-
-        let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
-        for_each_docset_buffered(&mut docset, &mut buffer, callback);
+        for_each_docset_buffered(&mut docset, callback);
         Ok(())
     }
 


### PR DESCRIPTION
## What

In the no-score collection path (`Weight::for_each_no_score` → `for_each_docset_buffered`),
matched doc ids were handed to the collector's `collect_block` one
`COLLECT_BLOCK_BUFFER_LEN` (64) block at a time. For aggregations this is the dominant path
(`requires_scoring() == false`), and 64 docs per `collect_block` call under-amortizes the
per-call overhead (virtual dispatch + aggregation bookkeeping).

`for_each_docset_buffered` now owns a **2048-element** heap buffer and fills it through
successive `fill_buffer` calls over 64-element windows, flushing a single larger block to
`collect_block`. `fill_buffer` keeps its `COLLECT_BLOCK_BUFFER_LEN` (64) window contract, so
**no `DocSet` implementation changes** — only how much we accumulate before flushing.

## Notes

- The large buffer is allocated with `Box::new_zeroed_slice(..).assume_init()` to zero directly
  on the heap (no 2048-element stack temporary). This API is stable since **1.92.0**, hence the
  MSRV bump `1.86 → 1.92`.
- Audited every `collect_block` implementation: none assume a max slice length of 64 (they
  delegate or iterate the slice; filter wrappers use a growable `Vec`). Doc comments on
  `COLLECT_BLOCK_BUFFER_LEN` and `SegmentCollector::collect_block` updated accordingly — the
  block handed to `collect_block` may now exceed 64.
- Uses `unsafe` to reinterpret each 64-element `chunks_exact_mut` window as `&mut [DocId; 64]`
  for the `fill_buffer` call (sound: 2048 is a multiple of 64).

## Benchmarks

`cargo bench --bench agg_bench` on the `full` (1M-doc) input, single segment, no deletes — so every bench exercises the `for_each_no_score` → `collect_block` path. Reported value is the **minimum of 3 runs** (most stable estimator; the per-run median swung ±5–20% on its own). Apple Silicon (M-series), `REUSE_AGG_BENCH_INDEX` so both sides hit the identical index.

**Summary:** median **-1.7%**, mean -1.6% across 47 aggregations. Negative = faster. Broad improvement on the cheap full-scan aggregations (where per-`collect_block` overhead dominated); a handful of heavy `order_by_card` / `top_hits` benches regress and are within this harness's run-to-run noise.

<details><summary>Per-benchmark median (min of 3), sorted by delta</summary>

| benchmark | before | after | delta |
|---|--:|--:|--:|
| `histogram_hard_bounds` | 1.602 ms | 1.428 ms | -10.9% |
| `cardinality_agg_low_card` | 1.192 ms | 1.070 ms | -10.2% |
| `filter_agg_all_query_count_agg` | 5.093 ms | 4.801 ms | -5.7% |
| `histogram` | 2.878 ms | 2.715 ms | -5.7% |
| `terms_many_order_by_term` | 5.514 ms | 5.265 ms | -4.5% |
| `range_agg_with_term_agg_status` | 6.409 ms | 6.146 ms | -4.1% |
| `filter_agg_term_query_count_agg` | 7.519 ms | 7.220 ms | -4.0% |
| `average_u64` | 3.025 ms | 2.908 ms | -3.9% |
| `average_f64` | 3.180 ms | 3.060 ms | -3.8% |
| `average_f64_u64` | 5.904 ms | 5.683 ms | -3.8% |
| `range_agg` | 3.348 ms | 3.224 ms | -3.7% |
| `range_agg_with_avg_sub_agg` | 7.145 ms | 6.890 ms | -3.6% |
| `terms_status_with_cardinality_agg` | 3.358 ms | 3.246 ms | -3.3% |
| `terms_all_unique` | 6.164 ms | 5.965 ms | -3.2% |
| `avg_and_range_with_avg_sub_agg` | 10.060 ms | 9.740 ms | -3.2% |
| `terms_all_unique_with_avg_sub_agg` | 19.049 ms | 18.452 ms | -3.1% |
| `terms_status_with_avg_sub_agg` | 5.472 ms | 5.312 ms | -2.9% |
| `stats_f64` | 3.160 ms | 3.068 ms | -2.9% |
| `filter_agg_all_query_with_sub_aggs` | 10.079 ms | 9.827 ms | -2.5% |
| `extendedstats_f64` | 3.324 ms | 3.242 ms | -2.5% |
| `histogram_with_avg_sub_agg` | 9.345 ms | 9.123 ms | -2.4% |
| `histogram_with_term_agg_status` | 9.441 ms | 9.230 ms | -2.2% |
| `terms_7` | 2.344 ms | 2.300 ms | -1.9% |
| `filter_agg_term_query_with_sub_aggs` | 12.473 ms | 12.257 ms | -1.7% |
| `terms_150_000` | 6.462 ms | 6.350 ms | -1.7% |
| `range_agg_with_term_agg_many` | 12.541 ms | 12.350 ms | -1.5% |
| `percentiles_f64` | 6.476 ms | 6.381 ms | -1.5% |
| `terms_status_with_terms_zipf_1000_sub_agg` | 4.112 ms | 4.053 ms | -1.4% |
| `terms_status_with_histogram` | 4.873 ms | 4.828 ms | -0.9% |
| `cardinality_agg` | 13.139 ms | 13.047 ms | -0.7% |
| `terms_many_with_avg_sub_agg` | 17.935 ms | 17.819 ms | -0.6% |
| `cardinality_agg_high_card` | 65.139 ms | 64.745 ms | -0.6% |
| `terms_many_top_1000` | 9.417 ms | 9.361 ms | -0.6% |
| `composite_term_many_page_1000` | 28.273 ms | 28.197 ms | -0.3% |
| `composite_term_many_page_1000_with_avg_sub_agg` | 29.137 ms | 29.147 ms | +0.0% |
| `terms_zipf_1000_with_terms_status_sub_agg` | 12.853 ms | 12.886 ms | +0.3% |
| `terms_100_buckets_with_cardinality_agg` | 50.915 ms | 51.058 ms | +0.3% |
| `terms_zipf_1000_with_histogram` | 23.664 ms | 23.780 ms | +0.5% |
| `composite_histogram_calendar` | 27.774 ms | 27.930 ms | +0.6% |
| `composite_term_few` | 13.571 ms | 13.654 ms | +0.6% |
| `terms_zipf_1000_with_avg_sub_agg` | 9.544 ms | 9.672 ms | +1.3% |
| `terms_many_json_mixed_type_with_avg_sub_agg` | 27.830 ms | 28.248 ms | +1.5% |
| `composite_histogram` | 17.038 ms | 17.488 ms | +2.6% |
| `terms_many_with_top_hits` | 92.988 ms | 95.822 ms | +3.0% |
| `terms_zipf_1000` | 2.211 ms | 2.317 ms | +4.8% |
| `terms_many_with_single_term_2_order_by_card` | 49.301 ms | 51.690 ms | +4.8% |
| `terms_many_with_single_term_order_by_card` | 74.692 ms | 81.090 ms | +8.6% |

</details>


## Tests

`cargo build`, `cargo clippy --all-targets` (no new warnings), and
`cargo test --lib {aggregation, query::, collector::}` all pass.
