### PR TITLE
2x faster terms × histogram aggregation via a specialized collector

### DIFF
--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -67,6 +67,7 @@ fn bench_agg(mut group: InputGroup<Index>) {
     register!(group, terms_zipf_1000_with_terms_status_sub_agg);
     register!(group, terms_status_with_histogram);
     register!(group, terms_status_with_date_histogram);
+    register!(group, terms_status_with_date_histogram_hard_bounds);
     register!(group, terms_status_with_date_histogram_and_sibling_terms);
     register!(group, terms_zipf_1000);
     register!(group, terms_zipf_1000_with_histogram);
@@ -398,6 +399,29 @@ fn terms_status_with_date_histogram(index: &Index) {
             "terms": { "field": "text_few_terms_status" },
             "aggs": {
                 "over_time": { "date_histogram": { "field": "timestamp", "fixed_interval": "1h" } }
+            }
+        }
+    });
+    execute_agg(index, agg_req);
+}
+
+/// Same fused terms × date_histogram, but with `hard_bounds`. The timestamps span 0..120h; the
+/// bounds drop only the first and last hour (ms: 1h=3_600_000, 119h=428_400_000), so almost every
+/// doc is in-bounds. This exercises the collector's hard-bounds path: `bounds.contains` runs per
+/// doc (the `all_docs_in_bounds` short-circuit is off) and the rare out-of-bounds doc takes the
+/// `term_counts` branch.
+fn terms_status_with_date_histogram_hard_bounds(index: &Index) {
+    let agg_req = json!({
+        "my_texts": {
+            "terms": { "field": "text_few_terms_status" },
+            "aggs": {
+                "over_time": {
+                    "date_histogram": {
+                        "field": "timestamp",
+                        "fixed_interval": "1h",
+                        "hard_bounds": { "min": 3_600_000, "max": 428_400_000 }
+                    }
+                }
             }
         }
     });

--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -66,6 +66,8 @@ fn bench_agg(mut group: InputGroup<Index>) {
     register!(group, terms_status_with_terms_zipf_1000_sub_agg);
     register!(group, terms_zipf_1000_with_terms_status_sub_agg);
     register!(group, terms_status_with_histogram);
+    register!(group, terms_status_with_date_histogram);
+    register!(group, terms_status_with_date_histogram_and_sibling_terms);
     register!(group, terms_zipf_1000);
     register!(group, terms_zipf_1000_with_histogram);
     register!(group, terms_zipf_1000_with_avg_sub_agg);
@@ -386,6 +388,34 @@ fn terms_status_with_histogram(index: &Index) {
                 "histo": {"histogram": { "field": "score_f64", "interval": 10 }}
             }
         }
+    });
+    execute_agg(index, agg_req);
+}
+
+fn terms_status_with_date_histogram(index: &Index) {
+    let agg_req = json!({
+        "my_texts": {
+            "terms": { "field": "text_few_terms_status" },
+            "aggs": {
+                "over_time": { "date_histogram": { "field": "timestamp", "fixed_interval": "1h" } }
+            }
+        }
+    });
+    execute_agg(index, agg_req);
+}
+
+/// Same fused terms × date_histogram, but with a sibling terms aggregation next to it. The fused
+/// fast path should still trigger for `my_texts` (sibling aggregations are independent top-level
+/// aggregations, so they don't change its eligibility).
+fn terms_status_with_date_histogram_and_sibling_terms(index: &Index) {
+    let agg_req = json!({
+        "my_texts": {
+            "terms": { "field": "text_few_terms_status" },
+            "aggs": {
+                "over_time": { "date_histogram": { "field": "timestamp", "fixed_interval": "1h" } }
+            }
+        },
+        "other_texts": { "terms": { "field": "text_few_terms" } }
     });
     execute_agg(index, agg_req);
 }
@@ -783,7 +813,9 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
             doc_with_value /= 20;
         }
         let _val_max = 1_000_000.0;
