### PR TITLE
Add BlockSegmentPostings::rank() for skip-list-based positional counting

### DIFF
--- a/src/postings/block_segment_postings.rs
+++ b/src/postings/block_segment_postings.rs
@@ -287,6 +287,33 @@ impl BlockSegmentPostings {
         doc
     }
 
+    /// Returns the number of documents with a doc id strictly smaller than `target`
+    /// (i.e. the *rank* of `target` in this posting list).
+    ///
+    /// This jumps to the block that may contain `target` through the skip list, so no
+    /// skipped block is decoded; a single block is then decoded to locate `target`
+    /// within it. The cost is therefore `O(number_of_skip_list_entries)` plus one block
+    /// decode, rather than `O(doc_freq)`.
+    ///
+    /// Like [`Self::seek`], the underlying cursor only ever moves forward. This method
+    /// must be called with **non-decreasing** `target` values (galloping); calling it
+    /// with a `target` smaller than a previous one yields an incorrect result. `target`
+    /// must be a valid doc id (i.e. `target <= TERMINATED`), exactly as for `seek`.
+    ///
+    /// Edge cases: returns `0` when `target` is smaller than every doc id, and
+    /// `doc_freq()` when `target` is larger than every doc id.
+    pub fn rank(&mut self, target: DocId) -> u32 {
+        if self.doc_freq == 0 {
+            return 0;
+        }
+        // `within` = number of docs in the landed block with a doc id < target.
+        let within = self.seek(target);
+        // `remaining_docs` counts the landed block and everything after it, so the
+        // difference is the number of docs in all blocks strictly before it.
+        let docs_before_block = self.doc_freq - self.skip_reader.remaining_docs();
+        docs_before_block + within as u32
+    }
+
     pub(crate) fn position_offset(&self) -> u64 {
         self.skip_reader.position_offset()
     }
@@ -566,6 +593,40 @@ mod tests {
             inverted_index.reset_block_postings_from_terminfo(&term_info, &mut block_segments)?;
         }
         assert_eq!(block_segments.docs(), &[1, 3, 5]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_block_segment_postings_rank() -> crate::Result<()> {
+        // ~8 blocks worth of docs so the skip list is actually exercised.
+        let docs: Vec<DocId> = (0..1000u32).map(|i| i * 3).collect();
+        let mut block_postings = build_block_postings(&docs[..])?;
+        let doc_freq = block_postings.doc_freq();
+
+        // rank(target) must equal the number of docs strictly below target.
+        // Targets are queried in non-decreasing order, as the API requires.
+        // `target` values must be a valid doc id (<= TERMINATED) and non-decreasing.
+        let targets = [
+            0u32, 1, 2, 3, 4, 299, 300, 301, 1500, 2996, 2997, 3000, 10_000,
+        ];
+        for &target in &targets {
+            let expected = docs.iter().filter(|&&d| d < target).count() as u32;
+            assert_eq!(
+                block_postings.rank(target),
+                expected,
+                "rank({target}) mismatch"
+            );
+        }
+
+        // Edge cases: below the first doc -> 0, above the last doc -> doc_freq.
+        let mut fresh = build_block_postings(&docs[..])?;
+        assert_eq!(fresh.rank(0), 0);
+        let mut fresh = build_block_postings(&docs[..])?;
+        assert_eq!(fresh.rank(1_000_000), doc_freq);
+
+        // Empty postings: rank is always 0.
+        let mut empty = BlockSegmentPostings::empty();
+        assert_eq!(empty.rank(42), 0);
         Ok(())
     }
 }

--- a/src/postings/skip.rs
+++ b/src/postings/skip.rs
@@ -187,6 +187,12 @@ impl SkipReader {
         self.last_doc_in_block
     }
 
+    /// Number of docs from the start of the current block to the end of the postings
+    /// (i.e. the current block plus every block after it).
+    pub(crate) fn remaining_docs(&self) -> u32 {
+        self.remaining_docs
+    }
+
     pub fn position_offset(&self) -> u64 {
         self.position_offset
     }


### PR DESCRIPTION
## Summary

This PR adds `BlockSegmentPostings::rank(target)`, which returns the number of
documents in a posting list whose doc id is strictly smaller than `target`
(i.e. the *rank* of `target` in the list).

The method navigates to the candidate block through the skip list and decodes a
single block, so its cost is `O(number_of_skip_list_entries)` plus one block
decode, rather than `O(doc_freq)`. To support it, `SkipReader::remaining_docs()`
is exposed as `pub(crate)`.

## Motivation

When counting matches that fall inside a contiguous doc-id window `[lo, hi)`,
the natural approach is to iterate the posting list and tally matched docs, which
is `O(doc_freq)`. If the doc ids of interest are known up front (for example,
window boundaries obtained from a sorted fast field), the count over a window can
instead be expressed as `rank(hi) - rank(lo)`.

A concrete use case is range/bucket counting — e.g. computing how many matches of
a term fall into each of several adjacent doc-id ranges. Because postings are
stored as 128-doc blocks indexed by a skip list, a positional rank can skip over
whole blocks instead of decoding them, which is asymptotically cheaper than a
full scan when the windows are large.

`rank()` is offered as a low-level primitive on `BlockSegmentPostings`
(consistent with the existing low-level `seek()` API on the same type), not as a
high-level query construct.

## Implementation

```rust
pub fn rank(&mut self, target: DocId) -> u32 {
    if self.doc_freq == 0 {
        return 0;
    }
    let within = self.seek(target);
    let docs_before_block = self.doc_freq - self.skip_reader.remaining_docs();
    docs_before_block + within as u32
}
```

- `seek(target)` already positions the cursor on the block that may contain
  `target` (via the skip list, no decode of skipped blocks) and returns the
  in-block index of the first doc `>= target` — i.e. the number of docs in that
  block strictly less than `target`.
- `SkipReader::remaining_docs()` counts the current block plus every block after
  it, so `doc_freq - remaining_docs()` is the number of docs in all blocks
  strictly before the current one.
- Their sum is the number of docs strictly less than `target`.

## Contract

`rank()` reuses `seek()`'s forward-only cursor, so it inherits the same usage
constraints:

- **Non-decreasing targets.** The cursor only ever advances; calling `rank()`
  with a `target` smaller than a previous call returns an incorrect result
  (galloping access pattern).
- **Valid doc id.** `target` must satisfy `target <= TERMINATED`, exactly as for
  `seek()` (no real doc id exceeds `TERMINATED`).

Both constraints are documented on the method. Edge cases: `rank()` returns `0`
when `target` is below every doc id and `doc_freq()` when it is above every doc
id.

## Testing

Adds `test_block_segment_postings_rank`, which builds a multi-block posting list
(so the skip list is genuinely exercised) and asserts `rank(target)` against a
brute-force count for a sequence of non-decreasing targets, plus the
below-first, above-last, and empty-postings edge cases.

```
cargo test postings::block_segment_postings
cargo +nightly fmt --all -- --check
cargo clippy --lib
```
all pass locally.
