### PR TITLE
fix(query-parser): honor phrase prefix and slop on JSON fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Tantivy 0.26 (Unreleased)
 - Fix integer overflow in segment sorting and merge policy truncation [#2846](https://github.com/quickwit-oss/tantivy/pull/2846)(@anaslimem)
 - Fix merging of intermediate aggregation results [#2719](https://github.com/quickwit-oss/tantivy/pull/2719)(@PSeitz)
 - Fix deduplicate doc counts in term aggregation for multi-valued fields [#2854](https://github.com/quickwit-oss/tantivy/pull/2854)(@nuri-yoo)
+- Honor phrase prefix (`"..."*`) and slop (`"..."~N`) on JSON fields; previously both were silently dropped, degrading the query to an exact phrase [#2966](https://github.com/quickwit-oss/tantivy/pull/2966)(@DavIvek)
 
 ## Features/Improvements
 - **Aggregation**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Tantivy 0.26 (Unreleased)
 - Fix integer overflow in segment sorting and merge policy truncation [#2846](https://github.com/quickwit-oss/tantivy/pull/2846)(@anaslimem)
 - Fix merging of intermediate aggregation results [#2719](https://github.com/quickwit-oss/tantivy/pull/2719)(@PSeitz)
 - Fix deduplicate doc counts in term aggregation for multi-valued fields [#2854](https://github.com/quickwit-oss/tantivy/pull/2854)(@nuri-yoo)
+- Honor phrase prefix (`"..."*`) and slop (`"..."~N`) on JSON fields; previously both were silently dropped, degrading the query to an exact phrase [#2966](https://github.com/quickwit-oss/tantivy/pull/2966)(@DavIvek)
 
 ## Features/Improvements
 - **Aggregation**

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -602,6 +602,8 @@ impl QueryParser {
                 field,
                 json_path,
                 phrase,
+                slop,
+                prefix,
                 &self.tokenizer_manager,
                 json_options,
             ),
@@ -995,11 +997,14 @@ fn generate_literals_for_str(
     }))
 }
 
+#[expect(clippy::too_many_arguments)]
 fn generate_literals_for_json_object(
     field_name: &str,
     field: Field,
     json_path: &str,
     phrase: &str,
+    slop: u32,
+    prefix: bool,
     tokenizer_manager: &TokenizerManager,
     json_options: &JsonObjectOptions,
 ) -> Result<Vec<LogicalLiteral>, QueryParserError> {
@@ -1036,6 +1041,12 @@ fn generate_literals_for_json_object(
     });
 
     if positions_and_terms.len() <= 1 {
+        if prefix {
+            return Err(QueryParserError::PhrasePrefixRequiresAtLeastTwoTerms {
+                phrase: phrase.to_owned(),
+                tokenizer: text_options.tokenizer().to_owned(),
+            });
+        }
         for (_, term) in positions_and_terms {
             logical_literals.push(LogicalLiteral::Term(term));
         }
@@ -1048,8 +1059,8 @@ fn generate_literals_for_json_object(
     }
     logical_literals.push(LogicalLiteral::Phrase {
         terms: positions_and_terms,
-        slop: 0,
-        prefix: false,
+        slop,
+        prefix,
     });
     Ok(logical_literals)
 }
@@ -1960,6 +1971,42 @@ mod test {
                 phrase: "".to_owned(),
                 tokenizer: "default".to_owned()
             }
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_prefix_on_json_field() {
+        let query_parser = make_query_parser();
+        let query = query_parser
+            .parse_query("json.attr:\"big bad wo\"*")
+            .unwrap();
+        assert_eq!(
+            format!("{query:?}"),
+            "PhrasePrefixQuery { field: Field(14), phrase_terms: [(0, Term(field=14, type=Json, \
+             path=attr, type=Str, \"big\")), (1, Term(field=14, type=Json, path=attr, type=Str, \
+             \"bad\"))], prefix: (2, Term(field=14, type=Json, path=attr, type=Str, \"wo\")), \
+             max_expansions: 50 }"
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_prefix_too_short_on_json_field() {
+        let err = parse_query_to_logical_ast("json.attr:\"wo\"*", true).unwrap_err();
+        assert_eq!(
+            err,
+            QueryParserError::PhrasePrefixRequiresAtLeastTwoTerms {
+                phrase: "wo".to_owned(),
+                tokenizer: "default".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_slop_on_json_field() {
+        test_parse_query_to_logical_ast_helper(
+            "json.attr:\"a b\"~2",
+            r#""[(0, Term(field=14, type=Json, path=attr, type=Str, "a")), (1, Term(field=14, type=Json, path=attr, type=Str, "b"))]"~2"#,
+            false,
         );
     }
 

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -2025,6 +2025,46 @@ mod test {
     }
 
     #[test]
+    fn test_phrase_prefix_and_slop_on_json_field_with_documents() -> crate::Result<()> {
+        use serde_json::json;
+
+        use crate::collector::Count;
+
+        let mut schema_builder = Schema::builder();
+        let json = schema_builder.add_json_field("json", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.add_document(doc!(json => json!({"attr": "big bad wolf"})))?;
+        index_writer.add_document(doc!(json => json!({"attr": "big bad world"})))?;
+        index_writer.add_document(doc!(json => json!({"attr": "big bad"})))?;
+        index_writer.add_document(doc!(json => json!({"attr": "small bad wolf"})))?;
+        index_writer.add_document(doc!(json => json!({"attr": "big angry bad wolf"})))?;
+        index_writer.commit()?;
+
+        let query_parser = QueryParser::for_index(&index, Vec::new());
+        let searcher = index.reader()?.searcher();
+
+        // Phrase prefix: matches "big bad wolf" and "big bad world", but not "big bad" (no term
+        // after the phrase to expand) nor "small bad wolf" (phrase does not match).
+        let phrase_prefix = query_parser.parse_query("json.attr:\"big bad wo\"*")?;
+        assert_eq!(searcher.search(&*phrase_prefix, &Count)?, 2);
+
+        // Without the trailing `*` the same input is an exact phrase and matches nothing.
+        let exact_phrase = query_parser.parse_query("json.attr:\"big bad wo\"")?;
+        assert_eq!(searcher.search(&*exact_phrase, &Count)?, 0);
+
+        // Slop: "big angry bad wolf" only matches "big bad" once a slop of 1 is allowed.
+        let phrase = query_parser.parse_query("json.attr:\"big bad\"")?;
+        assert_eq!(searcher.search(&*phrase, &Count)?, 3);
+        let phrase_slop = query_parser.parse_query("json.attr:\"big bad\"~1")?;
+        assert_eq!(searcher.search(&*phrase_slop, &Count)?, 4);
+
+        Ok(())
+    }
+
+    #[test]
     pub fn test_term_set_query() {
         test_parse_query_to_logical_ast_helper(
             "title: IN [a b cd]",

--- a/src/query/query_parser/query_parser.rs
+++ b/src/query/query_parser/query_parser.rs
@@ -611,6 +611,8 @@ impl QueryParser {
                 field,
                 json_path,
                 phrase,
+                slop,
+                prefix,
                 &self.tokenizer_manager,
                 json_options,
             ),
@@ -1008,11 +1010,14 @@ fn generate_literals_for_str(
     }))
 }
 
+#[expect(clippy::too_many_arguments)]
 fn generate_literals_for_json_object(
     field_name: &str,
     field: Field,
     json_path: &str,
     phrase: &str,
+    slop: u32,
+    prefix: bool,
     tokenizer_manager: &TokenizerManager,
     json_options: &JsonObjectOptions,
 ) -> Result<Vec<LogicalLiteral>, QueryParserError> {
@@ -1049,6 +1054,12 @@ fn generate_literals_for_json_object(
     });
 
     if positions_and_terms.len() <= 1 {
+        if prefix {
+            return Err(QueryParserError::PhrasePrefixRequiresAtLeastTwoTerms {
+                phrase: phrase.to_owned(),
+                tokenizer: text_options.tokenizer().to_owned(),
+            });
+        }
         for (_, term) in positions_and_terms {
             logical_literals.push(LogicalLiteral::Term(term));
         }
@@ -1061,8 +1072,8 @@ fn generate_literals_for_json_object(
     }
     logical_literals.push(LogicalLiteral::Phrase {
         terms: positions_and_terms,
-        slop: 0,
-        prefix: false,
+        slop,
+        prefix,
     });
     Ok(logical_literals)
 }
@@ -1974,6 +1985,42 @@ mod test {
                 phrase: "".to_owned(),
                 tokenizer: "default".to_owned()
             }
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_prefix_on_json_field() {
+        let query_parser = make_query_parser();
+        let query = query_parser
+            .parse_query("json.attr:\"big bad wo\"*")
+            .unwrap();
+        assert_eq!(
+            format!("{query:?}"),
+            "PhrasePrefixQuery { field: Field(14), phrase_terms: [(0, Term(field=14, type=Json, \
+             path=attr, type=Str, \"big\")), (1, Term(field=14, type=Json, path=attr, type=Str, \
+             \"bad\"))], prefix: (2, Term(field=14, type=Json, path=attr, type=Str, \"wo\")), \
+             max_expansions: 50 }"
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_prefix_too_short_on_json_field() {
+        let err = parse_query_to_logical_ast("json.attr:\"wo\"*", true).unwrap_err();
+        assert_eq!(
+            err,
+            QueryParserError::PhrasePrefixRequiresAtLeastTwoTerms {
+                phrase: "wo".to_owned(),
+                tokenizer: "default".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    pub fn test_phrase_slop_on_json_field() {
+        test_parse_query_to_logical_ast_helper(
+            "json.attr:\"a b\"~2",
+            r#""[(0, Term(field=14, type=Json, path=attr, type=Str, "a")), (1, Term(field=14, type=Json, path=attr, type=Str, "b"))]"~2"#,
+            false,
         );
     }
 


### PR DESCRIPTION
Phrase prefix (`"..."*`) and slop (`"..."~N`) were silently dropped on JSON fields. `generate_literals_for_json_object` hard-coded `slop: 0` and `prefix: false`, so a query like `data.name:"foo bar"*` degraded to an exact phrase on the JSON field — even though the underlying `PhrasePrefixQuery` already supports JSON-path terms.

This threads `slop`/`prefix` through the JSON branch, exactly as the `Str` branch (`generate_literals_for_str`) already does, and adds the "phrase prefix requires at least two terms" guard for the single-token case.

### Tests

Added as JSON analogues of the existing text-field tests (`test_phrase_prefix`, `test_phrase_prefix_too_short`, `test_phrase_slop`):

- `test_phrase_prefix_on_json_field`
- `test_phrase_prefix_too_short_on_json_field`
- `test_phrase_slop_on_json_field`

This aligns JSON fields with the phrase `~`/`*` behavior already documented for `QueryParser`.