-        for _ in 0..doc_with_value {
+        const SPAN_MS: i64 = 120 * 3600 * 1000; // 120 hours in ms
+        const NOISE_MS: i64 = 2 * 3600 * 1000; // ±2h noise
+        for i in 0..doc_with_value {
             let val: f64 = rng.random_range(0.0..1_000_000.0);
             let json = if rng.random_bool(0.1) {
                 // 10% are numeric values
@@ -791,6 +823,9 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
             } else {
                 json!({"mixed_type": many_terms_data.choose(&mut rng).unwrap().to_string()})
             };
+            let base_ms = (i as i64 * SPAN_MS) / doc_with_value as i64;
+            let noise_ms = rng.random_range(-NOISE_MS..NOISE_MS);
+            let ts_ms = (base_ms + noise_ms).clamp(0, SPAN_MS);
             index_writer.add_document(doc!(
                 single_term => "single_term",
                 text_field => "cool",
@@ -803,7 +838,7 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
                 score_field => val as u64,
                 score_field_f64 => lg_norm.sample(&mut rng),
                 score_field_i64 => val as i64,
-                date_field => DateTime::from_timestamp_millis((val * 1_000_000.) as i64),
+                date_field => DateTime::from_timestamp_millis(ts_ms),
             ))?;
             if cardinality == Cardinality::OptionalSparse {
                 for _ in 0..20 {

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -17,7 +17,18 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     pub fn fetch_block<'a>(&'a mut self, docs: &'a [u32], accessor: &Column<T>) {
         if accessor.index.get_cardinality().is_full() {
             self.val_cache.resize(docs.len(), T::default());
-            accessor.values.get_vals(docs, &mut self.val_cache);
+            // When the docs form a contiguous ascending run we can fetch the values
+            // as a single range. This lets codecs (e.g. bitpacked) bulk-decode the
+            // slice instead of gathering value-by-value, and avoids per-value dynamic
+            // dispatch. `docs` is always sorted ascending and free of duplicates here,
+            // so comparing the endpoints is enough to detect contiguity.
+            if is_contiguous(docs) {
+                accessor
+                    .values
+                    .get_range(docs[0] as u64, &mut self.val_cache);
+            } else {
+                accessor.values.get_vals(docs, &mut self.val_cache);
+            }
         } else {
             self.docid_cache.clear();
             self.row_id_cache.clear();
@@ -158,6 +169,22 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     }
 }
 
+/// Returns true if `docs` is a contiguous ascending run `[d, d + 1, ..., d + n - 1]`.
+///
+/// Assumes `docs` is sorted ascending and free of duplicates (the invariant for the
+/// doc blocks passed to `fetch_block`), so comparing the endpoints is sufficient.
+#[inline]
+fn is_contiguous(docs: &[u32]) -> bool {
+    let (Some(&first), Some(&last)) = (docs.first(), docs.last()) else {
+        return false;
+    };
+    debug_assert!(
+        docs.windows(2).all(|w| w[0] < w[1]),
+        "fetch_block requires docs sorted ascending without duplicates"
+    );
+    (last - first) as usize + 1 == docs.len()
+}
+
 /// Given two sorted lists of docids `docs` and `hits`, hits is a subset of `docs`.
 /// Return all docs that are not in `hits`.
 fn find_missing_docs<F>(docs: &[u32], hits: &[u32], mut callback: F)
@@ -287,5 +314,47 @@ mod tests {
         accessor.dedup_docid_val_pairs();
         assert_eq!(accessor.docid_cache, vec![0]);
         assert_eq!(accessor.val_cache, vec![1]);
+    }
+
+    #[test]
+    fn test_is_contiguous() {
+        assert!(!is_contiguous(&[]));
+        assert!(is_contiguous(&[5]));
+        assert!(is_contiguous(&[5, 6, 7, 8]));
+        assert!(is_contiguous(&[0, 1, 2]));
+        assert!(!is_contiguous(&[5, 7, 8]));
+        assert!(!is_contiguous(&[0, 1, 3]));
+    }
+
+    #[test]
+    fn test_fetch_block_contiguous_and_gather_match() {
+        use crate::column_index::ColumnIndex;
+        use crate::column_values::{
+            ALL_U64_CODEC_TYPES, serialize_and_load_u64_based_column_values,
+        };
+
+        let vals: Vec<u64> = (0..200u64).map(|i| i * 7 + 3).collect();
+        let values =
+            serialize_and_load_u64_based_column_values::<u64>(&&vals[..], &ALL_U64_CODEC_TYPES);
+        let column = Column {
+            index: ColumnIndex::Full,
+            values,
+        };
+
+        let check = |accessor: &mut ColumnBlockAccessor<u64>, docs: &[u32]| {
+            accessor.fetch_block(docs, &column);
+            let got: Vec<(u32, u64)> = accessor.iter_docid_vals(docs, &column).collect();
+            let expected: Vec<(u32, u64)> = docs.iter().map(|&d| (d, vals[d as usize])).collect();
+            assert_eq!(got, expected);
+        };
+
+        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        // Contiguous block -> get_range fast path.
+        check(&mut accessor, &(10..74).collect::<Vec<u32>>());
+        // Non-contiguous block -> get_vals gather path.
+        check(&mut accessor, &[0, 5, 9, 100, 199]);
+        // Single doc and full span.
+        check(&mut accessor, &[42]);
+        check(&mut accessor, &(0..200).collect::<Vec<u32>>());
     }
 }

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -15,8 +15,25 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
 {
     #[inline]
     pub fn fetch_block<'a>(&'a mut self, docs: &'a [u32], accessor: &Column<T>) {
-        if accessor.index.get_cardinality().is_full() {
-            self.val_cache.resize(docs.len(), T::default());
+        self.fetch_block_with_is_full(docs, accessor, accessor.index.get_cardinality().is_full());
+    }
+
+    /// Like [`Self::fetch_block`] but takes the column's fullness instead of querying
+    /// `accessor.index.get_cardinality()` each call — for callers that know it up front (e.g.
+    /// checked once at construction). `is_full` must equal
+    /// `accessor.index.get_cardinality().is_full()`.
+    #[inline]
+    pub fn fetch_block_with_is_full<'a>(
+        &'a mut self,
+        docs: &'a [u32],
+        accessor: &Column<T>,
+        is_full: bool,
+    ) {
+        if is_full {
+            // Skip the resize when already the right length (common case: fixed-size blocks).
+            if self.val_cache.len() != docs.len() {
+                self.val_cache.resize(docs.len(), T::default());
+            }
             // When the docs form a contiguous ascending run we can fetch the values
             // as a single range. This lets codecs (e.g. bitpacked) bulk-decode the
             // slice instead of gathering value-by-value, and avoids per-value dynamic

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -119,8 +119,18 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     /// the segment's `maxdoc`.
     #[inline(always)]
     fn get_range(&self, start: u64, output: &mut [T]) {
-        for (out, idx) in output.iter_mut().zip(start..) {
+        let mut out_chunks = output.chunks_exact_mut(4);
+        let mut idx = start;
+        for out_x4 in out_chunks.by_ref() {
+            out_x4[0] = self.get_val(idx as u32);
+            out_x4[1] = self.get_val((idx + 1) as u32);
+            out_x4[2] = self.get_val((idx + 2) as u32);
+            out_x4[3] = self.get_val((idx + 3) as u32);
+            idx += 4;
+        }
+        for out in out_chunks.into_remainder() {
             *out = self.get_val(idx as u32);
+            idx += 1;
         }
     }
 

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -121,6 +121,22 @@ pub(crate) fn create_and_validate<TColumnCodec: ColumnCodec>(
     reader.get_vals(&all_docs, &mut buffer);
     assert_eq!(vals, buffer);
 
+    // Validate `get_range` over the full column and a sub-range. The sub-range starts
+    // at a non-zero offset to exercise the entrance-ramp alignment of the batch decode.
+    buffer.resize(all_docs.len(), 0);
+    reader.get_range(0, &mut buffer);
+    assert_eq!(vals, buffer, "get_range (full) mismatch in data set {name}");
+    if vals.len() >= 2 {
+        let start = 1usize;
+        buffer.resize(vals.len() - start, 0);
+        reader.get_range(start as u64, &mut buffer);
+        assert_eq!(
+            &vals[start..],
+            &buffer[..],
+            "get_range (sub-range) mismatch in data set {name}"
+        );
+    }
+
     if !vals.is_empty() {
         let test_rand_idx = rand::rng().random_range(0..=vals.len() - 1);
         let expected_positions: Vec<u32> = vals

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -10,11 +10,11 @@ use crate::aggregation::accessor_helpers::{
 };
 use crate::aggregation::agg_req::{Aggregation, AggregationVariants, Aggregations};
 use crate::aggregation::bucket::{
-    build_segment_filter_collector, build_segment_range_collector, CompositeAggReqData,
-    CompositeAggregation, CompositeSourceAccessors, FilterAggReqData, HistogramAggReqData,
-    HistogramBounds, IncludeExcludeParam, MissingTermAggReqData, RangeAggReqData,
-    SegmentHistogramCollector, TermMissingAgg, TermsAggReqData, TermsAggregation,
-    TermsAggregationInternal,
+    build_segment_filter_collector, build_segment_histogram_collector,
+    build_segment_range_collector, CompositeAggReqData, CompositeAggregation,
+    CompositeSourceAccessors, FilterAggReqData, HistogramAggReqData, HistogramBounds,
+    IncludeExcludeParam, MissingTermAggReqData, RangeAggReqData, TermMissingAgg, TermsAggReqData,
+    TermsAggregation, TermsAggregationInternal,
 };
 use crate::aggregation::metric::{
     build_segment_stats_collector, AverageAggregation, CardinalityAggReqData,
@@ -338,12 +338,8 @@ pub(crate) fn build_segment_agg_collector(
                 req_data.segment_ordinal,
             )))
         }
-        AggKind::Histogram => Ok(Box::new(SegmentHistogramCollector::from_req_and_validate(
-            req, node,
-        )?)),
-        AggKind::DateHistogram => Ok(Box::new(SegmentHistogramCollector::from_req_and_validate(
-            req, node,
-        )?)),
+        AggKind::Histogram => build_segment_histogram_collector(req, node),
+        AggKind::DateHistogram => build_segment_histogram_collector(req, node),
         AggKind::Range => Ok(build_segment_range_collector(req, node)?),
         AggKind::Filter => build_segment_filter_collector(req, node),
         AggKind::Composite => Ok(Box::new(

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -338,24 +338,41 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         agg_data
             .column_block_accessor
             .fetch_block(docs, &req.accessor);
-        for (doc, val) in agg_data
-            .column_block_accessor
-            .iter_docid_vals(docs, &req.accessor)
-        {
-            let val = f64_from_fastfield_u64(val, req.field_type);
-            let bucket_pos = get_bucket_pos(val);
-            if bounds.contains(val) {
-                let bucket = buckets.entry(bucket_pos).or_insert_with(|| {
-                    let key = get_bucket_key_from_pos(bucket_pos as f64, interval, offset);
-                    SegmentHistogramBucketEntry {
-                        key,
-                        doc_count: 0,
-                        bucket_id: self.bucket_id_provider.next_bucket_id(),
-                    }
-                });
-                bucket.doc_count += 1;
-                if let Some(sub_agg) = &mut self.sub_agg {
+        // special path for nested buckets
+        if let Some(sub_agg) = &mut self.sub_agg {
+            for (doc, val) in agg_data
+                .column_block_accessor
+                .iter_docid_vals(docs, &req.accessor)
+            {
+                let val = f64_from_fastfield_u64(val, req.field_type);
+                let bucket_pos = get_bucket_pos(val);
+                if bounds.contains(val) {
+                    let bucket = buckets.entry(bucket_pos).or_insert_with(|| {
+                        let key = get_bucket_key_from_pos(bucket_pos as f64, interval, offset);
+                        SegmentHistogramBucketEntry {
+                            key,
+                            doc_count: 0,
+                            bucket_id: self.bucket_id_provider.next_bucket_id(),
+                        }
+                    });
+                    bucket.doc_count += 1;
                     sub_agg.push(bucket.bucket_id, doc);
+                }
+            }
+        } else {
+            for val in agg_data.column_block_accessor.iter_vals() {
+                let val = f64_from_fastfield_u64(val, req.field_type);
+                let bucket_pos = get_bucket_pos(val);
+                if bounds.contains(val) {
+                    let bucket = buckets.entry(bucket_pos).or_insert_with(|| {
+                        let key = get_bucket_key_from_pos(bucket_pos as f64, interval, offset);
+                        SegmentHistogramBucketEntry {
+                            key,
+                            doc_count: 0,
+                            bucket_id: self.bucket_id_provider.next_bucket_id(),
+                        }
+                    });
+                    bucket.doc_count += 1;
                 }
             }
         }

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -244,7 +244,7 @@ impl Display for HistogramBounds {
 }
 
 impl HistogramBounds {
-    fn contains(&self, val: f64) -> bool {
+    pub(crate) fn contains(&self, val: f64) -> bool {
         val >= self.min && val <= self.max
     }
 }
@@ -317,11 +317,11 @@ impl<B: BucketIdSlot> SegmentHistogramBucketEntry<B> {
 /// the histogram bounds). Buckets in `[base_pos, base_pos + len)` can be stored in a flat `Vec`
 /// indexed by `bucket_pos - base_pos`, avoiding the hash map on the hot path.
 #[derive(Clone, Copy, Debug)]
-struct DenseRange {
+pub(crate) struct DenseRange {
     /// `bucket_pos` mapped to index 0 of the dense `Vec`.
-    base_pos: i64,
+    pub(crate) base_pos: i64,
     /// Number of bucket positions in the range.
-    len: usize,
+    pub(crate) len: usize,
 }
 
 /// Storage for the histogram buckets of a single parent bucket.
@@ -444,8 +444,6 @@ pub struct SegmentHistogramCollector<B> {
     /// Theoretical bucket range derived from the column min/max, if dense `Vec` storage is
     /// viable. `None` keeps every parent bucket in the sparse hash map.
     dense_range: Option<DenseRange>,
-
-    small_column_block_accessor: columnar::ColumnBlockAccessor<u32>,
 }
 
 impl<B: BucketIdSlot> SegmentAggregationCollector for SegmentHistogramCollector<B> {
@@ -601,15 +599,7 @@ impl<B: BucketIdSlot> SegmentHistogramCollector<B> {
             None
         };
         let mut req_data = agg_data.per_request.histogram_req_data[node.idx_in_req_data].clone();
-        req_data.req.validate()?;
-        if req_data.field_type == ColumnType::DateTime && !req_data.is_date_histogram {
-            req_data.req.normalize_date_time();
-        }
-        req_data.bounds = req_data.req.hard_bounds.unwrap_or(HistogramBounds {
-            min: f64::MIN,
-            max: f64::MAX,
-        });
-        req_data.offset = req_data.req.offset.unwrap_or(0.0);
+        normalize_histogram_req(&mut req_data)?;
         agg_data
             .context
             .limits
@@ -629,9 +619,89 @@ impl<B: BucketIdSlot> SegmentHistogramCollector<B> {
             req_data,
             bucket_id_provider: BucketIdProvider::default(),
             dense_range,
-            small_column_block_accessor: columnar::ColumnBlockAccessor::default(),
         })
     }
+}
+
+impl SegmentHistogramCollector<()> {
+    /// Builds a histogram collector whose parent `t` is a dense histogram filled from
+    /// `counts[t * num_time_buckets .. (t + 1) * num_time_buckets]` (row-major). Used by the fused
+    /// terms×histogram collector to turn its flat 2D counters into the regular intermediate result,
+    /// so cross-segment merging is shared with the general path.
+    pub(crate) fn from_dense_rows(
+        req_data: HistogramAggReqData,
+        base_pos: i64,
+        num_time_buckets: usize,
+        counts: &[u32],
+    ) -> Self {
+        let interval = req_data.req.interval;
+        let offset = req_data.offset;
+        let num_parents = if num_time_buckets == 0 {
+            0
+        } else {
+            counts.len() / num_time_buckets
+        };
+        let parent_buckets = (0..num_parents)
+            .map(|t| {
+                let row = &counts[t * num_time_buckets..(t + 1) * num_time_buckets];
+                let buckets = row
+                    .iter()
+                    .enumerate()
+                    .map(|(b, &doc_count)| SegmentHistogramBucketEntry {
+                        key: get_bucket_key_from_pos(
+                            (base_pos + b as i64) as f64,
+                            interval,
+                            offset,
+                        ),
+                        doc_count: doc_count as u64,
+                        bucket_id: (),
+                    })
+                    .collect();
+                HistogramBuckets::Dense { base_pos, buckets }
+            })
+            .collect();
+        Self {
+            parent_buckets,
+            sub_agg: None,
+            req_data,
+            bucket_id_provider: BucketIdProvider::default(),
+            dense_range: None,
+        }
+    }
+}
+
+/// Validates and normalizes a histogram request in place: applies date ns-normalization (for a
+/// `histogram` on a date column) and resolves `bounds`/`offset` from the request.
+fn normalize_histogram_req(req_data: &mut HistogramAggReqData) -> crate::Result<()> {
+    req_data.req.validate()?;
+    if req_data.field_type == ColumnType::DateTime && !req_data.is_date_histogram {
+        req_data.req.normalize_date_time();
+    }
+    req_data.bounds = req_data.req.hard_bounds.unwrap_or(HistogramBounds {
+        min: f64::MIN,
+        max: f64::MAX,
+    });
+    req_data.offset = req_data.req.offset.unwrap_or(0.0);
+    Ok(())
+}
+
+/// Clones and normalizes (resolving interval/offset/bounds) the histogram request at `node`, and
+/// returns it together with its dense bucket range — or `None` if the column has no usable range.
+/// Used by the fused terms×histogram collector, which then owns the normalized request.
+pub(crate) fn prepare_histogram_dense_range(
+    agg_data: &AggregationsSegmentCtx,
+    node: &AggRefNode,
+) -> crate::Result<Option<(HistogramAggReqData, DenseRange)>> {
+    let mut req_data = agg_data.per_request.histogram_req_data[node.idx_in_req_data].clone();
+    normalize_histogram_req(&mut req_data)?;
+    let dense_range = compute_dense_range(
+        &req_data.accessor,
+        req_data.field_type,
+        req_data.req.interval,
+        req_data.offset,
+        req_data.bounds,
+    );
+    Ok(dense_range.map(|range| (req_data, range)))
 }
 
 /// Builds a boxed histogram (or date histogram) segment collector, picking the bucket-id storage
@@ -653,7 +723,7 @@ pub(crate) fn build_segment_histogram_collector(
 }
 
 #[inline]
-fn get_bucket_pos_f64(val: f64, interval: f64, offset: f64) -> f64 {
+pub(crate) fn get_bucket_pos_f64(val: f64, interval: f64, offset: f64) -> f64 {
     ((val - offset) / interval).floor()
 }
 

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -682,6 +682,22 @@ fn normalize_histogram_req(req_data: &mut HistogramAggReqData) -> crate::Result<
         max: f64::MAX,
     });
     req_data.offset = req_data.req.offset.unwrap_or(0.0);
+    // Drop `hard_bounds` that can't exclude any value (the column's range already sits inside
+    // them): the per-doc `bounds.contains` check is then a no-op, so collapsing to the unbounded
+    // sentinel lets the histogram hot loop skip it and the fused term×histogram path derive
+    // per-term counts from the grid. Only this collect-time filter is touched — empty-bucket
+    // emission reads `req.hard_bounds` directly (see `get_req_min_max`), and `hard_bounds` only
+    // ever clips that range, so a wider-than-data bound leaves the result unchanged.
+    if req_data.req.hard_bounds.is_some() {
+        let col_min = f64_from_fastfield_u64(req_data.accessor.min_value(), req_data.field_type);
+        let col_max = f64_from_fastfield_u64(req_data.accessor.max_value(), req_data.field_type);
+        if col_min >= req_data.bounds.min && col_max <= req_data.bounds.max {
+            req_data.bounds = HistogramBounds {
+                min: f64::MIN,
+                max: f64::MAX,
+            };
+        }
+    }
     Ok(())
 }
 
@@ -1405,6 +1421,55 @@ mod tests {
             "An invalid argument was passed: 'extended_bounds have to be inside hard_bounds, \
              extended_bounds: [1,12], hard_bounds [2,12]'"
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn histogram_non_binding_hard_bounds_test_multi_segment() -> crate::Result<()> {
+        histogram_non_binding_hard_bounds_test_with_opt(false)
+    }
+    #[test]
+    fn histogram_non_binding_hard_bounds_test_single_segment() -> crate::Result<()> {
+        histogram_non_binding_hard_bounds_test_with_opt(true)
+    }
+    /// `hard_bounds` wider than the data (here with mid-interval edges, to cover the "bound cuts a
+    /// bucket" case) can't exclude any value, so the result must be identical to the same request
+    /// without bounds. Guards the normalization that collapses such bounds to the unbounded
+    /// sentinel so the hot loop / fused path can skip the per-doc bounds check.
+    fn histogram_non_binding_hard_bounds_test_with_opt(merge_segments: bool) -> crate::Result<()> {
+        let values = vec![10.0, 12.0, 14.0, 16.0, 10.0, 13.0, 10.0, 12.0];
+        let index = get_test_index_from_values(merge_segments, &values)?;
+
+        // Mid-interval edges, but wider than the data range [10, 16] -> they exclude nothing.
+        let with_bounds: Aggregations = serde_json::from_value(json!({
+            "histogram": {
+                "histogram": {
+                    "field": "score_f64",
+                    "interval": 1.0,
+                    "hard_bounds": { "min": 9.5, "max": 16.5 }
+                }
+            }
+        }))
+        .unwrap();
+        let no_bounds: Aggregations = serde_json::from_value(json!({
+            "histogram": {
+                "histogram": { "field": "score_f64", "interval": 1.0 }
+            }
+        }))
+        .unwrap();
+
+        let res_bounds = exec_request(with_bounds, &index)?;
+        let res_plain = exec_request(no_bounds, &index)?;
+        // Dropping a non-binding bound must not change anything.
+        assert_eq!(res_bounds, res_plain);
+
+        // Sanity: buckets span the data range with gaps filled (min_doc_count defaults to 0).
+        assert_eq!(res_bounds["histogram"]["buckets"][0]["key"], 10.0);
+        assert_eq!(res_bounds["histogram"]["buckets"][0]["doc_count"], 3);
+        assert_eq!(res_bounds["histogram"]["buckets"][6]["key"], 16.0);
+        assert_eq!(res_bounds["histogram"]["buckets"][6]["doc_count"], 1);
+        assert_eq!(res_bounds["histogram"]["buckets"][7], Value::Null);
 
         Ok(())
     }

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -249,14 +249,47 @@ impl HistogramBounds {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq)]
-pub(crate) struct SegmentHistogramBucketEntry {
-    pub key: f64,
-    pub doc_count: u64,
-    pub bucket_id: BucketId,
+/// The per-bucket identifier stored in a [`SegmentHistogramBucketEntry`].
+///
+/// It is [`BucketId`] when the histogram has sub aggregations (which key their state by it), and
+/// the zero-sized `()` when it does not. Without sub aggregations the id is never read, so storing
+/// `()` drops 8 bytes per bucket (24 -> 16) and turns id assignment into a no-op.
+pub trait BucketIdSlot: Copy + Default + std::fmt::Debug + PartialEq {
+    /// Assigns the next id from the provider, called once when a bucket is first filled.
+    fn assign(provider: &mut BucketIdProvider) -> Self;
+    /// Resolves to the `BucketId` for sub-aggregation bookkeeping.
+    ///
+    /// Only ever called for the [`BucketId`] slot: the `()` slot is used exactly when there are no
+    /// sub aggregations, so every call site is guarded by `sub_agg.is_some()` and is dead for `()`.
+    fn to_bucket_id(self) -> BucketId;
+}
+impl BucketIdSlot for BucketId {
+    #[inline(always)]
+    fn assign(provider: &mut BucketIdProvider) -> Self {
+        provider.next_bucket_id()
+    }
+    #[inline(always)]
+    fn to_bucket_id(self) -> BucketId {
+        self
+    }
+}
+impl BucketIdSlot for () {
+    #[inline(always)]
+    fn assign(_provider: &mut BucketIdProvider) -> Self {}
+    #[inline(always)]
+    fn to_bucket_id(self) -> BucketId {
+        unreachable!("bucket ids are only resolved when sub aggregations are present")
+    }
 }
 
-impl SegmentHistogramBucketEntry {
+#[derive(Default, Clone, Debug, PartialEq)]
+pub(crate) struct SegmentHistogramBucketEntry<B> {
+    pub key: f64,
+    pub doc_count: u64,
+    pub bucket_id: B,
+}
+
+impl<B: BucketIdSlot> SegmentHistogramBucketEntry<B> {
     pub(crate) fn into_intermediate_bucket_entry(
         self,
         sub_aggregation: &mut Option<HighCardBufferedSubAggs>,
@@ -269,7 +302,7 @@ impl SegmentHistogramBucketEntry {
                 .add_intermediate_aggregation_result(
                     agg_data,
                     &mut sub_aggregation_res,
-                    self.bucket_id,
+                    self.bucket_id.to_bucket_id(),
                 )?;
         }
         Ok(IntermediateHistogramBucketEntry {
@@ -280,29 +313,142 @@ impl SegmentHistogramBucketEntry {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct HistogramBuckets {
-    pub buckets: FxHashMap<i64, SegmentHistogramBucketEntry>,
+/// The contiguous bucket range a histogram can span, derived from the column min/max (clamped to
+/// the histogram bounds). Buckets in `[base_pos, base_pos + len)` can be stored in a flat `Vec`
+/// indexed by `bucket_pos - base_pos`, avoiding the hash map on the hot path.
+#[derive(Clone, Copy, Debug)]
+struct DenseRange {
+    /// `bucket_pos` mapped to index 0 of the dense `Vec`.
+    base_pos: i64,
+    /// Number of bucket positions in the range.
+    len: usize,
 }
-impl HistogramBuckets {
+
+/// Storage for the histogram buckets of a single parent bucket.
+///
+/// Starts out sparse (a hash map keyed by `bucket_pos`). Once enough distinct buckets have been
+/// filled that we are clearly going to cover most of the column's theoretical range, it switches
+/// to a dense `Vec` indexed by `bucket_pos - base_pos`, which removes hashing from the hot loop.
+#[derive(Clone, Debug)]
+enum HistogramBuckets<B> {
+    Sparse(FxHashMap<i64, SegmentHistogramBucketEntry<B>>),
+    Dense {
+        base_pos: i64,
+        /// One slot per bucket position; a slot with `doc_count == 0` has not been hit yet.
+        buckets: Vec<SegmentHistogramBucketEntry<B>>,
+    },
+}
+impl<B> Default for HistogramBuckets<B> {
+    fn default() -> Self {
+        HistogramBuckets::Sparse(FxHashMap::default())
+    }
+}
+impl<B: BucketIdSlot> HistogramBuckets<B> {
     fn memory_consumption(&self) -> u64 {
-        self.buckets.capacity() as u64 * std::mem::size_of::<SegmentHistogramBucketEntry>() as u64
+        let num_slots = match self {
+            HistogramBuckets::Sparse(map) => map.capacity(),
+            HistogramBuckets::Dense { buckets, .. } => buckets.capacity(),
+        };
+        num_slots as u64 * std::mem::size_of::<SegmentHistogramBucketEntry<B>>() as u64
+    }
+
+    /// Switches from sparse to dense storage once the dense `Vec` would use no more memory than the
+    /// hash map does now, so the switch never increases memory. Called at block boundaries.
+    ///
+    /// The `Vec` holds one `Entry` per bucket position in the range. The map additionally stores
+    /// the key and a control byte per slot, at a load factor of 7/16..7/8, so for a dense histogram
+    /// its footprint grows past the `Vec` well before full coverage. And since the `Vec` never
+    /// grows afterwards while the map would keep growing, dense only gets relatively cheaper — so
+    /// no upper bound on the range is needed: a large but sparse range simply never crosses over.
+    #[inline]
+    fn maybe_densify(&mut self, dense_range: Option<DenseRange>) {
+        let Some(range) = dense_range else { return };
+        let HistogramBuckets::Sparse(map) = self else {
+            return;
+        };
+        let dense_bytes = range
+            .len
+            .saturating_mul(std::mem::size_of::<SegmentHistogramBucketEntry<B>>());
+        let sparse_bytes = map
+            .capacity()
+            .saturating_mul(std::mem::size_of::<(i64, SegmentHistogramBucketEntry<B>)>() + 1);
+        if dense_bytes > sparse_bytes {
+            return;
+        }
+        let map = std::mem::take(map);
+        let mut buckets = vec![SegmentHistogramBucketEntry::<B>::default(); range.len];
+        for (bucket_pos, entry) in map {
+            buckets[(bucket_pos - range.base_pos) as usize] = entry;
+        }
+        *self = HistogramBuckets::Dense {
+            base_pos: range.base_pos,
+            buckets,
+        };
+    }
+
+    /// Returns the bucket entry for `bucket_pos`, setting its key (and `bucket_id`, when `B` is
+    /// [`BucketId`]) on first use.
+    ///
+    /// For the dense variant `bucket_pos` is guaranteed to be inside the range, since it is
+    /// derived from the column min/max that bounds every value (see [`compute_dense_range`]).
+    #[inline]
+    fn get_or_create(
+        &mut self,
+        bucket_pos: i64,
+        bucket_id_provider: &mut BucketIdProvider,
+        key_from_pos: impl FnOnce(i64) -> f64,
+    ) -> &mut SegmentHistogramBucketEntry<B> {
+        match self {
+            HistogramBuckets::Sparse(map) => {
+                map.entry(bucket_pos)
+                    .or_insert_with(|| SegmentHistogramBucketEntry {
+                        key: key_from_pos(bucket_pos),
+                        doc_count: 0,
+                        bucket_id: B::assign(bucket_id_provider),
+                    })
+            }
+            HistogramBuckets::Dense { base_pos, buckets } => {
+                let idx = (bucket_pos - *base_pos) as usize;
+                debug_assert!(idx < buckets.len(), "bucket_pos outside the dense range");
+                let entry = &mut buckets[idx];
+                if entry.doc_count == 0 {
+                    entry.key = key_from_pos(bucket_pos);
+                    entry.bucket_id = B::assign(bucket_id_provider);
+                }
+                entry
+            }
+        }
+    }
+
+    /// Consumes the storage, yielding all non-empty bucket entries.
+    fn into_filled_entries(self) -> Vec<SegmentHistogramBucketEntry<B>> {
+        match self {
+            HistogramBuckets::Sparse(map) => map.into_values().collect(),
+            HistogramBuckets::Dense { buckets, .. } => {
+                buckets.into_iter().filter(|b| b.doc_count > 0).collect()
+            }
+        }
     }
 }
 
 /// The collector puts values from the fast field into the correct buckets and does a conversion to
 /// the correct datatype.
 #[derive(Debug)]
-pub struct SegmentHistogramCollector {
+pub struct SegmentHistogramCollector<B> {
     /// The buckets containing the aggregation data.
     /// One Histogram bucket per parent bucket id.
-    parent_buckets: Vec<HistogramBuckets>,
+    parent_buckets: Vec<HistogramBuckets<B>>,
     sub_agg: Option<HighCardBufferedSubAggs>,
     req_data: HistogramAggReqData,
     bucket_id_provider: BucketIdProvider,
+    /// Theoretical bucket range derived from the column min/max, if dense `Vec` storage is
+    /// viable. `None` keeps every parent bucket in the sparse hash map.
+    dense_range: Option<DenseRange>,
+
+    small_column_block_accessor: columnar::ColumnBlockAccessor<u32>,
 }
 
-impl SegmentAggregationCollector for SegmentHistogramCollector {
+impl<B: BucketIdSlot> SegmentAggregationCollector for SegmentHistogramCollector<B> {
     fn add_intermediate_aggregation_result(
         &mut self,
         agg_data: &AggregationsSegmentCtx,
@@ -327,7 +473,10 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         let mem_pre = self.get_memory_consumption(parent_bucket_id);
-        let buckets = &mut self.parent_buckets[parent_bucket_id as usize].buckets;
+        let dense_range = self.dense_range;
+        let store = &mut self.parent_buckets[parent_bucket_id as usize];
+        // Upgrade to dense storage before processing the block if the buckets are dense enough.
+        store.maybe_densify(dense_range);
 
         let req = &self.req_data;
         let bounds = req.bounds;
@@ -345,40 +494,35 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
                 .iter_docid_vals(docs, &req.accessor)
             {
                 let val = f64_from_fastfield_u64(val, req.field_type);
-                let bucket_pos = get_bucket_pos(val);
                 if bounds.contains(val) {
-                    let bucket = buckets.entry(bucket_pos).or_insert_with(|| {
-                        let key = get_bucket_key_from_pos(bucket_pos as f64, interval, offset);
-                        SegmentHistogramBucketEntry {
-                            key,
-                            doc_count: 0,
-                            bucket_id: self.bucket_id_provider.next_bucket_id(),
-                        }
-                    });
+                    let bucket = store.get_or_create(
+                        get_bucket_pos(val),
+                        &mut self.bucket_id_provider,
+                        |pos| get_bucket_key_from_pos(pos as f64, interval, offset),
+                    );
                     bucket.doc_count += 1;
-                    sub_agg.push(bucket.bucket_id, doc);
+                    sub_agg.push(bucket.bucket_id.to_bucket_id(), doc);
                 }
             }
         } else {
             for val in agg_data.column_block_accessor.iter_vals() {
                 let val = f64_from_fastfield_u64(val, req.field_type);
-                let bucket_pos = get_bucket_pos(val);
                 if bounds.contains(val) {
-                    let bucket = buckets.entry(bucket_pos).or_insert_with(|| {
-                        let key = get_bucket_key_from_pos(bucket_pos as f64, interval, offset);
-                        SegmentHistogramBucketEntry {
-                            key,
-                            doc_count: 0,
-                            bucket_id: self.bucket_id_provider.next_bucket_id(),
-                        }
-                    });
+                    let bucket = store.get_or_create(
+                        get_bucket_pos(val),
+                        &mut self.bucket_id_provider,
+                        |pos| get_bucket_key_from_pos(pos as f64, interval, offset),
+                    );
                     bucket.doc_count += 1;
                 }
             }
         }
 
-        let mem_delta = self.get_memory_consumption(parent_bucket_id) - mem_pre;
-        if mem_delta > 0 {
+        // `checked_sub` is `None` when densifying shrank the accounted memory; only account growth.
+        if let Some(mem_delta) = self
+            .get_memory_consumption(parent_bucket_id)
+            .checked_sub(mem_pre)
+        {
             agg_data.context.limits.add_memory_consumed(mem_delta)?;
         }
 
@@ -402,9 +546,7 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
         _agg_data: &AggregationsSegmentCtx,
     ) -> crate::Result<()> {
         while self.parent_buckets.len() <= max_bucket as usize {
-            self.parent_buckets.push(HistogramBuckets {
-                buckets: FxHashMap::default(),
-            });
+            self.parent_buckets.push(HistogramBuckets::default());
         }
         Ok(())
     }
@@ -421,7 +563,7 @@ impl SegmentAggregationCollector for SegmentHistogramCollector {
     }
 }
 
-impl SegmentHistogramCollector {
+impl<B: BucketIdSlot> SegmentHistogramCollector<B> {
     fn get_memory_consumption(&self, parent_bucket_id: BucketId) -> u64 {
         self.parent_buckets[parent_bucket_id as usize].memory_consumption()
     }
@@ -430,11 +572,12 @@ impl SegmentHistogramCollector {
     fn add_intermediate_bucket_result(
         &mut self,
         agg_data: &AggregationsSegmentCtx,
-        histogram: HistogramBuckets,
+        histogram: HistogramBuckets<B>,
     ) -> crate::Result<IntermediateBucketResult> {
-        let mut buckets = Vec::with_capacity(histogram.buckets.len());
+        let filled = histogram.into_filled_entries();
+        let mut buckets = Vec::with_capacity(filled.len());
 
-        for bucket in histogram.buckets.into_values() {
+        for bucket in filled {
             let bucket_res = bucket.into_intermediate_bucket_entry(&mut self.sub_agg, agg_data);
 
             buckets.push(bucket_res?);
@@ -471,6 +614,13 @@ impl SegmentHistogramCollector {
             .context
             .limits
             .add_memory_consumed(req_data.get_memory_consumption() as u64)?;
+        let dense_range = compute_dense_range(
+            &req_data.accessor,
+            req_data.field_type,
+            req_data.req.interval,
+            req_data.offset,
+            req_data.bounds,
+        );
         let sub_agg = sub_agg.map(BufferedSubAggs::new);
 
         Ok(Self {
@@ -478,13 +628,61 @@ impl SegmentHistogramCollector {
             sub_agg,
             req_data,
             bucket_id_provider: BucketIdProvider::default(),
+            dense_range,
+            small_column_block_accessor: columnar::ColumnBlockAccessor::default(),
         })
+    }
+}
+
+/// Builds a boxed histogram (or date histogram) segment collector, picking the bucket-id storage
+/// based on whether there are sub aggregations: `()` (no id stored) when there are none, otherwise
+/// [`BucketId`].
+pub(crate) fn build_segment_histogram_collector(
+    agg_data: &mut AggregationsSegmentCtx,
+    node: &AggRefNode,
+) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    if node.children.is_empty() {
+        Ok(Box::new(
+            SegmentHistogramCollector::<()>::from_req_and_validate(agg_data, node)?,
+        ))
+    } else {
+        Ok(Box::new(
+            SegmentHistogramCollector::<BucketId>::from_req_and_validate(agg_data, node)?,
+        ))
     }
 }
 
 #[inline]
 fn get_bucket_pos_f64(val: f64, interval: f64, offset: f64) -> f64 {
     ((val - offset) / interval).floor()
+}
+
+/// Computes the dense bucket range for a column from its min/max value (clamped to the histogram
+/// bounds), or `None` if there are no values within bounds (or the range overflows `usize`).
+///
+/// There is no upper bound on the range: whether dense storage is actually used is decided later,
+/// per parent bucket, by [`HistogramBuckets::maybe_densify`] based on the memory it would save.
+///
+/// The column min/max bound every value the collector can see, so a `Vec` sized to this range can
+/// be indexed by `bucket_pos - base_pos` without any out-of-bounds check on the hot path.
+fn compute_dense_range(
+    accessor: &Column<u64>,
+    field_type: ColumnType,
+    interval: f64,
+    offset: f64,
+    bounds: HistogramBounds,
+) -> Option<DenseRange> {
+    let col_min = f64_from_fastfield_u64(accessor.min_value(), field_type);
+    let col_max = f64_from_fastfield_u64(accessor.max_value(), field_type);
+    let lo = col_min.max(bounds.min);
+    let hi = col_max.min(bounds.max);
+    if lo > hi {
+        return None;
+    }
+    let base_pos = get_bucket_pos_f64(lo, interval, offset) as i64;
+    let top_pos = get_bucket_pos_f64(hi, interval, offset) as i64;
+    let len = usize::try_from(top_pos.checked_sub(base_pos)?.checked_add(1)?).ok()?;
+    (len > 0).then_some(DenseRange { base_pos, len })
 }
 
 #[inline]
@@ -788,6 +986,62 @@ mod tests {
         assert_eq!(res["histogram"]["buckets"][99]["key"], 99.0);
         assert_eq!(res["histogram"]["buckets"][99]["doc_count"], 1);
         assert_eq!(res["histogram"]["buckets"][100], Value::Null);
+        Ok(())
+    }
+
+    #[test]
+    fn histogram_dense_storage_test() -> crate::Result<()> {
+        histogram_dense_storage_test_with_opt(false)?;
+        histogram_dense_storage_test_with_opt(true)?;
+        Ok(())
+    }
+
+    /// Exercises the switch from sparse hash map to dense `Vec` storage. The switch happens at a
+    /// block boundary (a block is `COLLECT_BLOCK_BUFFER_LEN` = 64 docs), so we need many docs in a
+    /// single segment, densely covering the bucket range. `with_sub_agg` toggles the `iter_vals`
+    /// fast path vs. the `iter_docid_vals` path used when there is a sub aggregation.
+    fn histogram_dense_storage_test_with_opt(with_sub_agg: bool) -> crate::Result<()> {
+        let num_buckets = 50usize;
+        let docs_per_bucket = 10usize;
+        // Value `k` repeated `docs_per_bucket` times for each bucket `k`, so every value in bucket
+        // `k` equals `k` and the per-bucket average is exactly `k`.
+        let values: Vec<f64> = (0..num_buckets * docs_per_bucket)
+            .map(|i| (i % num_buckets) as f64)
+            .collect();
+        // `merge_segments = true` collapses the per-value segments into a single segment with all
+        // the docs, which is collected in 64-doc blocks and therefore switches to dense storage.
+        let index = get_test_index_from_values(true, &values)?;
+
+        let agg_req: Aggregations = serde_json::from_value(if with_sub_agg {
+            json!({
+                "histogram": {
+                    "histogram": { "field": "score_f64", "interval": 1.0 },
+                    "aggs": { "avg": { "avg": { "field": "score_f64" } } }
+                }
+            })
+        } else {
+            json!({
+                "histogram": {
+                    "histogram": { "field": "score_f64", "interval": 1.0 }
+                }
+            })
+        })
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        for k in 0..num_buckets {
+            assert_eq!(res["histogram"]["buckets"][k]["key"], k as f64);
+            assert_eq!(
+                res["histogram"]["buckets"][k]["doc_count"],
+                docs_per_bucket as u64
+            );
+            if with_sub_agg {
+                assert_eq!(res["histogram"]["buckets"][k]["avg"]["value"], k as f64);
+            }
+        }
+        assert_eq!(res["histogram"]["buckets"][num_buckets], Value::Null);
+
         Ok(())
     }
 

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -636,11 +636,7 @@ impl SegmentHistogramCollector<()> {
     ) -> Self {
         let interval = req_data.req.interval;
         let offset = req_data.offset;
-        let num_parents = if num_time_buckets == 0 {
-            0
-        } else {
-            counts.len() / num_time_buckets
-        };
+        let num_parents = counts.len().checked_div(num_time_buckets).unwrap_or(0);
         let parent_buckets = (0..num_parents)
             .map(|t| {
                 let row = &counts[t * num_time_buckets..(t + 1) * num_time_buckets];

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -376,7 +376,7 @@ pub(crate) fn build_segment_term_collector(
     // Let's see if we can use a vec to aggregate our data
     // instead of a hashmap.
     let col_max_value = terms_req_data.accessor.max_value();
-    let max_term_id: u64 =
+    let max_column_val: u64 =
         col_max_value.max(terms_req_data.missing_value_for_accessor.unwrap_or(0u64));
 
     // Fused fast path: low-cardinality terms × a single `histogram`/`date_histogram` leaf over full
@@ -385,7 +385,7 @@ pub(crate) fn build_segment_term_collector(
         req_data,
         node,
         &terms_req_data,
-        max_term_id,
+        max_column_val,
         is_top_level,
     )? {
         return Ok(collector);
@@ -399,30 +399,30 @@ pub(crate) fn build_segment_term_collector(
 
     let mut bucket_id_provider = BucketIdProvider::default();
     // Decide which bucket storage is best suited for this aggregation.
-    if is_top_level && max_term_id < MAX_NUM_TERMS_FOR_VEC && !has_sub_aggregations {
-        let term_buckets = VecTermBucketsNoAgg::new(max_term_id + 1, &mut bucket_id_provider);
+    if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC && !has_sub_aggregations {
+        let term_buckets = VecTermBucketsNoAgg::new(max_column_val + 1, &mut bucket_id_provider);
         let collector: SegmentTermCollector<_, HighCardSubAggBuffer> = SegmentTermCollector {
             parent_buckets: vec![term_buckets],
             sub_agg: None,
             bucket_id_provider,
-            max_term_id,
+            max_term_id: max_column_val,
             terms_req_data,
         };
         Ok(Box::new(collector))
-    } else if is_top_level && max_term_id < MAX_NUM_TERMS_FOR_VEC {
-        let term_buckets = VecTermBuckets::new(max_term_id + 1, &mut bucket_id_provider);
+    } else if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC {
+        let term_buckets = VecTermBuckets::new(max_column_val + 1, &mut bucket_id_provider);
         let sub_agg = sub_agg_collector.map(LowCardBufferedSubAggs::new);
         let collector: SegmentTermCollector<_, LowCardSubAggBuffer> = SegmentTermCollector {
             parent_buckets: vec![term_buckets],
             sub_agg,
             bucket_id_provider,
-            max_term_id,
+            max_term_id: max_column_val,
             terms_req_data,
         };
         Ok(Box::new(collector))
-    } else if max_term_id < 8_000_000 && is_top_level {
+    } else if max_column_val < 8_000_000 && is_top_level {
         let term_buckets: PagedTermMap =
-            PagedTermMap::new(max_term_id + 1, &mut bucket_id_provider);
+            PagedTermMap::new(max_column_val + 1, &mut bucket_id_provider);
         // Build sub-aggregation blueprint (flat pairs)
         let sub_agg = sub_agg_collector.map(BufferedSubAggs::new);
         let collector: SegmentTermCollector<PagedTermMap, HighCardSubAggBuffer> =
@@ -430,7 +430,7 @@ pub(crate) fn build_segment_term_collector(
                 parent_buckets: vec![term_buckets],
                 sub_agg,
                 bucket_id_provider,
-                max_term_id,
+                max_term_id: max_column_val,
                 terms_req_data,
             };
         Ok(Box::new(collector))
@@ -443,7 +443,7 @@ pub(crate) fn build_segment_term_collector(
                 parent_buckets: vec![term_buckets],
                 sub_agg,
                 bucket_id_provider,
-                max_term_id,
+                max_term_id: max_column_val,
                 terms_req_data,
             };
         Ok(Box::new(collector))

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -29,6 +29,8 @@ use crate::aggregation::{format_date, BucketId, Key};
 use crate::error::DataCorruption;
 use crate::TantivyError;
 
+mod term_histogram;
+
 /// Contains all information required by the SegmentTermCollector to perform the
 /// terms aggregation on a segment.
 #[derive(Debug, Clone)]
@@ -376,6 +378,18 @@ pub(crate) fn build_segment_term_collector(
     let col_max_value = terms_req_data.accessor.max_value();
     let max_term_id: u64 =
         col_max_value.max(terms_req_data.missing_value_for_accessor.unwrap_or(0u64));
+
+    // Fused fast path: low-cardinality terms × a single `histogram`/`date_histogram` leaf over full
+    // columns with a small enough bucket grid. Anything else falls through to the general path.
+    if let Some(collector) = term_histogram::maybe_build_collector(
+        req_data,
+        node,
+        &terms_req_data,
+        max_term_id,
+        is_top_level,
+    )? {
+        return Ok(collector);
+    }
 
     let sub_agg_collector = if has_sub_aggregations {
         Some(build_segment_agg_collectors(req_data, &node.children)?)

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -59,6 +59,16 @@ pub(crate) struct SegmentTermHistogramCollector {
     /// `collect` independent of `agg_data`.
     term_block: ColumnBlockAccessor<u64>,
     hist_block: ColumnBlockAccessor<u64>,
+    /// When true, `term_counts` is left untouched during `collect` and derived from the grid
+    /// row-sums at result time. Valid only when there are no hard bounds: then every doc lands in
+    /// the dense range, so the per-term total equals the sum over its histogram buckets, and we
+    /// can drop both the per-doc `term_counts` increment and the (always-true) bounds check.
+    ///
+    /// This is a real hot-loop win (~17% on `terms_status_with_(date_)histogram`): with low term
+    /// cardinality, `term_counts[term_id] += 1` repeatedly hits the same few addresses, so the
+    /// read-modify-write serializes across iterations on store-to-load forwarding latency. Summing
+    /// the grid once at the end avoids that loop-carried dependency entirely.
+    derive_term_counts_from_histogram: bool,
 }
 
 impl SegmentAggregationCollector for SegmentTermHistogramCollector {
@@ -74,6 +84,15 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         );
         // Expand the flat grid back into the regular structures and reuse the shared builders, so
         // ordering/cut-off/dict handling and cross-segment merging match the general path exactly.
+        if self.derive_term_counts_from_histogram {
+            // `collect` skipped the per-doc total; recover it as the grid row-sum (every doc landed
+            // in a bucket, since there are no hard bounds).
+            let nb = self.num_time_buckets;
+            let counts = &self.counts;
+            for (t, slot) in self.term_counts.iter_mut().enumerate() {
+                *slot = counts[t * nb..(t + 1) * nb].iter().sum();
+            }
+        }
         let mut bucket_id_provider = BucketIdProvider::default();
         let term_buckets = VecTermBuckets {
             buckets: self
@@ -131,21 +150,37 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         let term_counts = &mut self.term_counts;
         let counts = &mut self.counts;
 
-        // Single fused pass: both columns are full (checked at construction), so their values align
-        // with `docs` positionally and we zip them. `term_id` is a dense `Vec` index here, and the
-        // histogram bucket is guaranteed inside `[0, num_time_buckets)` because the dense range is
-        // derived from the column min/max that bounds every value.
-        for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals()) {
-            let term_id = term_id as usize;
-            term_counts[term_id] += 1;
-            let val = f64_from_fastfield_u64(hist_raw, field_type);
-            if bounds.contains(val) {
+        // Both columns are full (checked at construction), so values align with `docs` positionally
+        // and are read together in one pass.
+        if self.derive_term_counts_from_histogram {
+            // No hard bounds: every doc lands in a bucket, so we skip the per-doc `term_counts`
+            // increment (derived from the grid at flush) and the always-true bounds check.
+            for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
+            {
+                let term_id = term_id as usize;
+                let val = f64_from_fastfield_u64(hist_raw, field_type);
                 let bucket = (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
                 debug_assert!(
                     bucket < num_time_buckets,
                     "histogram bucket outside dense range"
                 );
                 counts[term_id * num_time_buckets + bucket] += 1;
+            }
+        } else {
+            for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
+            {
+                let term_id = term_id as usize;
+                term_counts[term_id] += 1;
+                let val = f64_from_fastfield_u64(hist_raw, field_type);
+                if bounds.contains(val) {
+                    let bucket =
+                        (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
+                    debug_assert!(
+                        bucket < num_time_buckets,
+                        "histogram bucket outside dense range"
+                    );
+                    counts[term_id * num_time_buckets + bucket] += 1;
+                }
             }
         }
         Ok(())
@@ -231,6 +266,10 @@ pub(super) fn maybe_build_collector(
         .context
         .limits
         .add_memory_consumed((counts.len() * std::mem::size_of::<u32>()) as u64)?;
+    // With no hard bounds every doc lands in the dense range, so the per-term totals can be derived
+    // from the grid at result time instead of incremented per doc.
+    let derive_term_counts_from_histogram =
+        hist_req_data.bounds.min == f64::MIN && hist_req_data.bounds.max == f64::MAX;
     Ok(Some(Box::new(SegmentTermHistogramCollector {
         term_counts: vec![0u32; num_terms],
         counts,
@@ -240,6 +279,7 @@ pub(super) fn maybe_build_collector(
         hist_req_data,
         term_block: ColumnBlockAccessor::default(),
         hist_block: ColumnBlockAccessor::default(),
+        derive_term_counts_from_histogram,
     })))
 }
 
@@ -376,6 +416,62 @@ mod tests {
                 bucket["histo"]["buckets"][0]["doc_count"],
                 docs_per_term as u64
             );
+        }
+
+        Ok(())
+    }
+
+    /// `hard_bounds` exercises the non-derived `term_counts` branch: a term's `doc_count` must
+    /// count *every* doc with that term, including docs whose histogram value is outside the
+    /// bounds (those are excluded from the histogram buckets but still counted for the term). This
+    /// is the case where the per-doc `term_counts` increment cannot be replaced by the grid
+    /// row-sum.
+    #[test]
+    fn fused_term_histogram_with_hard_bounds() -> crate::Result<()> {
+        // 300 docs: term = {a, b, c} by i % 3, value = i % 20. Per term: 100 docs, each value in
+        // 0..=19 occurring 5 times.
+        let docs: Vec<(f64, String)> = (0..300u64)
+            .map(|i| {
+                (
+                    (i % 20) as f64,
+                    ["a", "b", "c"][(i % 3) as usize].to_string(),
+                )
+            })
+            .collect();
+        let index = get_test_index_from_values_and_terms(true, &[docs])?;
+
+        // hard_bounds [5, 14] (inclusive) keeps only values 5..=14 in the histogram (10 buckets);
+        // values 0..=4 and 15..=19 are out of bounds.
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id", "order": { "_key": "asc" } },
+                "aggs": {
+                    "histo": {
+                        "histogram": {
+                            "field": "score_f64",
+                            "interval": 1.0,
+                            "hard_bounds": { "min": 5.0, "max": 14.0 }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        for (term_idx, term) in ["a", "b", "c"].iter().enumerate() {
+            assert_eq!(res["by_term"]["buckets"][term_idx]["key"], *term);
+            // doc_count includes the 50 per-term docs whose value is outside [5, 14].
+            assert_eq!(res["by_term"]["buckets"][term_idx]["doc_count"], 100);
+            let histo = &res["by_term"]["buckets"][term_idx]["histo"]["buckets"];
+            for b in 0..10usize {
+                let key = 5 + b;
+                assert_eq!(histo[b]["key"], key as f64, "term {term} bucket key {key}");
+                assert_eq!(histo[b]["doc_count"], 5, "term {term} bucket {key}");
+            }
+            // Only the 10 in-bounds buckets exist.
+            assert_eq!(histo[10], serde_json::Value::Null);
         }
 
         Ok(())

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -22,7 +22,9 @@ use crate::aggregation::{f64_from_fastfield_u64, BucketId};
 /// Maximum number of cells (`num_terms × num_time_buckets`) in the fused flat 2D grid. Above this
 /// the grid would be too large/cache-unfriendly, so we fall back to the general buffered path.
 /// `1 << 14` cells = 128 KB of `u64` counters, comfortably L2-resident.
-const MAX_FUSED_GRID_BUCKETS: usize = 1 << 14;
+///
+/// Since we are only at the top-level, this won't be multiplied by any parent buckets.
+const MAX_FUSED_GRID_BUCKETS: usize = 16384;
 
 /// Fused collector for `terms` (low cardinality) × a single `histogram`/`date_histogram` leaf with
 /// nothing nested below it, when the resulting `num_terms × num_time_buckets` grid is small (see
@@ -87,10 +89,11 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         if self.derive_term_counts_from_histogram {
             // `collect` skipped the per-doc total; recover it as the grid row-sum (every doc landed
             // in a bucket, since there are no hard bounds).
-            let nb = self.num_time_buckets;
-            let counts = &self.counts;
-            for (t, slot) in self.term_counts.iter_mut().enumerate() {
-                *slot = counts[t * nb..(t + 1) * nb].iter().sum();
+            for (term_id, term_count) in self.term_counts.iter_mut().enumerate() {
+                *term_count = self.counts
+                    [term_id * self.num_time_buckets..(term_id + 1) * self.num_time_buckets]
+                    .iter()
+                    .sum();
             }
         }
         let mut bucket_id_provider = BucketIdProvider::default();
@@ -141,6 +144,11 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         self.hist_block
             .fetch_block(docs, &self.hist_req_data.accessor);
 
+        // Hoist the loop-invariant fields into locals: the optimizer can't prove the
+        // `self.counts`/`self.term_counts` writes don't alias these `self` fields, so it can't keep
+        // them in registers and re-reads them from memory every iteration — ~15% slower on
+        // `terms_status_with_date_histogram` when read straight from `self`.
+        // Note: check which are actually relevant.
         let field_type = self.hist_req_data.field_type;
         let bounds = self.hist_req_data.bounds;
         let interval = self.hist_req_data.req.interval;
@@ -155,10 +163,10 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         if self.derive_term_counts_from_histogram {
             // No hard bounds: every doc lands in a bucket, so we skip the per-doc `term_counts`
             // increment (derived from the grid at flush) and the always-true bounds check.
-            for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
+            for (term_id, hist_val) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
             {
                 let term_id = term_id as usize;
-                let val = f64_from_fastfield_u64(hist_raw, field_type);
+                let val = f64_from_fastfield_u64(hist_val, field_type);
                 let bucket = (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
                 debug_assert!(
                     bucket < num_time_buckets,
@@ -233,9 +241,10 @@ pub(super) fn maybe_build_collector(
     let fuseable = is_top_level
         && terms_req_data.allowed_term_ids.is_none()
         && terms_req_data.accessor.get_cardinality().is_full()
-        // The flat counters are `u32`; a per-segment count can't exceed the doc count, so this
-        // guarantees no overflow (essentially always true, as `DocId` is `u32`).
-        && terms_req_data.accessor.num_docs() < u32::MAX
+        // The flat counters are `u32`, bumped once per value, so no count can exceed the column's
+        // value count. (Essentially always true here: the column is full, so its value count
+        // equals the doc count, and `DocId` is `u32`.)
+        && terms_req_data.accessor.values.num_vals() < u32::MAX
         && node.children.len() == 1
         && matches!(
             node.children[0].kind,
@@ -472,6 +481,58 @@ mod tests {
             }
             // Only the 10 in-bounds buckets exist.
             assert_eq!(histo[10], serde_json::Value::Null);
+        }
+
+        Ok(())
+    }
+
+    /// Non-binding `hard_bounds` (wider than the data, with mid-interval edges) must still produce
+    /// exact results via the derive-from-grid path: since no doc is out of bounds, normalization
+    /// drops the bound, every doc lands in the dense range, and each term's total equals its
+    /// histogram row-sum. This is the case that previously fell back to the per-doc counter only
+    /// because `bounds != [MIN, MAX]`.
+    #[test]
+    fn fused_term_histogram_with_non_binding_hard_bounds() -> crate::Result<()> {
+        // 300 docs: term = {a, b, c} by i % 3, value = i % 20. Data values span [0, 19].
+        let docs: Vec<(f64, String)> = (0..300u64)
+            .map(|i| {
+                (
+                    (i % 20) as f64,
+                    ["a", "b", "c"][(i % 3) as usize].to_string(),
+                )
+            })
+            .collect();
+        let index = get_test_index_from_values_and_terms(true, &[docs])?;
+
+        // Bounds wider than [0, 19], with mid-interval edges -> they exclude nothing.
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id", "order": { "_key": "asc" } },
+                "aggs": {
+                    "histo": {
+                        "histogram": {
+                            "field": "score_f64",
+                            "interval": 1.0,
+                            "hard_bounds": { "min": -0.5, "max": 19.5 }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        for (term_idx, term) in ["a", "b", "c"].iter().enumerate() {
+            assert_eq!(res["by_term"]["buckets"][term_idx]["key"], *term);
+            // Every doc is in-bounds, so the per-term total is the full 100 (as without bounds).
+            assert_eq!(res["by_term"]["buckets"][term_idx]["doc_count"], 100);
+            let histo = &res["by_term"]["buckets"][term_idx]["histo"]["buckets"];
+            for b in 0..20usize {
+                assert_eq!(histo[b]["key"], b as f64, "term {term} bucket {b}");
+                assert_eq!(histo[b]["doc_count"], 5, "term {term} bucket {b}");
+            }
+            assert_eq!(histo[20], serde_json::Value::Null);
         }
 
         Ok(())

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -65,6 +65,9 @@ pub(crate) struct SegmentTermHistogramCollector {
     hist_block: ColumnBlockAccessor<u64>,
     /// No hard bounds, so every doc is in-bounds.
     all_docs_in_bounds: bool,
+    /// Both columns are full (fused-path precondition); cached so `collect` skips the per-block
+    /// cardinality lookup in `fetch_block`.
+    is_full: bool,
 }
 
 impl SegmentAggregationCollector for SegmentTermHistogramCollector {
@@ -132,9 +135,9 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         // single `agg_data` scratch accessor). The collector owns all its inputs, so `collect`
         // doesn't touch `agg_data`.
         self.term_block
-            .fetch_block(docs, &self.terms_req_data.accessor);
+            .fetch_block_with_is_full(docs, &self.terms_req_data.accessor, self.is_full);
         self.hist_block
-            .fetch_block(docs, &self.hist_req_data.accessor);
+            .fetch_block_with_is_full(docs, &self.hist_req_data.accessor, self.is_full);
 
         // Hoist the loop-invariant fields into locals: the optimizer can't prove the
         // `self.counts`/`self.term_counts` writes don't alias these `self` fields, so it can't keep
@@ -223,6 +226,7 @@ pub(super) fn maybe_build_collector(
     // using too much memory. We could check the maximum theoretical buckets up-front and pass
     // them down.
     let fuseable = is_top_level
+        // TODO: We can easily support this
         && terms_req_data.allowed_term_ids.is_none()
         && terms_req_data.accessor.get_cardinality().is_full()
         // The flat counters are `u32`, bumped once per value, so no count can exceed the column's
@@ -273,6 +277,7 @@ pub(super) fn maybe_build_collector(
         term_block: ColumnBlockAccessor::default(),
         hist_block: ColumnBlockAccessor::default(),
         all_docs_in_bounds,
+        is_full: terms_req_data.accessor.get_cardinality().is_full(),
     })))
 }
 

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -41,9 +41,8 @@ const MAX_FUSED_GRID_BUCKETS: usize = 16384;
 /// general path.
 #[derive(Debug)]
 pub(crate) struct SegmentTermHistogramCollector {
-    /// The counts, indexed by term id.
-    ///
-    /// Only used when we can't derive the term counts from `counts`.
+    /// Per-term count of docs *outside* `hard_bounds` (still in `doc_count`, but in no bucket).
+    /// Per-term total = this + the term's `counts` row-sum; all-zero when there are no bounds.
     term_counts: Vec<u32>,
     /// Flattened `[num_terms * num_time_buckets]` histogram counters (`u32`, see
     /// `term_counts`).
@@ -64,16 +63,8 @@ pub(crate) struct SegmentTermHistogramCollector {
     /// `collect` independent of `agg_data`.
     term_block: ColumnBlockAccessor<u64>,
     hist_block: ColumnBlockAccessor<u64>,
-    /// When true, `term_counts` is left untouched during `collect` and derived from the grid
-    /// row-sums at result time. Valid only when there are no hard bounds: then every doc lands in
-    /// the dense range, so the per-term total equals the sum over its histogram buckets, and we
-    /// can drop both the per-doc `term_counts` increment and the (always-true) bounds check.
-    ///
-    /// This is a real hot-loop win (~17% on `terms_status_with_(date_)histogram`): with low term
-    /// cardinality, `term_counts[term_id] += 1` repeatedly hits the same few addresses, so the
-    /// read-modify-write serializes across iterations on store-to-load forwarding latency. Summing
-    /// the grid once at the end avoids that loop-carried dependency entirely.
-    derive_term_counts_from_histogram: bool,
+    /// No hard bounds, so every doc is in-bounds.
+    all_docs_in_bounds: bool,
 }
 
 impl SegmentAggregationCollector for SegmentTermHistogramCollector {
@@ -89,24 +80,22 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         );
         // Expand the flat grid back into the regular structures and reuse the shared builders, so
         // ordering/cut-off/dict handling and cross-segment merging match the general path exactly.
-        if self.derive_term_counts_from_histogram {
-            // `collect` skipped the per-doc total; recover it as the grid row-sum (every doc landed
-            // in a bucket, since there are no hard bounds).
-            for (term_id, term_count) in self.term_counts.iter_mut().enumerate() {
-                *term_count = self.counts
-                    [term_id * self.num_time_buckets..(term_id + 1) * self.num_time_buckets]
-                    .iter()
-                    .sum();
-            }
-        }
         let mut bucket_id_provider = BucketIdProvider::default();
+        // Per-term total = histogram row-sum (in-bounds) + `term_counts` (out-of-bounds remainder).
         let term_buckets = VecTermBuckets {
             buckets: self
                 .term_counts
                 .iter()
-                .map(|&count| Bucket {
-                    count,
-                    bucket_id: bucket_id_provider.next_bucket_id(),
+                .enumerate()
+                .map(|(term_id, &out_of_bounds)| {
+                    let in_bounds: u32 = self.counts
+                        [term_id * self.num_time_buckets..(term_id + 1) * self.num_time_buckets]
+                        .iter()
+                        .sum();
+                    Bucket {
+                        count: in_bounds + out_of_bounds,
+                        bucket_id: bucket_id_provider.next_bucket_id(),
+                    }
                 })
                 .collect(),
         };
@@ -158,40 +147,27 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         let offset = self.hist_req_data.offset;
         let base_pos = self.base_pos;
         let num_time_buckets = self.num_time_buckets;
+        let all_docs_in_bounds = self.all_docs_in_bounds;
         let term_counts = &mut self.term_counts;
         let counts = &mut self.counts;
 
         // Both columns are full (checked at construction), so values align with `docs` positionally
         // and are read together in one pass.
-        if self.derive_term_counts_from_histogram {
-            // No hard bounds: every doc lands in a bucket, so we skip the per-doc `term_counts`
-            // increment (derived from the grid at flush) and the always-true bounds check.
-            for (term_id, hist_val) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
-            {
-                let term_id = term_id as usize;
-                let val = f64_from_fastfield_u64(hist_val, field_type);
+        // In-bounds docs bump the `counts` grid, out-of-bounds bump `term_counts`; deriving the
+        // total at flush avoids a per-doc `term_counts` RMW that serializes on
+        // store-to-load forwarding.
+        for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals()) {
+            let term_id = term_id as usize;
+            let val = f64_from_fastfield_u64(hist_raw, field_type);
+            if all_docs_in_bounds || bounds.contains(val) {
                 let bucket = (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
                 debug_assert!(
                     bucket < num_time_buckets,
                     "histogram bucket outside dense range"
                 );
                 counts[term_id * num_time_buckets + bucket] += 1;
-            }
-        } else {
-            for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals())
-            {
-                let term_id = term_id as usize;
+            } else {
                 term_counts[term_id] += 1;
-                let val = f64_from_fastfield_u64(hist_raw, field_type);
-                if bounds.contains(val) {
-                    let bucket =
-                        (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
-                    debug_assert!(
-                        bucket < num_time_buckets,
-                        "histogram bucket outside dense range"
-                    );
-                    counts[term_id * num_time_buckets + bucket] += 1;
-                }
             }
         }
         Ok(())
@@ -278,9 +254,9 @@ pub(super) fn maybe_build_collector(
         .context
         .limits
         .add_memory_consumed((counts.len() * std::mem::size_of::<u32>()) as u64)?;
-    // With no hard bounds every doc lands in the dense range, so the per-term totals can be derived
-    // from the grid at result time instead of incremented per doc.
-    let derive_term_counts_from_histogram =
+    // No hard bounds means every doc is in-bounds, letting `collect` short-circuit the bounds
+    // check.
+    let all_docs_in_bounds =
         hist_req_data.bounds.min == f64::MIN && hist_req_data.bounds.max == f64::MAX;
     Ok(Some(Box::new(SegmentTermHistogramCollector {
         term_counts: vec![0u32; num_terms],
@@ -291,7 +267,7 @@ pub(super) fn maybe_build_collector(
         hist_req_data,
         term_block: ColumnBlockAccessor::default(),
         hist_block: ColumnBlockAccessor::default(),
-        derive_term_counts_from_histogram,
+        all_docs_in_bounds,
     })))
 }
 

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -41,13 +41,16 @@ const MAX_FUSED_GRID_BUCKETS: usize = 16384;
 /// general path.
 #[derive(Debug)]
 pub(crate) struct SegmentTermHistogramCollector {
-    /// `[num_terms]` total doc count per term bucket (independent of the histogram bounds).
-    /// `u32` is enough: a per-segment count can't exceed the segment's doc count (`DocId` is
-    /// `u32`); the fused path is only taken when `num_docs < u32::MAX` (see
-    /// `maybe_build_collector`).
+    /// The counts, indexed by term id.
+    ///
+    /// Only used when we can't derive the term counts from `counts`.
     term_counts: Vec<u32>,
-    /// Flat row-major `[num_terms * num_time_buckets]` histogram counters (`u32`, see
+    /// Flattened `[num_terms * num_time_buckets]` histogram counters (`u32`, see
     /// `term_counts`).
+    ///
+    /// Each term id get its own contiguous slice of `num_time_buckets` histogram counter.
+    /// When we count all docs (#nofilter), we can derive the per-term total as the sum over that
+    /// term's slice.
     counts: Vec<u32>,
     /// Histogram buckets per term (the dense time-range length).
     num_time_buckets: usize,

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -42,7 +42,8 @@ const MAX_FUSED_GRID_BUCKETS: usize = 16384;
 #[derive(Debug)]
 pub(crate) struct SegmentTermHistogramCollector {
     /// Per-term count of docs *outside* `hard_bounds` (still in `doc_count`, but in no bucket).
-    /// Per-term total = this + the term's `counts` row-sum; all-zero when there are no bounds.
+    /// Per-term total = this + the term's `counts` row-sum; left empty when there are no hard
+    /// bounds (every doc is in-bounds, so there's no remainder to track).
     term_counts: Vec<u32>,
     /// Flattened `[num_terms * num_time_buckets]` histogram counters (`u32`, see
     /// `term_counts`).
@@ -84,17 +85,16 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
         // Expand the flat grid back into the regular structures and reuse the shared builders, so
         // ordering/cut-off/dict handling and cross-segment merging match the general path exactly.
         let mut bucket_id_provider = BucketIdProvider::default();
-        // Per-term total = histogram row-sum (in-bounds) + `term_counts` (out-of-bounds remainder).
+        // Per-term total = histogram row-sum (in-bounds) + `term_counts` (out-of-bounds remainder,
+        // empty when there are no hard bounds).
         let term_buckets = VecTermBuckets {
             buckets: self
-                .term_counts
-                .iter()
+                .counts
+                .chunks_exact(self.num_time_buckets)
                 .enumerate()
-                .map(|(term_id, &out_of_bounds)| {
-                    let in_bounds: u32 = self.counts
-                        [term_id * self.num_time_buckets..(term_id + 1) * self.num_time_buckets]
-                        .iter()
-                        .sum();
+                .map(|(term_id, row)| {
+                    let in_bounds: u32 = row.iter().sum();
+                    let out_of_bounds = self.term_counts.get(term_id).copied().unwrap_or(0);
                     Bucket {
                         count: in_bounds + out_of_bounds,
                         bucket_id: bucket_id_provider.next_bucket_id(),
@@ -258,17 +258,23 @@ pub(super) fn maybe_build_collector(
         return Ok(None);
     }
 
-    let counts = vec![0u32; num_terms * range.len];
-    agg_data
-        .context
-        .limits
-        .add_memory_consumed((counts.len() * std::mem::size_of::<u32>()) as u64)?;
     // No hard bounds means every doc is in-bounds, letting `collect` short-circuit the bounds
-    // check.
+    // check — and leaving `term_counts` (the out-of-bounds remainder) unused, so we skip allocating
+    // it.
     let all_docs_in_bounds =
         hist_req_data.bounds.min == f64::MIN && hist_req_data.bounds.max == f64::MAX;
+    let counts = vec![0u32; num_terms * range.len];
+    let term_counts = if all_docs_in_bounds {
+        Vec::new()
+    } else {
+        vec![0u32; num_terms]
+    };
+    // Charge both grids to the aggregation memory limit.
+    agg_data.context.limits.add_memory_consumed(
+        ((counts.len() + term_counts.len()) * std::mem::size_of::<u32>()) as u64,
+    )?;
     Ok(Some(Box::new(SegmentTermHistogramCollector {
-        term_counts: vec![0u32; num_terms],
+        term_counts,
         counts,
         num_time_buckets: range.len,
         base_pos: range.base_pos,
@@ -284,7 +290,11 @@ pub(super) fn maybe_build_collector(
 #[cfg(test)]
 mod tests {
     use crate::aggregation::agg_req::Aggregations;
-    use crate::aggregation::tests::{exec_request, get_test_index_from_values_and_terms};
+    use crate::aggregation::tests::{
+        exec_request, exec_request_with_query_and_memory_limit,
+        get_test_index_from_values_and_terms,
+    };
+    use crate::aggregation::AggregationLimitsGuard;
 
     /// Hand-computed correctness check for the fused terms×histogram fast path
     /// ([`super::SegmentTermHistogramCollector`]): low-cardinality terms × a histogram leaf over
@@ -523,6 +533,52 @@ mod tests {
             }
             assert_eq!(histo[20], serde_json::Value::Null);
         }
+
+        Ok(())
+    }
+
+    /// Regression: with hard bounds the fused path allocates `term_counts` (one `u32`/term) on top
+    /// of the grid, and that allocation must be charged to the memory limit. With many terms and a
+    /// single time bucket the two are equal in size, so a limit admitting the grid alone but not
+    /// grid + `term_counts` must fail.
+    #[test]
+    fn fused_term_histogram_hard_bounds_charges_term_counts() -> crate::Result<()> {
+        // 16k distinct terms, one doc each; values alternate in/out of the single-bucket bounds
+        // [5, 5] so the bounds bind and `term_counts` is allocated. num_terms=16000,
+        // num_time_buckets=1 => `counts` and `term_counts` are ~64 KB each.
+        let docs: Vec<(f64, String)> = (0..16_000u64)
+            .map(|i| (if i % 2 == 0 { 5.0 } else { 10.0 }, format!("t{i:05}")))
+            .collect();
+        let index = get_test_index_from_values_and_terms(true, &[docs])?;
+
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id" },
+                "aggs": {
+                    "histo": {
+                        "histogram": {
+                            "field": "score_f64",
+                            "interval": 1.0,
+                            "hard_bounds": { "min": 5.0, "max": 5.0 }
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        // ~96 KB admits the grid (~64 KB) but not grid + `term_counts` (~128 KB).
+        let err = exec_request_with_query_and_memory_limit(
+            agg_req,
+            &index,
+            None,
+            AggregationLimitsGuard::new(Some(96_000), None),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("memory limit was exceeded"),
+            "expected a memory-limit error, got: {err}"
+        );
 
         Ok(())
     }

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -217,6 +217,11 @@ pub(super) fn maybe_build_collector(
     //
     // We don't cap the term cardinality here: the flat grid is bounded by the total cell count
     // (`num_terms * num_time_buckets <= MAX_FUSED_GRID_BUCKETS`) checked below, which subsumes it.
+    //
+    // We only allow this at the top-level, since we don't know how many buckets are created. We
+    // are less likely to get enough docs for the preallocation to be worth and there's a risk of
+    // using too much memory. We could check the maximum theoretical buckets up-front and pass
+    // them down.
     let fuseable = is_top_level
         && terms_req_data.allowed_term_ids.is_none()
         && terms_req_data.accessor.get_cardinality().is_full()

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -232,7 +232,7 @@ pub(super) fn maybe_build_collector(
     agg_data: &mut AggregationsSegmentCtx,
     node: &AggRefNode,
     terms_req_data: &TermsAggReqData,
-    max_term_id: u64,
+    col_max_val: u64,
     is_top_level: bool,
 ) -> crate::Result<Option<Box<dyn SegmentAggregationCollector>>> {
     // Both columns must be full (one value per doc) so their values align positionally with `docs`
@@ -268,7 +268,7 @@ pub(super) fn maybe_build_collector(
     else {
         return Ok(None);
     };
-    let num_terms = (max_term_id + 1) as usize;
+    let num_terms = col_max_val.saturating_add(1) as usize;
     if num_terms.saturating_mul(range.len) > MAX_FUSED_GRID_BUCKETS {
         return Ok(None);
     }

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -1,0 +1,383 @@
+//! Fused collector for the very common shape `terms` (low cardinality) × a single
+//! `histogram`/`date_histogram` sub-aggregation with nothing nested below it.
+//!
+//! See [`SegmentTermHistogramCollector`] for the approach and [`maybe_build_collector`] for the
+//! conditions under which it is used.
+
+use columnar::ColumnBlockAccessor;
+
+use super::{Bucket, SegmentTermCollector, TermsAggReqData, VecTermBuckets};
+use crate::aggregation::agg_data::{AggKind, AggRefNode, AggregationsSegmentCtx};
+use crate::aggregation::bucket::{
+    get_bucket_pos_f64, prepare_histogram_dense_range, HistogramAggReqData,
+    SegmentHistogramCollector,
+};
+use crate::aggregation::buffered_sub_aggs::LowCardSubAggBuffer;
+use crate::aggregation::intermediate_agg_result::{
+    IntermediateAggregationResult, IntermediateAggregationResults,
+};
+use crate::aggregation::segment_agg_result::{BucketIdProvider, SegmentAggregationCollector};
+use crate::aggregation::{f64_from_fastfield_u64, BucketId};
+
+/// Maximum number of cells (`num_terms × num_time_buckets`) in the fused flat 2D grid. Above this
+/// the grid would be too large/cache-unfriendly, so we fall back to the general buffered path.
+/// `1 << 14` cells = 128 KB of `u64` counters, comfortably L2-resident.
+const MAX_FUSED_GRID_BUCKETS: usize = 1 << 14;
+
+/// Fused collector for `terms` (low cardinality) × a single `histogram`/`date_histogram` leaf with
+/// nothing nested below it, when the resulting `num_terms × num_time_buckets` grid is small (see
+/// [`MAX_FUSED_GRID_BUCKETS`]).
+///
+/// It keeps a flat, fully dense 2D counter grid (`counts[term * num_time_buckets + bucket]`) and a
+/// per-term total. A single pass reads both the term and histogram columns in document order and
+/// bumps the counters directly — no doc-id buffering, no per-term scattered re-fetch, no dynamic
+/// dispatch on flush, no per-bucket key/id storage during collection (keys are derived from the
+/// index at the end).
+///
+/// At result time the flat grid is expanded back into the regular term map + histogram storage and
+/// handed to the shared intermediate-result builders, so cross-segment merging is identical to the
+/// general path.
+#[derive(Debug)]
+pub(crate) struct SegmentTermHistogramCollector {
+    /// `[num_terms]` total doc count per term bucket (independent of the histogram bounds).
+    /// `u32` is enough: a per-segment count can't exceed the segment's doc count (`DocId` is
+    /// `u32`); the fused path is only taken when `num_docs < u32::MAX` (see
+    /// `maybe_build_collector`).
+    term_counts: Vec<u32>,
+    /// Flat row-major `[num_terms * num_time_buckets]` histogram counters (`u32`, see
+    /// `term_counts`).
+    counts: Vec<u32>,
+    /// Histogram buckets per term (the dense time-range length).
+    num_time_buckets: usize,
+    /// `bucket_pos` mapped to time-bucket index 0.
+    base_pos: i64,
+    terms_req_data: TermsAggReqData,
+    /// The (cloned, normalized) histogram request: its column + interval/offset/bounds.
+    hist_req_data: HistogramAggReqData,
+    /// Private block accessors for both columns. We read them together, so each needs its own
+    /// (the shared `agg_data` scratch accessor only holds one block at a time). Owning them keeps
+    /// `collect` independent of `agg_data`.
+    term_block: ColumnBlockAccessor<u64>,
+    hist_block: ColumnBlockAccessor<u64>,
+}
+
+impl SegmentAggregationCollector for SegmentTermHistogramCollector {
+    fn add_intermediate_aggregation_result(
+        &mut self,
+        agg_data: &AggregationsSegmentCtx,
+        results: &mut IntermediateAggregationResults,
+        parent_bucket_id: BucketId,
+    ) -> crate::Result<()> {
+        debug_assert_eq!(
+            parent_bucket_id, 0,
+            "fused term-histogram collector is top-level only"
+        );
+        // Expand the flat grid back into the regular structures and reuse the shared builders, so
+        // ordering/cut-off/dict handling and cross-segment merging match the general path exactly.
+        let mut bucket_id_provider = BucketIdProvider::default();
+        let term_buckets = VecTermBuckets {
+            buckets: self
+                .term_counts
+                .iter()
+                .map(|&count| Bucket {
+                    count,
+                    bucket_id: bucket_id_provider.next_bucket_id(),
+                })
+                .collect(),
+        };
+        let mut histogram = SegmentHistogramCollector::<()>::from_dense_rows(
+            self.hist_req_data.clone(),
+            self.base_pos,
+            self.num_time_buckets,
+            &self.counts,
+        );
+        let name = self.terms_req_data.name.clone();
+        let bucket = SegmentTermCollector::<VecTermBuckets, LowCardSubAggBuffer>::into_intermediate_bucket_result(
+            &self.terms_req_data,
+            Some(&mut histogram as &mut dyn SegmentAggregationCollector),
+            term_buckets,
+            agg_data,
+        )?;
+        results.push(name, IntermediateAggregationResult::Bucket(bucket))?;
+        Ok(())
+    }
+
+    #[inline]
+    fn collect(
+        &mut self,
+        parent_bucket_id: BucketId,
+        docs: &[crate::DocId],
+        _agg_data: &mut AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        debug_assert_eq!(
+            parent_bucket_id, 0,
+            "fused term-histogram collector is top-level only"
+        );
+
+        // Fetch both columns into our own accessors (we read them together, so they can't share the
+        // single `agg_data` scratch accessor). The collector owns all its inputs, so `collect`
+        // doesn't touch `agg_data`.
+        self.term_block
+            .fetch_block(docs, &self.terms_req_data.accessor);
+        self.hist_block
+            .fetch_block(docs, &self.hist_req_data.accessor);
+
+        let field_type = self.hist_req_data.field_type;
+        let bounds = self.hist_req_data.bounds;
+        let interval = self.hist_req_data.req.interval;
+        let offset = self.hist_req_data.offset;
+        let base_pos = self.base_pos;
+        let num_time_buckets = self.num_time_buckets;
+        let term_counts = &mut self.term_counts;
+        let counts = &mut self.counts;
+
+        // Single fused pass: both columns are full (checked at construction), so their values align
+        // with `docs` positionally and we zip them. `term_id` is a dense `Vec` index here, and the
+        // histogram bucket is guaranteed inside `[0, num_time_buckets)` because the dense range is
+        // derived from the column min/max that bounds every value.
+        for (term_id, hist_raw) in self.term_block.iter_vals().zip(self.hist_block.iter_vals()) {
+            let term_id = term_id as usize;
+            term_counts[term_id] += 1;
+            let val = f64_from_fastfield_u64(hist_raw, field_type);
+            if bounds.contains(val) {
+                let bucket = (get_bucket_pos_f64(val, interval, offset) as i64 - base_pos) as usize;
+                debug_assert!(
+                    bucket < num_time_buckets,
+                    "histogram bucket outside dense range"
+                );
+                counts[term_id * num_time_buckets + bucket] += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self, _agg_data: &mut AggregationsSegmentCtx) -> crate::Result<()> {
+        // Nothing is buffered: `collect` writes the flat grid directly.
+        Ok(())
+    }
+
+    fn prepare_max_bucket(
+        &mut self,
+        _max_bucket: BucketId,
+        _agg_data: &AggregationsSegmentCtx,
+    ) -> crate::Result<()> {
+        // Top-level: the flat grid is allocated up front.
+        Ok(())
+    }
+
+    fn compute_metric_value(
+        &self,
+        _bucket_id: BucketId,
+        _sub_agg_name: &str,
+        _sub_agg_property: &str,
+        _agg_data: &AggregationsSegmentCtx,
+    ) -> Option<f64> {
+        None
+    }
+}
+
+/// Builds the fused terms×histogram collector for a single top-level parent, when the shape is
+/// eligible. Returns `Ok(None)` to fall back to the general buffered terms path.
+///
+/// Eligibility: top-level, low-cardinality terms over a full column with no missing/include-exclude
+/// handling; a single `histogram`/`date_histogram` leaf (no nesting below it) over a full column;
+/// and a `num_terms × num_time_buckets` grid no larger than [`MAX_FUSED_GRID_BUCKETS`].
+pub(super) fn maybe_build_collector(
+    agg_data: &mut AggregationsSegmentCtx,
+    node: &AggRefNode,
+    terms_req_data: &TermsAggReqData,
+    max_term_id: u64,
+    is_top_level: bool,
+) -> crate::Result<Option<Box<dyn SegmentAggregationCollector>>> {
+    // Both columns must be full (one value per doc) so their values align positionally with `docs`
+    // and we can zip them. Requiring full columns also makes the terms agg's `missing` config a
+    // no-op (`fetch_block_with_missing` early-returns on full columns), so we needn't check for it.
+    //
+    // We don't cap the term cardinality here: the flat grid is bounded by the total cell count
+    // (`num_terms * num_time_buckets <= MAX_FUSED_GRID_BUCKETS`) checked below, which subsumes it.
+    let fuseable = is_top_level
+        && terms_req_data.allowed_term_ids.is_none()
+        && terms_req_data.accessor.get_cardinality().is_full()
+        // The flat counters are `u32`; a per-segment count can't exceed the doc count, so this
+        // guarantees no overflow (essentially always true, as `DocId` is `u32`).
+        && terms_req_data.accessor.num_docs() < u32::MAX
+        && node.children.len() == 1
+        && matches!(
+            node.children[0].kind,
+            AggKind::Histogram | AggKind::DateHistogram
+        )
+        && node.children[0].children.is_empty()
+        && agg_data.per_request.histogram_req_data[node.children[0].idx_in_req_data]
+            .accessor
+            .get_cardinality()
+            .is_full();
+    if !fuseable {
+        return Ok(None);
+    }
+
+    // Clone + normalize the histogram request and get its dense bucket range; only take the fused
+    // path when the flat `num_terms × num_time_buckets` grid is small enough.
+    let Some((hist_req_data, range)) = prepare_histogram_dense_range(agg_data, &node.children[0])?
+    else {
+        return Ok(None);
+    };
+    let num_terms = (max_term_id + 1) as usize;
+    if num_terms.saturating_mul(range.len) > MAX_FUSED_GRID_BUCKETS {
+        return Ok(None);
+    }
+
+    let counts = vec![0u32; num_terms * range.len];
+    agg_data
+        .context
+        .limits
+        .add_memory_consumed((counts.len() * std::mem::size_of::<u32>()) as u64)?;
+    Ok(Some(Box::new(SegmentTermHistogramCollector {
+        term_counts: vec![0u32; num_terms],
+        counts,
+        num_time_buckets: range.len,
+        base_pos: range.base_pos,
+        terms_req_data: terms_req_data.clone(),
+        hist_req_data,
+        term_block: ColumnBlockAccessor::default(),
+        hist_block: ColumnBlockAccessor::default(),
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::aggregation::agg_req::Aggregations;
+    use crate::aggregation::tests::{exec_request, get_test_index_from_values_and_terms};
+
+    /// Hand-computed correctness check for the fused terms×histogram fast path
+    /// ([`super::SegmentTermHistogramCollector`]): low-cardinality terms × a histogram leaf over
+    /// full columns, exercised single- and multi-segment.
+    #[test]
+    fn fused_term_histogram_test() -> crate::Result<()> {
+        fused_term_histogram_with_opt(false)?;
+        fused_term_histogram_with_opt(true)?;
+        Ok(())
+    }
+
+    fn fused_term_histogram_with_opt(merge_segments: bool) -> crate::Result<()> {
+        // 300 docs: term = {a, b, c} by i % 3, histogram value = i % 20 (interval 1 => buckets
+        // 0..19). gcd(3, 20) = 1, so every (term, bucket) pair occurs exactly 300 / 60 = 5 times.
+        let docs: Vec<(f64, String)> = (0..300u64)
+            .map(|i| {
+                (
+                    (i % 20) as f64,
+                    ["a", "b", "c"][(i % 3) as usize].to_string(),
+                )
+            })
+            .collect();
+        // Two segments, to also exercise cross-segment merging of the fused per-term histograms.
+        let segments = vec![docs[..150].to_vec(), docs[150..].to_vec()];
+        let index = get_test_index_from_values_and_terms(merge_segments, &segments)?;
+
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id", "order": { "_key": "asc" } },
+                "aggs": {
+                    "histo": { "histogram": { "field": "score_f64", "interval": 1.0 } }
+                }
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        for (term_idx, term) in ["a", "b", "c"].iter().enumerate() {
+            assert_eq!(res["by_term"]["buckets"][term_idx]["key"], *term);
+            assert_eq!(res["by_term"]["buckets"][term_idx]["doc_count"], 100);
+            let histo = &res["by_term"]["buckets"][term_idx]["histo"]["buckets"];
+            for b in 0..20usize {
+                assert_eq!(histo[b]["key"], b as f64, "term {term} bucket {b}");
+                assert_eq!(histo[b]["doc_count"], 5, "term {term} bucket {b}");
+            }
+            assert_eq!(histo[20], serde_json::Value::Null);
+        }
+        assert_eq!(res["by_term"]["buckets"][3], serde_json::Value::Null);
+
+        Ok(())
+    }
+
+    /// A `missing` config on a *full* term column still takes the fused path (the string sentinel
+    /// is just `col_max + 1`, so the column stays low-cardinality). Since no doc is missing, the
+    /// real term buckets must be exactly as without `missing`.
+    #[test]
+    fn fused_term_histogram_with_missing_on_full_column() -> crate::Result<()> {
+        let docs: Vec<(f64, String)> = (0..300u64)
+            .map(|i| {
+                (
+                    (i % 20) as f64,
+                    ["a", "b", "c"][(i % 3) as usize].to_string(),
+                )
+            })
+            .collect();
+        let index = get_test_index_from_values_and_terms(true, &[docs])?;
+
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id", "missing": "MISSING", "order": { "_key": "asc" } },
+                "aggs": {
+                    "histo": { "histogram": { "field": "score_f64", "interval": 1.0 } }
+                }
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        // Column is full, so "MISSING" never applies: a, b, c are unchanged (100 docs, 5 per
+        // bucket).
+        for (term_idx, term) in ["a", "b", "c"].iter().enumerate() {
+            assert_eq!(res["by_term"]["buckets"][term_idx]["key"], *term);
+            assert_eq!(res["by_term"]["buckets"][term_idx]["doc_count"], 100);
+            let histo = &res["by_term"]["buckets"][term_idx]["histo"]["buckets"];
+            for b in 0..20usize {
+                assert_eq!(histo[b]["doc_count"], 5, "term {term} bucket {b}");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Term cardinality above the general path's `MAX_NUM_TERMS_FOR_VEC` (100) still fuses: the
+    /// flat grid is bounded by the total cell count (`num_terms * num_time_buckets`), not the
+    /// term count.
+    #[test]
+    fn fused_term_histogram_many_terms() -> crate::Result<()> {
+        let num_terms = 150usize;
+        let docs_per_term = 2usize;
+        // All docs share histogram value 0 (a single bucket), so the grid is 150 x 1 = 150 cells.
+        let docs: Vec<(f64, String)> = (0..num_terms * docs_per_term)
+            .map(|i| (0.0, format!("t{:03}", i % num_terms)))
+            .collect();
+        let index = get_test_index_from_values_and_terms(true, &[docs])?;
+
+        let agg_req: Aggregations = serde_json::from_value(serde_json::json!({
+            "by_term": {
+                "terms": { "field": "string_id", "size": 1000, "order": { "_key": "asc" } },
+                "aggs": {
+                    "histo": { "histogram": { "field": "score_f64", "interval": 1.0 } }
+                }
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+
+        let buckets = res["by_term"]["buckets"].as_array().unwrap();
+        assert_eq!(buckets.len(), num_terms);
+        for (i, bucket) in buckets.iter().enumerate() {
+            assert_eq!(bucket["key"], format!("t{i:03}"));
+            assert_eq!(bucket["doc_count"], docs_per_term as u64);
+            assert_eq!(bucket["histo"]["buckets"][0]["key"], 0.0);
+            assert_eq!(
+                bucket["histo"]["buckets"][0]["doc_count"],
+                docs_per_term as u64
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/aggregation/buffered_sub_aggs.rs
+++ b/src/aggregation/buffered_sub_aggs.rs
@@ -138,6 +138,7 @@ impl SubAggBuffer for HighCardSubAggBuffer {
         }
     }
 
+    #[inline]
     fn push(&mut self, bucket_id: BucketId, doc_id: DocId) {
         let idx = bucket_id % NUM_PARTITIONS as u32;
         let slot = &mut self.partitions[idx as usize];
@@ -196,6 +197,7 @@ impl SubAggBuffer for LowCardSubAggBuffer {
         }
     }
 
+    #[inline]
     fn push(&mut self, bucket_id: BucketId, doc_id: DocId) {
         let idx = bucket_id as usize;
         if self.per_bucket_docs.len() <= idx {


### PR DESCRIPTION
## What problem(s) was I solving?

`terms` × `histogram`/`date_histogram` (e.g. "status terms, each broken into a date histogram over time") is one of the most common aggregations in log/observability workloads, but it ran entirely through the general nested-aggregation machinery:

- The terms collector buffers doc-ids per bucket, then the histogram sub-collector **re-fetches the histogram column scattered by those doc-ids** (random access) with per-flush dynamic dispatch.
- The histogram collector stored every bucket in an `FxHashMap` keyed by bucket position — **hashing on every value** even when buckets densely cover a contiguous range.
- Every histogram bucket carried a `BucketId` **even with no sub-aggregation** to consume it.

## How I implemented it

1. **Specialized terms × histogram collector** — new `src/aggregation/bucket/term_agg/term_histogram.rs`. For top-level low-cardinality `terms` over a full column × a single `histogram`/`date_histogram` leaf (nothing nested) over a full column, with a small grid (capped at 2¹⁴ cells). It keeps a flat dense 2-D `u32` grid `counts[term * num_time_buckets + bucket]`; one pass zips both columns positionally and bumps counters directly — no doc-id buffering, no scattered re-fetch, no per-flush dynamic dispatch, no per-bucket key/id storage during collection. At result time it expands back via `SegmentHistogramCollector::from_dense_rows` into the shared intermediate builders, so cross-segment merge / ordering / cut-off / dict handling are identical to the general path.

   - **Derive per-term counts from the histogram grid.** With no hard bounds, every doc lands in the dense range, so a term's total `doc_count` equals the sum of its histogram row. Rather than keep a separate per-doc term counter (`term_counts[t] += 1` on every document), we drop that work entirely during collection and recover the totals as grid row-sums at the end. This removes a loop-carried store-to-load dependency on the few hot term addresses — **~17%** on the benches. (With `hard_bounds`, out-of-range docs still count toward the term but not the histogram, so the per-doc counter is retained.)

2. **Dense histogram bucket storage** (`histogram.rs`) — `HistogramBuckets` is now `Sparse(FxHashMap) | Dense { base_pos, Vec }`. Starts sparse; `maybe_densify` (at block boundaries) switches to a `Vec` indexed by `bucket_pos - base_pos` only once that uses ≤ the map's current memory, so peak memory never rises and a large-but-sparse range never crosses over. Removes hashing from the dense hot loop. `compute_dense_range` derives the range from column min/max clamped to bounds.

3. **Zero-sized bucket id when there are no sub-aggregations** (`histogram.rs`) — `SegmentHistogramBucketEntry<B>` is generic over a `BucketIdSlot`: `BucketId` with sub-aggs, `()` without. `()` makes id assignment a no-op and drops 8 bytes/bucket (24→16). `build_segment_histogram_collector` picks the slot by whether the node has children.

4. **Split histogram hot loop by sub-agg presence** — the no-sub-agg path uses the cheaper `iter_vals` (no doc-ids); the sub-agg path keeps `iter_docid_vals`.

5. **Contiguous-block fast path in the columnar accessor** (`block_accessor.rs`, `column_values/mod.rs`) — `fetch_block` detects a contiguous ascending doc run and fetches via `get_range` (bulk slice decode, no per-value dynamic dispatch) instead of `get_vals` gather; `get_range`'s default impl now decodes 4-wide.

6. **Misc** — `#[inline]` on `SubAggBuffer::push`; `term_agg.rs` → `term_agg/mod.rs` to host the submodule; Histogram/DateHistogram now route through `build_segment_histogram_collector` in `agg_data.rs`.

# Scope

Currently the specialized collector only covers terms-> histogram aggregations, but we could also cover histogram -> terms with it for some cases.

# Benchmark
`terms_status_with_histogram` is 2x faster than before and on par with a pure term aggregation like `terms_7`.

```
full
average_u64                                           Memory: 21.8 KB (-0.01%)      Avg: 3.0488ms (+0.24%)      Median: 3.0495ms (+1.25%)      [2.9689ms .. 3.1085ms]       
average_f64                                           Memory: 21.5 KB (-3.36%)      Avg: 3.1754ms (+0.01%)      Median: 3.1552ms (-0.11%)      [3.1036ms .. 3.3260ms]       
average_f64_u64                                       Memory: 22.1 KB (-3.02%)      Avg: 5.9575ms (+1.54%)      Median: 5.9325ms (+1.49%)      [5.8536ms .. 6.2756ms]       
stats_f64                                             Memory: 22.8 KB (+4.45%)      Avg: 3.1777ms (+0.08%)      Median: 3.1654ms (+0.59%)      [3.1200ms .. 3.2973ms]       
extendedstats_f64                                     Memory: 23.1 KB (-0.49%)      Avg: 3.3235ms (-0.85%)      Median: 3.3084ms (-0.57%)      [3.2781ms .. 3.4639ms]       
percentiles_f64                                       Memory: 39.4 KB (+0.31%)      Avg: 7.0153ms (-1.05%)      Median: 6.9986ms (-0.61%)      [6.9162ms .. 7.2479ms]       
terms_7                                               Memory: 37.2 KB               Avg: 2.3745ms (-1.50%)      Median: 2.3700ms (-1.24%)      [2.3510ms .. 2.4221ms]       
terms_all_unique                                      Memory: 12.7 MB               Avg: 6.8086ms (-1.52%)      Median: 6.8867ms (+0.40%)      [6.1163ms .. 7.6669ms]       
terms_150_000                                         Memory: 3.0 MB                Avg: 6.4853ms (-1.94%)      Median: 6.4640ms (-1.32%)      [6.3474ms .. 6.7107ms]       
terms_many_top_1000                                   Memory: 5.2 MB                Avg: 9.3724ms (-0.49%)      Median: 9.3168ms (-0.58%)      [9.1974ms .. 9.9923ms]       
terms_many_order_by_term                              Memory: 3.0 MB                Avg: 5.3237ms (-1.55%)      Median: 5.2654ms (-1.68%)      [5.1582ms .. 5.7237ms]       
terms_many_with_top_hits                              Memory: 48.9 MB               Avg: 91.3558ms (-3.88%)     Median: 91.1049ms (-2.45%)     [77.6622ms .. 120.1151ms]    
terms_all_unique_with_avg_sub_agg                     Memory: 54.7 MB (-0.00%)      Avg: 18.4627ms (+0.17%)     Median: 18.8469ms (+0.40%)     [15.8393ms .. 21.2119ms]     
terms_many_with_avg_sub_agg                           Memory: 13.5 MB (+0.00%)      Avg: 17.4354ms (+1.13%)     Median: 17.6457ms (+1.63%)     [14.7116ms .. 20.5066ms]     
terms_status_with_avg_sub_agg                         Memory: 90.7 KB               Avg: 5.1456ms (-1.74%)      Median: 5.1092ms (-1.80%)      [5.0377ms .. 5.4171ms]       
terms_status_with_terms_zipf_1000_sub_agg             Memory: 203.8 KB              Avg: 4.1112ms (-2.98%)      Median: 4.1000ms (-2.05%)      [4.0760ms .. 4.2348ms]       
terms_zipf_1000_with_terms_status_sub_agg             Memory: 682.3 KB              Avg: 12.6181ms (-12.90%)    Median: 12.5871ms (-12.79%)    [12.4670ms .. 12.9818ms]     
terms_status_with_histogram                           Memory: 129.7 KB (+16.57%)    Avg: 2.4701ms (-49.01%)     Median: 2.4535ms (-49.18%)     [2.4164ms .. 2.6420ms]       
terms_status_with_date_histogram                      Memory: 125.7 KB (+20.39%)    Avg: 2.4710ms (-47.13%)     Median: 2.4571ms (-47.09%)     [2.4264ms .. 2.5937ms]       
terms_status_with_date_histogram_and_sibling_terms    Memory: 126.4 KB (+5.79%)     Avg: 3.9756ms (-36.27%)     Median: 3.9637ms (-35.94%)     [3.9328ms .. 4.0482ms]       
terms_zipf_1000                                       Memory: 69.7 KB               Avg: 2.2323ms (-1.86%)      Median: 2.2230ms (-1.98%)      [2.1847ms .. 2.4241ms]       
terms_zipf_1000_with_histogram                        Memory: 1.2 MB (-10.06%)      Avg: 20.4613ms (-7.77%)     Median: 20.1618ms (-8.04%)     [19.9110ms .. 28.3846ms]     
terms_zipf_1000_with_avg_sub_agg                      Memory: 466.6 KB              Avg: 9.2337ms (+5.18%)      Median: 9.1955ms (+5.83%)      [9.1335ms .. 9.6850ms]       
terms_many_json_mixed_type_with_avg_sub_agg           Memory: 17.9 MB               Avg: 28.0062ms (+3.81%)     Median: 27.5667ms (+3.28%)     [26.1262ms .. 38.6095ms]     
composite_term_many_page_1000                         Memory: 619.9 KB              Avg: 25.3132ms (+0.51%)     Median: 25.0434ms (+0.30%)     [24.8027ms .. 28.2588ms]     
composite_term_many_page_1000_with_avg_sub_agg        Memory: 4.2 MB                Avg: 25.8580ms (-3.62%)     Median: 25.8224ms (-2.74%)     [25.3591ms .. 27.0475ms]     
composite_term_few                                    Memory: 37.2 KB               Avg: 12.2783ms (-13.84%)    Median: 12.1950ms (-13.95%)    [11.8739ms .. 12.9316ms]     
composite_histogram                                   Memory: 309.0 KB              Avg: 17.5778ms (-15.27%)    Median: 17.4555ms (-16.21%)    [17.0569ms .. 18.6302ms]     
composite_histogram_calendar                          Memory: 21.1 KB (-0.29%)      Avg: 26.6866ms (+3.88%)     Median: 26.4930ms (+4.32%)     [23.5668ms .. 29.8123ms]     
cardinality_agg                                       Memory: 5.9 MB                Avg: 13.0570ms (-5.35%)     Median: 13.0484ms (-3.40%)     [12.7178ms .. 13.6398ms]     
cardinality_agg_high_card                             Memory: 24.0 MB               Avg: 66.9179ms (-0.62%)     Median: 66.8118ms (-0.65%)     [66.3455ms .. 68.6998ms]     
cardinality_agg_low_card                              Memory: 21.0 KB               Avg: 1.2359ms (-3.91%)      Median: 1.2090ms (-5.35%)      [1.1834ms .. 1.9768ms]       
terms_status_with_cardinality_agg                     Memory: 92.2 KB               Avg: 3.2289ms (-3.48%)      Median: 3.2162ms (-2.13%)      [3.1695ms .. 3.4494ms]       
terms_100_buckets_with_cardinality_agg                Memory: 9.7 MB                Avg: 49.7009ms (-3.86%)     Median: 49.6114ms (-2.90%)     [48.9692ms .. 51.0129ms]     
terms_many_with_single_term_order_by_card             Memory: 48.9 MB               Avg: 78.2022ms (-18.09%)    Median: 79.1280ms (-15.08%)    [69.7685ms .. 92.2715ms]     
terms_many_with_single_term_2_order_by_card           Memory: 40.6 MB (+0.00%)      Avg: 53.8404ms (-13.33%)    Median: 53.8191ms (-12.87%)    [45.8436ms .. 78.0856ms]     
range_agg                                             Memory: 25.5 KB (+0.31%)      Avg: 3.3144ms (-3.21%)      Median: 3.3037ms (-1.84%)      [3.2787ms .. 3.4476ms]       
range_agg_with_avg_sub_agg                            Memory: 93.7 KB               Avg: 6.9874ms (-1.87%)      Median: 6.9612ms (-1.36%)      [6.9177ms .. 7.2324ms]       
range_agg_with_term_agg_status                        Memory: 110.1 KB              Avg: 6.3740ms (-2.62%)      Median: 6.3541ms (-1.53%)      [6.2933ms .. 6.6485ms]       
range_agg_with_term_agg_many                          Memory: 6.9 MB                Avg: 13.1165ms (-1.57%)     Median: 12.9684ms (-1.91%)     [12.7785ms .. 14.9161ms]     
histogram                                             Memory: 22.5 KB (+1.16%)      Avg: 2.8934ms (-4.08%)      Median: 2.8674ms (-3.83%)      [2.8401ms .. 3.0533ms]       
histogram_hard_bounds                                 Memory: 21.2 KB (+1.17%)      Avg: 1.6378ms (-2.19%)      Median: 1.6340ms (-2.53%)      [1.5854ms .. 1.7588ms]       
histogram_with_avg_sub_agg                            Memory: 122.1 KB (+0.05%)     Avg: 8.4063ms (-10.13%)     Median: 8.3718ms (-9.82%)      [8.3107ms .. 8.7760ms]       
histogram_with_term_agg_status                        Memory: 496.7 KB (-0.37%)     Avg: 9.5842ms (+0.93%)      Median: 9.5203ms (+1.42%)      [9.4448ms .. 10.1218ms]      
avg_and_range_with_avg_sub_agg                        Memory: 82.7 KB               Avg: 9.8139ms (-3.28%)      Median: 9.7739ms (-3.49%)      [9.7269ms .. 10.1989ms]      
filter_agg_all_query_count_agg                        Memory: 128.8 KB (-0.44%)     Avg: 5.6002ms (+15.99%)     Median: 5.6153ms (+16.74%)     [5.3823ms .. 5.8560ms]       
filter_agg_term_query_count_agg                       Memory: 129.0 KB (-0.32%)     Avg: 8.0399ms (+10.79%)     Median: 8.0387ms (+11.03%)     [7.7664ms .. 8.6361ms]       
filter_agg_all_query_with_sub_aggs                    Memory: 151.1 KB (-0.17%)     Avg: 10.5435ms (+8.24%)     Median: 10.5488ms (+8.57%)     [10.2309ms .. 10.9686ms]     
filter_agg_term_query_with_sub_aggs                   Memory: 147.4 KB (-0.17%)     Avg: 12.9841ms (+6.54%)     Median: 12.9893ms (+7.05%)     [12.5942ms .. 13.3322ms]     
```

# Overhead
Preallocating a vec has some overhead. Here's the cutoff in number of hits:

| grid    | crossover |
| -------- | ------- |
| 256  | ~16 hits    |
| 1024 | ~30 hits     |
| 4096    | ~100 hits    |
| 16384    | ~1000 hits    |

# Future work

Accessing values is now taking 46% of the time in `terms_status_with_date_histogram`. The way we access them is very wasteful. All values are returned as u64, even if they are internally bitpacked to a few bits.

Currently we require both to be full, but only the histogram needs to be full. terms could be optional.