### PR TITLE
feat: add custom doc id mapping finalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ futures-util = { version = "0.3.28", optional = true }
 futures-channel = { version = "0.3.28", optional = true }
 fnv = "1.0.7"
 typetag = "0.2.21"
+unwrap-infallible = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/columnar/benches/common.rs
+++ b/columnar/benches/common.rs
@@ -54,6 +54,6 @@ pub fn generate_columnar_with_name(card: Card, num_docs: u32, column_name: &str)
     }
 
     let mut wrt: Vec<u8> = Vec::new();
-    columnar_writer.serialize(num_docs, &mut wrt).unwrap();
+    columnar_writer.serialize(num_docs, None, &mut wrt).unwrap();
     ColumnarReader::open(wrt).unwrap()
 }

--- a/common/src/bitset.rs
+++ b/common/src/bitset.rs
@@ -281,12 +281,16 @@ impl BitSet {
     }
 
     /// Inserts an element in the `BitSet`
+    ///
+    /// Returns true if the set changed.
     #[inline]
-    pub fn insert(&mut self, el: u32) {
+    pub fn insert(&mut self, el: u32) -> bool {
         // we do not check saturated els.
         let higher = el / 64u32;
         let lower = el % 64u32;
-        self.len += u64::from(self.tinysets[higher as usize].insert_mut(lower));
+        let changed = self.tinysets[higher as usize].insert_mut(lower);
+        self.len += u64::from(changed);
+        changed
     }
 
     /// Inserts an element in the `BitSet`

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -931,7 +931,9 @@ fn build_allowed_term_ids_for_str(
         // add matches
         allowed = Some(BitSet::with_max_value(allowed_capacity));
         let allowed = allowed.as_mut().unwrap();
-        for_each_matching_term_ord(str_col, include, |ord| allowed.insert(ord))?;
+        for_each_matching_term_ord(str_col, include, |ord| {
+            let _ = allowed.insert(ord);
+        })?;
     };
 
     if let Some(exclude) = exclude {

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1,10 +1,10 @@
 use crate::collector::Count;
 use crate::directory::{RamDirectory, WatchCallback};
-use crate::index::SegmentId;
+use crate::index::{SegmentComponent, SegmentId};
 use crate::indexer::{DocIdMapping, LogMergePolicy, NoMergePolicy};
 use crate::postings::Postings;
 use crate::query::TermQuery;
-use crate::schema::{Field, IndexRecordOption, Schema, Value, INDEXED, STORED, STRING, TEXT};
+use crate::schema::{Field, IndexRecordOption, Schema, Value, FAST, INDEXED, STORED, STRING, TEXT};
 use crate::tokenizer::TokenizerManager;
 use crate::{
     Directory, DocAddress, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter,
@@ -342,6 +342,49 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
         doc_2.get_first(text_field).and_then(|val| val.as_str()),
         Some("alpha beta")
     );
+
+    assert!(!index.settings().manual_doc_id_mapping);
+    let segment_metas = index.searchable_segment_metas()?;
+    let segment_meta = &segment_metas[0];
+    assert!(!segment_meta
+        .list_files()
+        .contains(&segment_meta.relative_path(SegmentComponent::TempStore)));
+
+    let mut index_writer = index.writer_for_tests()?;
+    index_writer.add_document(doc!(text_field=>"delta"))?;
+    index_writer.commit()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_single_segment_index_writer_with_sort_by_field_untracks_tempstore() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let sort_field = schema_builder.add_u64_field("sort", FAST | STORED);
+    let schema = schema_builder.build();
+    let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
+    let directory = RamDirectory::default();
+    let settings = IndexSettings {
+        sort_by_field: Some(crate::IndexSortByField {
+            field: sort_field_name,
+            order: crate::Order::Asc,
+        }),
+        ..Default::default()
+    };
+    let mut single_segment_index_writer = Index::builder()
+        .schema(schema)
+        .settings(settings)
+        .single_segment_index_writer(directory, 15_000_000)?;
+
+    single_segment_index_writer.add_document(doc!(sort_field=>2u64))?;
+    single_segment_index_writer.add_document(doc!(sort_field=>1u64))?;
+    let index = single_segment_index_writer.finalize()?;
+
+    let segment_metas = index.searchable_segment_metas()?;
+    let segment_meta = &segment_metas[0];
+    assert!(!segment_meta
+        .list_files()
+        .contains(&segment_meta.relative_path(SegmentComponent::TempStore)));
     Ok(())
 }
 
@@ -365,6 +408,30 @@ fn test_single_segment_index_writer_finalize_rejects_manual_doc_id_mapping() -> 
     let error = single_segment_index_writer.finalize().unwrap_err();
     assert!(matches!(error, TantivyError::InvalidArgument(_)));
     Ok(())
+}
+
+#[test]
+fn test_index_builder_rejects_manual_doc_id_mapping_with_sort_by_field() {
+    let mut schema_builder = Schema::builder();
+    schema_builder.add_text_field("text", TEXT | STORED);
+    let sort_field = schema_builder.add_u64_field("sort", STORED | FAST);
+    let schema = schema_builder.build();
+    let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
+    let settings = IndexSettings {
+        manual_doc_id_mapping: true,
+        sort_by_field: Some(crate::IndexSortByField {
+            field: sort_field_name,
+            order: crate::Order::Asc,
+        }),
+        ..Default::default()
+    };
+
+    let error = Index::builder()
+        .schema(schema)
+        .settings(settings)
+        .create_in_ram()
+        .unwrap_err();
+    assert!(matches!(error, TantivyError::InvalidArgument(_)));
 }
 
 #[test]

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -346,9 +346,11 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
     assert!(!index.settings().manual_doc_id_mapping);
     let segment_metas = index.searchable_segment_metas()?;
     let segment_meta = &segment_metas[0];
+    let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
     assert!(!segment_meta
         .list_files()
-        .contains(&segment_meta.relative_path(SegmentComponent::TempStore)));
+        .contains(&temp_store_path));
+    assert!(!index.directory().exists(&temp_store_path)?);
 
     let mut index_writer = index.writer_for_tests()?;
     index_writer.add_document(doc!(text_field=>"delta"))?;
@@ -382,9 +384,11 @@ fn test_single_segment_index_writer_with_sort_by_field_untracks_tempstore() -> c
 
     let segment_metas = index.searchable_segment_metas()?;
     let segment_meta = &segment_metas[0];
+    let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
     assert!(!segment_meta
         .list_files()
-        .contains(&segment_meta.relative_path(SegmentComponent::TempStore)));
+        .contains(&temp_store_path));
+    assert!(!index.directory().exists(&temp_store_path)?);
     Ok(())
 }
 

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -347,9 +347,7 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
     let segment_metas = index.searchable_segment_metas()?;
     let segment_meta = &segment_metas[0];
     let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
-    assert!(!segment_meta
-        .list_files()
-        .contains(&temp_store_path));
+    assert!(!segment_meta.list_files().contains(&temp_store_path));
     assert!(!index.directory().exists(&temp_store_path)?);
 
     let mut index_writer = index.writer_for_tests()?;
@@ -385,9 +383,7 @@ fn test_single_segment_index_writer_with_sort_by_field_untracks_tempstore() -> c
     let segment_metas = index.searchable_segment_metas()?;
     let segment_meta = &segment_metas[0];
     let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
-    assert!(!segment_meta
-        .list_files()
-        .contains(&temp_store_path));
+    assert!(!segment_meta.list_files().contains(&temp_store_path));
     assert!(!index.directory().exists(&temp_store_path)?);
     Ok(())
 }

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -306,8 +306,10 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
     let text_field = schema_builder.add_text_field("text", TEXT | STORED);
     let schema = schema_builder.build();
     let directory = RamDirectory::default();
-    let mut settings = IndexSettings::default();
-    settings.manual_doc_id_mapping = true;
+    let settings = IndexSettings {
+        manual_doc_id_mapping: true,
+        ..Default::default()
+    };
     let mut single_segment_index_writer = Index::builder()
         .schema(schema)
         .settings(settings)

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1,14 +1,14 @@
 use crate::collector::Count;
 use crate::directory::{RamDirectory, WatchCallback};
 use crate::index::SegmentId;
-use crate::indexer::{LogMergePolicy, NoMergePolicy};
+use crate::indexer::{DocIdMapping, LogMergePolicy, NoMergePolicy};
 use crate::postings::Postings;
 use crate::query::TermQuery;
-use crate::schema::{Field, IndexRecordOption, Schema, INDEXED, STRING, TEXT};
+use crate::schema::{Field, IndexRecordOption, Schema, Value, INDEXED, STORED, STRING, TEXT};
 use crate::tokenizer::TokenizerManager;
 use crate::{
-    Directory, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter, ReloadPolicy,
-    TantivyDocument, Term,
+    Directory, DocAddress, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter,
+    ReloadPolicy, TantivyDocument, Term,
 };
 
 #[test]
@@ -297,6 +297,46 @@ fn test_single_segment_index_writer() -> crate::Result<()> {
     );
     let count = searcher.search(&term_query, &Count)?;
     assert_eq!(count, 10);
+    Ok(())
+}
+
+#[test]
+fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+    let schema = schema_builder.build();
+    let directory = RamDirectory::default();
+    let mut single_segment_index_writer = Index::builder()
+        .schema(schema)
+        .single_segment_index_writer(directory, 15_000_000)?;
+
+    single_segment_index_writer.add_document(doc!(text_field=>"alpha beta"))?;
+    single_segment_index_writer.add_document(doc!())?;
+    single_segment_index_writer.add_document(doc!(text_field=>"gamma"))?;
+
+    let mapping = DocIdMapping::from_new_id_to_old_id(vec![2, 1, 0]);
+    let index = single_segment_index_writer.finalize_with_doc_id_mapping(&mapping)?;
+
+    let searcher = index.reader()?.searcher();
+    let segment_reader = searcher.segment_reader(0);
+    let fieldnorm_reader = segment_reader.get_fieldnorms_reader(text_field)?;
+
+    assert_eq!(fieldnorm_reader.fieldnorm(0), 1);
+    assert_eq!(fieldnorm_reader.fieldnorm(1), 0);
+    assert_eq!(fieldnorm_reader.fieldnorm(2), 2);
+
+    let doc_0 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 0))?;
+    assert_eq!(
+        doc_0.get_first(text_field).and_then(|val| val.as_str()),
+        Some("gamma")
+    );
+    let doc_1 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 1))?;
+    assert!(doc_1.get_first(text_field).is_none());
+    let doc_2 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 2))?;
+    assert_eq!(
+        doc_2.get_first(text_field).and_then(|val| val.as_str()),
+        Some("alpha beta")
+    );
     Ok(())
 }
 

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -1,14 +1,14 @@
 use crate::collector::Count;
 use crate::directory::{RamDirectory, WatchCallback};
-use crate::index::{SegmentComponent, SegmentId};
-use crate::indexer::{DocIdMapping, LogMergePolicy, NoMergePolicy};
+use crate::index::SegmentId;
+use crate::indexer::{LogMergePolicy, NoMergePolicy};
 use crate::postings::Postings;
 use crate::query::TermQuery;
-use crate::schema::{Field, IndexRecordOption, Schema, Value, FAST, INDEXED, STORED, STRING, TEXT};
+use crate::schema::{Field, IndexRecordOption, Schema, INDEXED, STRING, TEXT};
 use crate::tokenizer::TokenizerManager;
 use crate::{
-    Directory, DocAddress, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter,
-    ReloadPolicy, TantivyDocument, TantivyError, Term,
+    Directory, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter, ReloadPolicy,
+    TantivyDocument, Term,
 };
 
 #[test]
@@ -298,140 +298,6 @@ fn test_single_segment_index_writer() -> crate::Result<()> {
     let count = searcher.search(&term_query, &Count)?;
     assert_eq!(count, 10);
     Ok(())
-}
-
-#[test]
-fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
-    let mut schema_builder = Schema::builder();
-    let text_field = schema_builder.add_text_field("text", TEXT | STORED);
-    let schema = schema_builder.build();
-    let directory = RamDirectory::default();
-    let settings = IndexSettings {
-        manual_doc_id_mapping: true,
-        ..Default::default()
-    };
-    let mut single_segment_index_writer = Index::builder()
-        .schema(schema)
-        .settings(settings)
-        .single_segment_index_writer(directory, 15_000_000)?;
-
-    single_segment_index_writer.add_document(doc!(text_field=>"alpha beta"))?;
-    single_segment_index_writer.add_document(doc!())?;
-    single_segment_index_writer.add_document(doc!(text_field=>"gamma"))?;
-
-    let mapping = DocIdMapping::new_permutation(vec![2, 1, 0])?;
-    let index = single_segment_index_writer.finalize_with_doc_id_mapping(&mapping)?;
-
-    let searcher = index.reader()?.searcher();
-    let segment_reader = searcher.segment_reader(0);
-    let fieldnorm_reader = segment_reader.get_fieldnorms_reader(text_field)?;
-
-    assert_eq!(fieldnorm_reader.fieldnorm(0), 1);
-    assert_eq!(fieldnorm_reader.fieldnorm(1), 0);
-    assert_eq!(fieldnorm_reader.fieldnorm(2), 2);
-
-    let doc_0 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 0))?;
-    assert_eq!(
-        doc_0.get_first(text_field).and_then(|val| val.as_str()),
-        Some("gamma")
-    );
-    let doc_1 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 1))?;
-    assert!(doc_1.get_first(text_field).is_none());
-    let doc_2 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 2))?;
-    assert_eq!(
-        doc_2.get_first(text_field).and_then(|val| val.as_str()),
-        Some("alpha beta")
-    );
-
-    assert!(!index.settings().manual_doc_id_mapping);
-    let segment_metas = index.searchable_segment_metas()?;
-    let segment_meta = &segment_metas[0];
-    let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
-    assert!(!segment_meta.list_files().contains(&temp_store_path));
-    assert!(!index.directory().exists(&temp_store_path)?);
-
-    let mut index_writer = index.writer_for_tests()?;
-    index_writer.add_document(doc!(text_field=>"delta"))?;
-    index_writer.commit()?;
-
-    Ok(())
-}
-
-#[test]
-fn test_single_segment_index_writer_with_sort_by_field_untracks_tempstore() -> crate::Result<()> {
-    let mut schema_builder = Schema::builder();
-    let sort_field = schema_builder.add_u64_field("sort", FAST | STORED);
-    let schema = schema_builder.build();
-    let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
-    let directory = RamDirectory::default();
-    let settings = IndexSettings {
-        sort_by_field: Some(crate::IndexSortByField {
-            field: sort_field_name,
-            order: crate::Order::Asc,
-        }),
-        ..Default::default()
-    };
-    let mut single_segment_index_writer = Index::builder()
-        .schema(schema)
-        .settings(settings)
-        .single_segment_index_writer(directory, 15_000_000)?;
-
-    single_segment_index_writer.add_document(doc!(sort_field=>2u64))?;
-    single_segment_index_writer.add_document(doc!(sort_field=>1u64))?;
-    let index = single_segment_index_writer.finalize()?;
-
-    let segment_metas = index.searchable_segment_metas()?;
-    let segment_meta = &segment_metas[0];
-    let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
-    assert!(!segment_meta.list_files().contains(&temp_store_path));
-    assert!(!index.directory().exists(&temp_store_path)?);
-    Ok(())
-}
-
-#[test]
-fn test_single_segment_index_writer_finalize_rejects_manual_doc_id_mapping() -> crate::Result<()> {
-    let mut schema_builder = Schema::builder();
-    let text_field = schema_builder.add_text_field("text", TEXT | STORED);
-    let schema = schema_builder.build();
-    let directory = RamDirectory::default();
-    let settings = IndexSettings {
-        manual_doc_id_mapping: true,
-        ..Default::default()
-    };
-    let mut single_segment_index_writer = Index::builder()
-        .schema(schema)
-        .settings(settings)
-        .single_segment_index_writer(directory, 15_000_000)?;
-
-    single_segment_index_writer.add_document(doc!(text_field=>"alpha"))?;
-
-    let error = single_segment_index_writer.finalize().unwrap_err();
-    assert!(matches!(error, TantivyError::InvalidArgument(_)));
-    Ok(())
-}
-
-#[test]
-fn test_index_builder_rejects_manual_doc_id_mapping_with_sort_by_field() {
-    let mut schema_builder = Schema::builder();
-    schema_builder.add_text_field("text", TEXT | STORED);
-    let sort_field = schema_builder.add_u64_field("sort", STORED | FAST);
-    let schema = schema_builder.build();
-    let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
-    let settings = IndexSettings {
-        manual_doc_id_mapping: true,
-        sort_by_field: Some(crate::IndexSortByField {
-            field: sort_field_name,
-            order: crate::Order::Asc,
-        }),
-        ..Default::default()
-    };
-
-    let error = Index::builder()
-        .schema(schema)
-        .settings(settings)
-        .create_in_ram()
-        .unwrap_err();
-    assert!(matches!(error, TantivyError::InvalidArgument(_)));
 }
 
 #[test]

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -8,7 +8,7 @@ use crate::schema::{Field, IndexRecordOption, Schema, Value, INDEXED, STORED, ST
 use crate::tokenizer::TokenizerManager;
 use crate::{
     Directory, DocAddress, DocSet, Index, IndexBuilder, IndexReader, IndexSettings, IndexWriter,
-    ReloadPolicy, TantivyDocument, Term,
+    ReloadPolicy, TantivyDocument, TantivyError, Term,
 };
 
 #[test]
@@ -342,6 +342,28 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
         doc_2.get_first(text_field).and_then(|val| val.as_str()),
         Some("alpha beta")
     );
+    Ok(())
+}
+
+#[test]
+fn test_single_segment_index_writer_finalize_rejects_manual_doc_id_mapping() -> crate::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+    let schema = schema_builder.build();
+    let directory = RamDirectory::default();
+    let settings = IndexSettings {
+        manual_doc_id_mapping: true,
+        ..Default::default()
+    };
+    let mut single_segment_index_writer = Index::builder()
+        .schema(schema)
+        .settings(settings)
+        .single_segment_index_writer(directory, 15_000_000)?;
+
+    single_segment_index_writer.add_document(doc!(text_field=>"alpha"))?;
+
+    let error = single_segment_index_writer.finalize().unwrap_err();
+    assert!(matches!(error, TantivyError::InvalidArgument(_)));
     Ok(())
 }
 

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -319,7 +319,7 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
     single_segment_index_writer.add_document(doc!())?;
     single_segment_index_writer.add_document(doc!(text_field=>"gamma"))?;
 
-    let mapping = DocIdMapping::from_new_id_to_old_id(vec![2, 1, 0]);
+    let mapping = DocIdMapping::new_permutation(vec![2, 1, 0])?;
     let index = single_segment_index_writer.finalize_with_doc_id_mapping(&mapping)?;
 
     let searcher = index.reader()?.searcher();

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -306,8 +306,11 @@ fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
     let text_field = schema_builder.add_text_field("text", TEXT | STORED);
     let schema = schema_builder.build();
     let directory = RamDirectory::default();
+    let mut settings = IndexSettings::default();
+    settings.manual_doc_id_mapping = true;
     let mut single_segment_index_writer = Index::builder()
         .schema(schema)
+        .settings(settings)
         .single_segment_index_writer(directory, 15_000_000)?;
 
     single_segment_index_writer.add_document(doc!(text_field=>"alpha beta"))?;

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -233,6 +233,14 @@ impl IndexBuilder {
 
     fn validate(&self) -> crate::Result<()> {
         if let Some(schema) = self.schema.as_ref() {
+            if self.index_settings.manual_doc_id_mapping
+                && self.index_settings.sort_by_field.is_some()
+            {
+                return Err(TantivyError::InvalidArgument(
+                    "IndexSettings::manual_doc_id_mapping cannot be combined with sort_by_field"
+                        .to_string(),
+                ));
+            }
             if let Some(sort_by_field) = self.index_settings.sort_by_field.as_ref() {
                 let schema_field = schema.get_field(&sort_by_field.field).map_err(|_| {
                     TantivyError::InvalidArgument(format!(

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -465,6 +465,7 @@ mod tests {
                     field: "text".to_string(),
                     order: Order::Asc,
                 }),
+                manual_doc_id_mapping: false,
                 docstore_compression: crate::store::Compressor::Zstd(ZstdCompressor {
                     compression_level: Some(4),
                 }),

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -251,6 +251,7 @@ pub struct IndexSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_by_field: Option<IndexSortByField>,
     /// If true, enables caller-provided doc id mappings at segment finalization time.
+    /// Always skip serializing this field since it's only used at segment finalization time.
     #[doc(hidden)]
     #[serde(skip)]
     pub manual_doc_id_mapping: bool,

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -250,6 +250,10 @@ pub struct IndexSettings {
     /// provided in `IndexSortByField`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_by_field: Option<IndexSortByField>,
+    /// If true, enables caller-provided doc id mappings at segment finalization time.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub manual_doc_id_mapping: bool,
     /// The `Compressor` used to compress the doc store.
     #[serde(default)]
     pub docstore_compression: Compressor,
@@ -273,6 +277,7 @@ impl Default for IndexSettings {
     fn default() -> Self {
         Self {
             sort_by_field: None,
+            manual_doc_id_mapping: false,
             docstore_compression: Compressor::default(),
             docstore_blocksize: default_docstore_blocksize(),
             docstore_compress_dedicated_thread: true,
@@ -529,6 +534,7 @@ mod tests {
             index_settings,
             IndexSettings {
                 sort_by_field: None,
+                manual_doc_id_mapping: false,
                 docstore_compression: Compressor::default(),
                 docstore_compress_dedicated_thread: true,
                 docstore_blocksize: 16_384
@@ -546,6 +552,18 @@ mod tests {
             let index_settings_deser: IndexSettings =
                 serde_json::from_value(index_settings_json).unwrap();
             assert_eq!(index_settings_deser, index_settings);
+        }
+        {
+            index_settings.manual_doc_id_mapping = true;
+            let index_settings_json = serde_json::to_value(&index_settings).unwrap();
+            assert_eq!(
+                index_settings_json,
+                serde_json::json!({
+                    "docstore_compression": "lz4",
+                    "docstore_blocksize": 16384
+                })
+            );
+            index_settings.manual_doc_id_mapping = false;
         }
         {
             index_settings.docstore_compress_dedicated_thread = false;

--- a/src/index/index_meta.rs
+++ b/src/index/index_meta.rs
@@ -556,6 +556,7 @@ mod tests {
             assert_eq!(index_settings_deser, index_settings);
         }
         {
+            // manual_doc_id_mapping should not be persisted.
             index_settings.manual_doc_id_mapping = true;
             let index_settings_json = serde_json::to_value(&index_settings).unwrap();
             assert_eq!(

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -100,7 +100,7 @@ impl DocIdMapping {
 
     fn from_new_id_to_old_id_inner<E: Error>(
         new_doc_id_to_old: Vec<DocId>,
-        mut check: impl FnMut(DocId) -> Result<(), E>,
+        mut validate: impl FnMut(DocId) -> Result<(), E>,
     ) -> Result<Self, E> {
         let max_doc = new_doc_id_to_old.len();
         let old_max_doc = new_doc_id_to_old
@@ -111,7 +111,7 @@ impl DocIdMapping {
             .unwrap_or(0);
         let mut old_doc_id_to_new = vec![0; old_max_doc as usize];
         for i in 0..max_doc {
-            (check)(new_doc_id_to_old[i])?;
+            (validate)(new_doc_id_to_old[i])?;
             old_doc_id_to_new[new_doc_id_to_old[i] as usize] = i as DocId;
         }
         Ok(DocIdMapping {

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -1,6 +1,10 @@
 //! This module is used when sorting the index by a property, e.g.
 //! to get mappings from old doc_id to new doc_id and vice versa, after sorting
+use std::convert::Infallible;
+use std::error::Error;
+
 use common::{BitSet, ReadOnlyBitSet};
+use unwrap_infallible::UnwrapInfallible;
 
 use super::SegmentWriter;
 use crate::schema::{Field, Schema};
@@ -75,29 +79,29 @@ impl DocIdMapping {
     /// once in the mapping. I.e., doc ids must be consecutive from `0` to
     /// `new_doc_id_to_old.len() - 1`, inclusive.
     pub fn new_permutation(new_doc_id_to_old: Vec<DocId>) -> crate::Result<Self> {
-        // Check that the mapping is a permutation of the segment doc ids.
         let max_doc = new_doc_id_to_old.len() as DocId;
-        let mut old_doc_id_to_new = vec![0; max_doc as usize];
+        let mut seen_doc_ids: BitSet = BitSet::with_max_value(max_doc);
 
-        let mut seen_doc_ids = BitSet::with_max_value(max_doc);
-        for (i, old_doc_id) in new_doc_id_to_old.iter().copied().enumerate() {
+        Self::from_new_id_to_old_id_inner(new_doc_id_to_old, |old_doc_id| {
             if old_doc_id >= max_doc || !seen_doc_ids.insert(old_doc_id) {
                 return Err(TantivyError::InvalidArgument(
                     "Mapping must be a permutation of the segment doc ids".to_string(),
                 ));
             }
-            old_doc_id_to_new[new_doc_id_to_old[i] as usize] = i as DocId;
-        }
-
-        let doc_id_mapping = DocIdMapping {
-            new_doc_id_to_old,
-            old_doc_id_to_new,
-        };
-        Ok(doc_id_mapping)
+            Ok::<(), TantivyError>(())
+        })
     }
 
     /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids.
     pub(crate) fn from_new_id_to_old_id(new_doc_id_to_old: Vec<DocId>) -> Self {
+        Self::from_new_id_to_old_id_inner(new_doc_id_to_old, |_| Ok::<(), Infallible>(()))
+            .unwrap_infallible()
+    }
+
+    fn from_new_id_to_old_id_inner<E: Error>(
+        new_doc_id_to_old: Vec<DocId>,
+        mut check: impl FnMut(DocId) -> Result<(), E>,
+    ) -> Result<Self, E> {
         let max_doc = new_doc_id_to_old.len();
         let old_max_doc = new_doc_id_to_old
             .iter()
@@ -107,12 +111,13 @@ impl DocIdMapping {
             .unwrap_or(0);
         let mut old_doc_id_to_new = vec![0; old_max_doc as usize];
         for i in 0..max_doc {
+            (check)(new_doc_id_to_old[i])?;
             old_doc_id_to_new[new_doc_id_to_old[i] as usize] = i as DocId;
         }
-        DocIdMapping {
+        Ok(DocIdMapping {
             new_doc_id_to_old,
             old_doc_id_to_new,
-        }
+        })
     }
 
     /// Returns the new doc_id for the old doc_id

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -187,6 +187,8 @@ mod tests_indexsorting {
     use common::DateTime;
 
     use crate::collector::TopDocs;
+    use crate::directory::{Directory, RamDirectory};
+    use crate::index::SegmentComponent;
     use crate::indexer::doc_id_mapping::DocIdMapping;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
@@ -568,6 +570,139 @@ mod tests_indexsorting {
         assert_eq!(fast_field.get_val(1), DateTime::from_timestamp_secs(1000));
         assert_eq!(fast_field.get_val(2), DateTime::from_timestamp_secs(999));
         Ok(())
+    }
+
+    #[test]
+    fn test_single_segment_index_writer_with_doc_id_mapping() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+        let schema = schema_builder.build();
+        let settings = IndexSettings {
+            manual_doc_id_mapping: true,
+            ..Default::default()
+        };
+        let mut single_segment_index_writer = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .single_segment_index_writer(RamDirectory::default(), 15_000_000)?;
+
+        single_segment_index_writer.add_document(doc!(text_field=>"alpha beta"))?;
+        single_segment_index_writer.add_document(doc!())?;
+        single_segment_index_writer.add_document(doc!(text_field=>"gamma"))?;
+
+        let mapping = DocIdMapping::new_permutation(vec![2, 1, 0])?;
+        let index = single_segment_index_writer.finalize_with_doc_id_mapping(&mapping)?;
+
+        let searcher = index.reader()?.searcher();
+        let segment_reader = searcher.segment_reader(0);
+        let fieldnorm_reader = segment_reader.get_fieldnorms_reader(text_field)?;
+
+        assert_eq!(fieldnorm_reader.fieldnorm(0), 1);
+        assert_eq!(fieldnorm_reader.fieldnorm(1), 0);
+        assert_eq!(fieldnorm_reader.fieldnorm(2), 2);
+
+        let doc_0 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 0))?;
+        assert_eq!(
+            doc_0.get_first(text_field).and_then(|val| val.as_str()),
+            Some("gamma")
+        );
+        let doc_1 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 1))?;
+        assert!(doc_1.get_first(text_field).is_none());
+        let doc_2 = searcher.doc::<TantivyDocument>(DocAddress::new(0, 2))?;
+        assert_eq!(
+            doc_2.get_first(text_field).and_then(|val| val.as_str()),
+            Some("alpha beta")
+        );
+
+        assert!(!index.settings().manual_doc_id_mapping);
+        let segment_metas = index.searchable_segment_metas()?;
+        let segment_meta = &segment_metas[0];
+        let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
+        assert!(!segment_meta.list_files().contains(&temp_store_path));
+        assert!(!index.directory().exists(&temp_store_path)?);
+
+        let mut index_writer = index.writer_for_tests()?;
+        index_writer.add_document(doc!(text_field=>"delta"))?;
+        index_writer.commit()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_segment_index_writer_with_sort_by_field_untracks_tempstore() -> crate::Result<()>
+    {
+        let mut schema_builder = Schema::builder();
+        let sort_field = schema_builder.add_u64_field("sort", FAST | STORED);
+        let schema = schema_builder.build();
+        let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
+        let settings = IndexSettings {
+            sort_by_field: Some(IndexSortByField {
+                field: sort_field_name,
+                order: Order::Asc,
+            }),
+            ..Default::default()
+        };
+        let mut single_segment_index_writer = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .single_segment_index_writer(RamDirectory::default(), 15_000_000)?;
+
+        single_segment_index_writer.add_document(doc!(sort_field=>2u64))?;
+        single_segment_index_writer.add_document(doc!(sort_field=>1u64))?;
+        let index = single_segment_index_writer.finalize()?;
+
+        let segment_metas = index.searchable_segment_metas()?;
+        let segment_meta = &segment_metas[0];
+        let temp_store_path = segment_meta.relative_path(SegmentComponent::TempStore);
+        assert!(!segment_meta.list_files().contains(&temp_store_path));
+        assert!(!index.directory().exists(&temp_store_path)?);
+        Ok(())
+    }
+
+    #[test]
+    fn test_single_segment_index_writer_finalize_rejects_manual_doc_id_mapping() -> crate::Result<()>
+    {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT | STORED);
+        let schema = schema_builder.build();
+        let settings = IndexSettings {
+            manual_doc_id_mapping: true,
+            ..Default::default()
+        };
+        let mut single_segment_index_writer = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .single_segment_index_writer(RamDirectory::default(), 15_000_000)?;
+
+        single_segment_index_writer.add_document(doc!(text_field=>"alpha"))?;
+
+        let error = single_segment_index_writer.finalize().unwrap_err();
+        assert!(matches!(error, TantivyError::InvalidArgument(_)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_index_builder_rejects_manual_doc_id_mapping_with_sort_by_field() {
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_text_field("text", TEXT | STORED);
+        let sort_field = schema_builder.add_u64_field("sort", STORED | FAST);
+        let schema = schema_builder.build();
+        let sort_field_name = schema.get_field_entry(sort_field).name().to_string();
+        let settings = IndexSettings {
+            manual_doc_id_mapping: true,
+            sort_by_field: Some(IndexSortByField {
+                field: sort_field_name,
+                order: Order::Asc,
+            }),
+            ..Default::default()
+        };
+
+        let error = Index::builder()
+            .schema(schema)
+            .settings(settings)
+            .create_in_ram()
+            .unwrap_err();
+        assert!(matches!(error, TantivyError::InvalidArgument(_)));
     }
 
     #[test]

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -71,20 +71,28 @@ pub struct DocIdMapping {
 
 impl DocIdMapping {
     /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids, with permutation validation.
-    /// I.e. every new doc id must appear exactly once in the mapping, and no new doc id may be greater than the length of the mapping.
+    /// The mapping is validated by checking that every old doc id appears exactly once in the mapping.
+    /// I.e., doc ids must be consecutive from `0` to `new_doc_id_to_old.len() - 1`, inclusive.
     pub fn new_permutation(new_doc_id_to_old: Vec<DocId>) -> crate::Result<Self> {
         // Check that the mapping is a permutation of the segment doc ids.
         let max_doc = new_doc_id_to_old.len() as DocId;
+        let mut old_doc_id_to_new = vec![0; max_doc as usize];
+
         let mut seen_doc_ids = BitSet::with_max_value(max_doc);
-        for new_doc_id in new_doc_id_to_old.iter().copied() {
-            if new_doc_id >= max_doc || !seen_doc_ids.insert(new_doc_id) {
+        for (i, old_doc_id) in new_doc_id_to_old.iter().copied().enumerate() {
+            if old_doc_id >= max_doc || !seen_doc_ids.insert(old_doc_id) {
                 return Err(TantivyError::InvalidArgument(
                     "Mapping must be a permutation of the segment doc ids".to_string(),
                 ));
             }
+            old_doc_id_to_new[new_doc_id_to_old[i] as usize] = i as DocId;
         }
 
-        Ok(Self::from_new_id_to_old_id(new_doc_id_to_old))
+        let doc_id_mapping = DocIdMapping {
+            new_doc_id_to_old,
+            old_doc_id_to_new,
+        };
+        Ok(doc_id_mapping)
     }
 
     /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids.
@@ -106,17 +114,17 @@ impl DocIdMapping {
         }
     }
 
-    /// returns the new doc_id for the old doc_id
+    /// Returns the new doc_id for the old doc_id
     pub(crate) fn get_new_doc_id(&self, doc_id: DocId) -> DocId {
         self.old_doc_id_to_new[doc_id as usize]
     }
 
-    /// iterate over old doc_ids in order of the new doc_ids
+    /// Iiterate over old doc_ids in order of the new doc_ids
     pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + '_ {
         self.new_doc_id_to_old.iter().copied()
     }
 
-    /// returns the new doc_ids in order of the old doc_ids
+    /// Returns the new doc_ids in order of the old doc_ids
     pub(crate) fn old_to_new_ids(&self) -> &[DocId] {
         &self.old_doc_id_to_new[..]
     }
@@ -129,8 +137,9 @@ impl DocIdMapping {
             .collect()
     }
 
-    /// returns the number of new doc_ids
+    /// Returns the number of documents in the mapping.
     pub(crate) fn len(&self) -> usize {
+        // new_doc_id_to_old and old_doc_id_to_new have the same length by construction.
         self.new_doc_id_to_old.len()
     }
 }
@@ -180,7 +189,7 @@ mod tests_indexsorting {
     use crate::indexer::doc_id_mapping::DocIdMapping;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
-    use crate::schema::*;
+    use crate::{schema::*, TantivyError};
     use crate::{DocAddress, Index, IndexBuilder, IndexSettings, IndexSortByField, Order};
 
     fn create_test_index(
@@ -570,6 +579,18 @@ mod tests_indexsorting {
         assert_eq!(doc_mapping.get_new_doc_id(3), 0);
         assert_eq!(doc_mapping.get_new_doc_id(4), 0);
         assert_eq!(doc_mapping.get_new_doc_id(5), 2);
+    }
+
+    #[test]
+    fn test_doc_mapping_new_permutation_rejects_out_of_range() {
+        let result = DocIdMapping::new_permutation(vec![5, 0]);
+        assert!(matches!(result, Err(TantivyError::InvalidArgument(_)),));
+    }
+
+    #[test]
+    fn test_doc_mapping_new_permutation_rejects_duplicates() {
+        let result = DocIdMapping::new_permutation(vec![0, 1, 0]);
+        assert!(matches!(result, Err(TantivyError::InvalidArgument(_)),));
     }
 
     #[test]

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -71,6 +71,10 @@ pub struct DocIdMapping {
 }
 
 impl DocIdMapping {
+    /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids.
+    ///
+    /// The caller MUST ensure that `new_doc_id_to_old` is a permutation of the
+    /// segment's old doc ids, with every old doc id appearing exactly once.
     pub fn from_new_id_to_old_id(new_doc_id_to_old: Vec<DocId>) -> Self {
         let max_doc = new_doc_id_to_old.len();
         let old_max_doc = new_doc_id_to_old
@@ -90,34 +94,39 @@ impl DocIdMapping {
     }
 
     /// returns the new doc_id for the old doc_id
-    pub fn get_new_doc_id(&self, doc_id: DocId) -> DocId {
+    pub(crate) fn get_new_doc_id(&self, doc_id: DocId) -> DocId {
         self.old_doc_id_to_new[doc_id as usize]
     }
-    /// returns the old doc_id for the new doc_id
-    pub fn get_old_doc_id(&self, doc_id: DocId) -> DocId {
-        self.new_doc_id_to_old[doc_id as usize]
-    }
+
     /// iterate over old doc_ids in order of the new doc_ids
-    pub fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + Clone + '_ {
+    pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + Clone + '_ {
         self.new_doc_id_to_old.iter().cloned()
     }
 
-    pub fn old_to_new_ids(&self) -> &[DocId] {
+    /// returns the new doc_ids in order of the old doc_ids
+    pub(crate) fn old_to_new_ids(&self) -> &[DocId] {
         &self.old_doc_id_to_new[..]
     }
 
     /// Remaps a given array to the new doc ids.
-    pub fn remap<T: Copy>(&self, els: &[T]) -> Vec<T> {
+    pub(crate) fn remap<T: Copy>(&self, els: &[T]) -> Vec<T> {
         self.new_doc_id_to_old
             .iter()
             .map(|old_doc| els[*old_doc as usize])
             .collect()
     }
-    pub fn num_new_doc_ids(&self) -> usize {
+
+    /// returns the number of new doc_ids
+    pub(crate) fn len(&self) -> usize {
         self.new_doc_id_to_old.len()
     }
-    pub fn num_old_doc_ids(&self) -> usize {
-        self.old_doc_id_to_new.len()
+}
+
+#[cfg(test)]
+impl DocIdMapping {
+    /// returns the old doc_id for the new doc_id
+    fn get_old_doc_id(&self, doc_id: DocId) -> DocId {
+        self.new_doc_id_to_old[doc_id as usize]
     }
 }
 

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -120,7 +120,7 @@ impl DocIdMapping {
     }
 
     /// Iiterate over old doc_ids in order of the new doc_ids
-    pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + '_ {
+    pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + Clone + '_ {
         self.new_doc_id_to_old.iter().copied()
     }
 

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -70,9 +70,10 @@ pub struct DocIdMapping {
 }
 
 impl DocIdMapping {
-    /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids, with permutation validation.
-    /// The mapping is validated by checking that every old doc id appears exactly once in the mapping.
-    /// I.e., doc ids must be consecutive from `0` to `new_doc_id_to_old.len() - 1`, inclusive.
+    /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids, with permutation
+    /// validation. The mapping is validated by checking that every old doc id appears exactly
+    /// once in the mapping. I.e., doc ids must be consecutive from `0` to
+    /// `new_doc_id_to_old.len() - 1`, inclusive.
     pub fn new_permutation(new_doc_id_to_old: Vec<DocId>) -> crate::Result<Self> {
         // Check that the mapping is a permutation of the segment doc ids.
         let max_doc = new_doc_id_to_old.len() as DocId;
@@ -189,8 +190,10 @@ mod tests_indexsorting {
     use crate::indexer::doc_id_mapping::DocIdMapping;
     use crate::indexer::NoMergePolicy;
     use crate::query::QueryParser;
-    use crate::{schema::*, TantivyError};
-    use crate::{DocAddress, Index, IndexBuilder, IndexSettings, IndexSortByField, Order};
+    use crate::schema::*;
+    use crate::{
+        DocAddress, Index, IndexBuilder, IndexSettings, IndexSortByField, Order, TantivyError,
+    };
 
     fn create_test_index(
         index_settings: Option<IndexSettings>,

--- a/src/indexer/doc_id_mapping.rs
+++ b/src/indexer/doc_id_mapping.rs
@@ -1,7 +1,6 @@
 //! This module is used when sorting the index by a property, e.g.
 //! to get mappings from old doc_id to new doc_id and vice versa, after sorting
-
-use common::ReadOnlyBitSet;
+use common::{BitSet, ReadOnlyBitSet};
 
 use super::SegmentWriter;
 use crate::schema::{Field, Schema};
@@ -71,11 +70,25 @@ pub struct DocIdMapping {
 }
 
 impl DocIdMapping {
+    /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids, with permutation validation.
+    /// I.e. every new doc id must appear exactly once in the mapping, and no new doc id may be greater than the length of the mapping.
+    pub fn new_permutation(new_doc_id_to_old: Vec<DocId>) -> crate::Result<Self> {
+        // Check that the mapping is a permutation of the segment doc ids.
+        let max_doc = new_doc_id_to_old.len() as DocId;
+        let mut seen_doc_ids = BitSet::with_max_value(max_doc);
+        for new_doc_id in new_doc_id_to_old.iter().copied() {
+            if new_doc_id >= max_doc || !seen_doc_ids.insert(new_doc_id) {
+                return Err(TantivyError::InvalidArgument(
+                    "Mapping must be a permutation of the segment doc ids".to_string(),
+                ));
+            }
+        }
+
+        Ok(Self::from_new_id_to_old_id(new_doc_id_to_old))
+    }
+
     /// Creates a `DocIdMapping` from a mapping of new doc ids to old doc ids.
-    ///
-    /// The caller MUST ensure that `new_doc_id_to_old` is a permutation of the
-    /// segment's old doc ids, with every old doc id appearing exactly once.
-    pub fn from_new_id_to_old_id(new_doc_id_to_old: Vec<DocId>) -> Self {
+    pub(crate) fn from_new_id_to_old_id(new_doc_id_to_old: Vec<DocId>) -> Self {
         let max_doc = new_doc_id_to_old.len();
         let old_max_doc = new_doc_id_to_old
             .iter()
@@ -99,8 +112,8 @@ impl DocIdMapping {
     }
 
     /// iterate over old doc_ids in order of the new doc_ids
-    pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + Clone + '_ {
-        self.new_doc_id_to_old.iter().cloned()
+    pub(crate) fn iter_old_doc_ids(&self) -> impl Iterator<Item = DocId> + '_ {
+        self.new_doc_id_to_old.iter().copied()
     }
 
     /// returns the new doc_ids in order of the old doc_ids

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -33,6 +33,7 @@ mod stamper;
 use crossbeam_channel as channel;
 use smallvec::SmallVec;
 
+pub use self::doc_id_mapping::DocIdMapping;
 pub use self::index_writer::{advance_deletes, IndexWriter, IndexWriterOptions};
 pub use self::log_merge_policy::LogMergePolicy;
 pub use self::merge_operation::MergeOperation;

--- a/src/indexer/segment_serializer.rs
+++ b/src/indexer/segment_serializer.rs
@@ -5,7 +5,6 @@ use crate::fieldnorm::FieldNormsSerializer;
 use crate::index::{Segment, SegmentComponent};
 use crate::postings::InvertedIndexSerializer;
 use crate::store::{Compressor, StoreWriter};
-use crate::IndexSettings;
 
 /// Segment serializer is in charge of laying out on disk
 /// the data accumulated and sorted by the `SegmentWriter`.
@@ -26,10 +25,20 @@ impl SegmentSerializer {
         // If the segment is going to be sorted, we stream the docs first to a temporary file.
         // In the merge case this is not necessary because we can kmerge the already sorted
         // segments
-        let remapping_required = segment.index().settings().sort_by_field.is_some() && !is_in_merge;
         let settings = segment.index().settings().clone();
+        let remapping_required =
+            (settings.sort_by_field.is_some() || settings.manual_doc_id_mapping) && !is_in_merge;
         let store_writer = if remapping_required {
-            Self::create_temp_store_writer(&mut segment, &settings)?
+            let store_write = segment.open_write(SegmentComponent::TempStore)?;
+            StoreWriter::new(
+                store_write,
+                Compressor::None,
+                // We want fast random access on the docs, so we choose a small block size.
+                // If this is zero, the skip index will contain too many checkpoints and
+                // therefore will be relatively slow.
+                16_000,
+                settings.docstore_compress_dedicated_thread,
+            )?
         } else {
             let store_write = segment.open_write(SegmentComponent::Store)?;
             StoreWriter::new(
@@ -40,38 +49,6 @@ impl SegmentSerializer {
             )?
         };
 
-        Self::for_segment_inner(segment, store_writer)
-    }
-
-    pub(crate) fn for_segment_with_doc_id_mapping(
-        mut segment: Segment,
-    ) -> crate::Result<SegmentSerializer> {
-        let settings = segment.index().settings().clone();
-        let store_writer = Self::create_temp_store_writer(&mut segment, &settings)?;
-        Self::for_segment_inner(segment, store_writer)
-    }
-
-    fn create_temp_store_writer(
-        segment: &mut Segment,
-        settings: &IndexSettings,
-    ) -> crate::Result<StoreWriter> {
-        let store_write = segment.open_write(SegmentComponent::TempStore)?;
-        let store_writer = StoreWriter::new(
-            store_write,
-            Compressor::None,
-            // We want fast random access on the docs, so we choose a small block size.
-            // If this is zero, the skip index will contain too many checkpoints and
-            // therefore will be relatively slow.
-            16_000,
-            settings.docstore_compress_dedicated_thread,
-        )?;
-        Ok(store_writer)
-    }
-
-    fn for_segment_inner(
-        mut segment: Segment,
-        store_writer: StoreWriter,
-    ) -> crate::Result<SegmentSerializer> {
         let fast_field_write = segment.open_write(SegmentComponent::FastFields)?;
 
         let fieldnorms_write = segment.open_write(SegmentComponent::FieldNorms)?;

--- a/src/indexer/segment_serializer.rs
+++ b/src/indexer/segment_serializer.rs
@@ -4,7 +4,8 @@ use crate::directory::WritePtr;
 use crate::fieldnorm::FieldNormsSerializer;
 use crate::index::{Segment, SegmentComponent};
 use crate::postings::InvertedIndexSerializer;
-use crate::store::StoreWriter;
+use crate::store::{Compressor, StoreWriter};
+use crate::IndexSettings;
 
 /// Segment serializer is in charge of laying out on disk
 /// the data accumulated and sorted by the `SegmentWriter`.
@@ -28,16 +29,7 @@ impl SegmentSerializer {
         let remapping_required = segment.index().settings().sort_by_field.is_some() && !is_in_merge;
         let settings = segment.index().settings().clone();
         let store_writer = if remapping_required {
-            let store_write = segment.open_write(SegmentComponent::TempStore)?;
-            StoreWriter::new(
-                store_write,
-                crate::store::Compressor::None,
-                // We want fast random access on the docs, so we choose a small block size.
-                // If this is zero, the skip index will contain too many checkpoints and
-                // therefore will be relatively slow.
-                16000,
-                settings.docstore_compress_dedicated_thread,
-            )?
+            Self::create_temp_store_writer(&mut segment, &settings)?
         } else {
             let store_write = segment.open_write(SegmentComponent::Store)?;
             StoreWriter::new(
@@ -48,6 +40,38 @@ impl SegmentSerializer {
             )?
         };
 
+        Self::for_segment_inner(segment, store_writer)
+    }
+
+    pub(crate) fn for_segment_with_doc_id_mapping(
+        mut segment: Segment,
+    ) -> crate::Result<SegmentSerializer> {
+        let settings = segment.index().settings().clone();
+        let store_writer = Self::create_temp_store_writer(&mut segment, &settings)?;
+        Self::for_segment_inner(segment, store_writer)
+    }
+
+    fn create_temp_store_writer(
+        segment: &mut Segment,
+        settings: &IndexSettings,
+    ) -> crate::Result<StoreWriter> {
+        let store_write = segment.open_write(SegmentComponent::TempStore)?;
+        let store_writer = StoreWriter::new(
+            store_write,
+            Compressor::None,
+            // We want fast random access on the docs, so we choose a small block size.
+            // If this is zero, the skip index will contain too many checkpoints and
+            // therefore will be relatively slow.
+            16_000,
+            settings.docstore_compress_dedicated_thread,
+        )?;
+        Ok(store_writer)
+    }
+
+    fn for_segment_inner(
+        mut segment: Segment,
+        store_writer: StoreWriter,
+    ) -> crate::Result<SegmentSerializer> {
         let fast_field_write = segment.open_write(SegmentComponent::FastFields)?;
 
         let fieldnorms_write = segment.open_write(SegmentComponent::FieldNorms)?;

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -138,6 +138,19 @@ impl SegmentWriter {
     ///
     /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
     pub fn finalize(self) -> crate::Result<Vec<u64>> {
+        // Ensure the segment writer was created in remap mode so the docstore can be reordered.
+        if self
+            .segment_serializer
+            .segment()
+            .index()
+            .settings()
+            .manual_doc_id_mapping
+        {
+            return Err(TantivyError::InvalidArgument(
+                "IndexSettings::manual_doc_id_mapping must be set to false".to_string(),
+            ));
+        }
+
         let mapping: Option<DocIdMapping> = self
             .segment_serializer
             .segment()

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -1,5 +1,5 @@
 use columnar::MonotonicallyMappableToU64;
-use common::JsonPathWriter;
+use common::{BitSet, JsonPathWriter};
 use itertools::Itertools;
 use tokenizer_api::BoxTokenStream;
 
@@ -136,10 +136,8 @@ impl SegmentWriter {
 
     /// Lay on disk the current content of the `SegmentWriter`
     ///
-    /// Finalize consumes the `SegmentWriter`, so that it cannot
-    /// be used afterwards.
-    pub fn finalize(mut self) -> crate::Result<Vec<u64>> {
-        self.fieldnorms_writer.fill_up_to_max_doc(self.max_doc);
+    /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
+    pub fn finalize(self) -> crate::Result<Vec<u64>> {
         let mapping: Option<DocIdMapping> = self
             .segment_serializer
             .segment()
@@ -149,6 +147,41 @@ impl SegmentWriter {
             .clone()
             .map(|sort_by_field| get_doc_id_mapping_from_field(sort_by_field, &self))
             .transpose()?;
+        self.finalize_inner(mapping.as_ref())
+    }
+
+    /// Lay on disk the current content of the `SegmentWriter` using the given doc id mapping.
+    ///
+    /// The mapping must cover all documents in this segment and maps the segment's original doc ids
+    /// to the doc ids that should be written on disk.
+    ///
+    /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
+    pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Vec<u64>> {
+        // Check that the mapping eventually covers all documents in the segment.
+        if mapping.len() != self.max_doc as usize {
+            return Err(TantivyError::InvalidArgument(format!(
+                "Mapping must cover all documents in this segment. Expected {} documents, got {}",
+                self.max_doc,
+                mapping.len()
+            )));
+        }
+
+        // Check that the mapping is a permutation of the segment doc ids.
+        let mut seen_doc_ids = BitSet::with_max_value(self.max_doc);
+        for old_doc_id in mapping.iter_old_doc_ids() {
+            if old_doc_id >= self.max_doc || !seen_doc_ids.insert(old_doc_id) {
+                return Err(TantivyError::InvalidArgument(
+                    "Mapping must be a permutation of the segment doc ids".to_string(),
+                ));
+            }
+        }
+
+        self.finalize_inner(Some(mapping))
+    }
+
+    fn finalize_inner(mut self, mapping: Option<&DocIdMapping>) -> crate::Result<Vec<u64>> {
+        // Pad before remapping; the mapping indexes fieldnorms by old doc id.
+        self.fieldnorms_writer.fill_up_to_max_doc(self.max_doc);
         remap_and_write(
             self.schema,
             &self.per_field_postings_writers,
@@ -156,9 +189,9 @@ impl SegmentWriter {
             self.fast_field_writers,
             &self.fieldnorms_writer,
             self.segment_serializer,
-            mapping.as_ref(),
+            mapping,
         )?;
-        let doc_opstamps = remap_doc_opstamps(self.doc_opstamps, mapping.as_ref());
+        let doc_opstamps = remap_doc_opstamps(self.doc_opstamps, mapping);
         Ok(doc_opstamps)
     }
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -147,7 +147,9 @@ impl SegmentWriter {
             .manual_doc_id_mapping
         {
             return Err(TantivyError::InvalidArgument(
-                "IndexSettings::manual_doc_id_mapping must be set to false. With manual_doc_id_mapping, you need to call finalize_with_doc_id_mapping".to_string(),
+                "IndexSettings::manual_doc_id_mapping must be set to false. With \
+                 manual_doc_id_mapping, you need to call finalize_with_doc_id_mapping"
+                    .to_string(),
             ));
         }
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -17,7 +17,7 @@ use crate::postings::{
 };
 use crate::schema::document::{Document, Value};
 use crate::schema::{FieldEntry, FieldType, Schema, DATE_TIME_PRECISION_INDEXED};
-use crate::store::{StoreReader, StoreWriter};
+use crate::store::{Compressor, StoreReader, StoreWriter};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TextAnalyzer, Tokenizer};
 use crate::{DocId, Opstamp, TantivyError};
 
@@ -87,11 +87,31 @@ impl SegmentWriter {
     /// - segment: The segment being written
     /// - schema
     pub fn for_segment(memory_budget_in_bytes: usize, segment: Segment) -> crate::Result<Self> {
+        Self::for_segment_inner(memory_budget_in_bytes, segment, |segment| {
+            SegmentSerializer::for_segment(segment, false)
+        })
+    }
+
+    /// Creates a new `SegmentWriter` for a segment that will be remapped during finalization.
+    pub fn for_segment_with_doc_id_mapping(
+        memory_budget_in_bytes: usize,
+        segment: Segment,
+    ) -> crate::Result<Self> {
+        Self::for_segment_inner(memory_budget_in_bytes, segment, |segment| {
+            SegmentSerializer::for_segment_with_doc_id_mapping(segment)
+        })
+    }
+
+    fn for_segment_inner(
+        memory_budget_in_bytes: usize,
+        segment: Segment,
+        segment_serializer: impl Fn(Segment) -> crate::Result<SegmentSerializer>,
+    ) -> crate::Result<Self> {
         let schema = segment.schema();
         let tokenizer_manager = segment.index().tokenizers().clone();
         let tokenizer_manager_fast_field = segment.index().fast_field_tokenizer().clone();
-        let table_size = compute_initial_table_size(memory_budget_in_bytes)?;
-        let segment_serializer = SegmentSerializer::for_segment(segment, false)?;
+        let table_size: usize = compute_initial_table_size(memory_budget_in_bytes)?;
+        let segment_serializer = segment_serializer(segment)?;
         let per_field_postings_writers = PerFieldPostingsWriter::for_schema(&schema);
         let per_field_text_analyzers = schema
             .fields()
@@ -157,6 +177,14 @@ impl SegmentWriter {
     ///
     /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Vec<u64>> {
+        // Ensure the segment writer was created in remap mode so the docstore can be reordered.
+        if self.segment_serializer.store_writer.compressor() != Compressor::None {
+            return Err(TantivyError::InvalidArgument(
+                "SegmentWriter was not created by for_segment_with_doc_id_mapping function"
+                    .to_string(),
+            ));
+        }
+
         // Check that the mapping eventually covers all documents in the segment.
         if mapping.len() != self.max_doc as usize {
             return Err(TantivyError::InvalidArgument(format!(
@@ -518,6 +546,7 @@ mod tests {
     use crate::collector::{Count, TopDocs};
     use crate::directory::RamDirectory;
     use crate::fastfield::FastValue;
+    use crate::indexer::doc_id_mapping::DocIdMapping;
     use crate::postings::{Postings, TermInfo};
     use crate::query::{PhraseQuery, QueryParser};
     use crate::schema::{
@@ -530,7 +559,7 @@ mod tests {
     use crate::tokenizer::{PreTokenizedString, Token};
     use crate::{
         DateTime, Directory, DocAddress, DocSet, Index, IndexWriter, SegmentReader,
-        TantivyDocument, Term, TERMINATED,
+        TantivyDocument, TantivyError, Term, TERMINATED,
     };
 
     #[test]
@@ -1168,5 +1197,119 @@ mod tests {
             error.to_string(),
             "Schema error: 'Error getting tokenizer for field: title'"
         );
+    }
+
+    /// Builds a `SegmentWriter` with a fast `u64` field and a text field that only some
+    /// documents populate, so the text field is missing fieldnorms on some docs.
+    ///
+    /// The `texts` slice provides, for each document, an optional text value. The order
+    /// number is always recorded in the `order` fast field so callers can recover the
+    /// original document via that value.
+    fn build_segment_writer_with_doc_id_mapping(
+        texts: &[Option<&str>],
+    ) -> (Index, crate::Segment, super::SegmentWriter) {
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_u64_field("order", FAST | STORED);
+        schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let segment = index.new_segment();
+        let order = index.schema().get_field("order").unwrap();
+        let text = index.schema().get_field("text").unwrap();
+        let mut segment_writer =
+            super::SegmentWriter::for_segment_with_doc_id_mapping(15_000_000, segment.clone())
+                .unwrap();
+        for (opstamp, text_opt) in texts.iter().enumerate() {
+            let mut doc = TantivyDocument::default();
+            doc.add_u64(order, opstamp as u64);
+            if let Some(text_value) = text_opt {
+                doc.add_text(text, *text_value);
+            }
+            segment_writer
+                .add_document(crate::indexer::AddOperation {
+                    opstamp: opstamp as u64,
+                    document: doc,
+                })
+                .unwrap();
+        }
+        (index, segment, segment_writer)
+    }
+
+    #[test]
+    fn test_finalize_with_doc_id_mapping_rejects_wrong_length() {
+        let (_index, _segment, segment_writer) =
+            build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b"), Some("c")]);
+        // Mapping only covers 2 of the 3 documents.
+        let mapping = DocIdMapping::from_new_id_to_old_id(vec![1, 0]);
+        let err = segment_writer
+            .finalize_with_doc_id_mapping(&mapping)
+            .unwrap_err();
+        assert!(
+            matches!(err, TantivyError::InvalidArgument(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_finalize_with_doc_id_mapping_rejects_out_of_range() {
+        let (_index, _segment, segment_writer) =
+            build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b")]);
+        // Doc id 5 does not exist in this segment.
+        let mapping = DocIdMapping::from_new_id_to_old_id(vec![5, 0]);
+        let err = segment_writer
+            .finalize_with_doc_id_mapping(&mapping)
+            .unwrap_err();
+        assert!(
+            matches!(err, TantivyError::InvalidArgument(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_finalize_with_doc_id_mapping_rejects_duplicates() {
+        let (_index, _segment, segment_writer) =
+            build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b"), Some("c")]);
+        // Old doc id 0 appears twice while doc id 2 is missing. The length still matches
+        // `max_doc`, so this must be caught by the permutation check.
+        let mapping = DocIdMapping::from_new_id_to_old_id(vec![0, 1, 0]);
+        let err = segment_writer
+            .finalize_with_doc_id_mapping(&mapping)
+            .unwrap_err();
+        assert!(
+            matches!(err, TantivyError::InvalidArgument(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_finalize_with_doc_id_mapping_remaps_missing_fieldnorms() -> crate::Result<()> {
+        // doc 0: "alpha beta"  (2 tokens)
+        // doc 1: <no text>     (missing fieldnorm -> 0)
+        // doc 2: "gamma"       (1 token)
+        // doc 3: <no text>     (missing fieldnorm -> 0)
+        let (index, segment, segment_writer) = build_segment_writer_with_doc_id_mapping(&[
+            Some("alpha beta"),
+            None,
+            Some("gamma"),
+            None,
+        ]);
+        let max_doc = segment_writer.max_doc();
+
+        // Reverse the documents. New doc id i maps to old doc id (3 - i).
+        let mapping = DocIdMapping::from_new_id_to_old_id(vec![3, 2, 1, 0]);
+        segment_writer.finalize_with_doc_id_mapping(&mapping)?;
+
+        let segment = segment.with_max_doc(max_doc);
+        let segment_reader = SegmentReader::open(&segment)?;
+        let text = index.schema().get_field("text").unwrap();
+        let fieldnorm_reader = segment_reader.get_fieldnorms_reader(text)?;
+
+        // After remapping, fieldnorms follow the reversed order:
+        // new 0 <- old 3 (0), new 1 <- old 2 (1), new 2 <- old 1 (0), new 3 <- old 0 (2)
+        assert_eq!(fieldnorm_reader.fieldnorm(0), 0);
+        assert_eq!(fieldnorm_reader.fieldnorm(1), 1);
+        assert_eq!(fieldnorm_reader.fieldnorm(2), 0);
+        assert_eq!(fieldnorm_reader.fieldnorm(3), 2);
+        Ok(())
     }
 }

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -17,7 +17,7 @@ use crate::postings::{
 };
 use crate::schema::document::{Document, Value};
 use crate::schema::{FieldEntry, FieldType, Schema, DATE_TIME_PRECISION_INDEXED};
-use crate::store::{Compressor, StoreReader, StoreWriter};
+use crate::store::{StoreReader, StoreWriter};
 use crate::tokenizer::{FacetTokenizer, PreTokenizedStream, TextAnalyzer, Tokenizer};
 use crate::{DocId, Opstamp, TantivyError};
 
@@ -87,31 +87,11 @@ impl SegmentWriter {
     /// - segment: The segment being written
     /// - schema
     pub fn for_segment(memory_budget_in_bytes: usize, segment: Segment) -> crate::Result<Self> {
-        Self::for_segment_inner(memory_budget_in_bytes, segment, |segment| {
-            SegmentSerializer::for_segment(segment, false)
-        })
-    }
-
-    /// Creates a new `SegmentWriter` for a segment that will be remapped during finalization.
-    pub fn for_segment_with_doc_id_mapping(
-        memory_budget_in_bytes: usize,
-        segment: Segment,
-    ) -> crate::Result<Self> {
-        Self::for_segment_inner(memory_budget_in_bytes, segment, |segment| {
-            SegmentSerializer::for_segment_with_doc_id_mapping(segment)
-        })
-    }
-
-    fn for_segment_inner(
-        memory_budget_in_bytes: usize,
-        segment: Segment,
-        segment_serializer: impl Fn(Segment) -> crate::Result<SegmentSerializer>,
-    ) -> crate::Result<Self> {
         let schema = segment.schema();
         let tokenizer_manager = segment.index().tokenizers().clone();
         let tokenizer_manager_fast_field = segment.index().fast_field_tokenizer().clone();
-        let table_size: usize = compute_initial_table_size(memory_budget_in_bytes)?;
-        let segment_serializer = segment_serializer(segment)?;
+        let table_size = compute_initial_table_size(memory_budget_in_bytes)?;
+        let segment_serializer = SegmentSerializer::for_segment(segment, false)?;
         let per_field_postings_writers = PerFieldPostingsWriter::for_schema(&schema);
         let per_field_text_analyzers = schema
             .fields()
@@ -178,10 +158,15 @@ impl SegmentWriter {
     /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Vec<u64>> {
         // Ensure the segment writer was created in remap mode so the docstore can be reordered.
-        if self.segment_serializer.store_writer.compressor() != Compressor::None {
+        if !self
+            .segment_serializer
+            .segment()
+            .index()
+            .settings()
+            .manual_doc_id_mapping
+        {
             return Err(TantivyError::InvalidArgument(
-                "SegmentWriter was not created by for_segment_with_doc_id_mapping function"
-                    .to_string(),
+                "IndexSettings::manual_doc_id_mapping must be set to true".to_string(),
             ));
         }
 
@@ -1212,13 +1197,13 @@ mod tests {
         schema_builder.add_u64_field("order", FAST | STORED);
         schema_builder.add_text_field("text", TEXT);
         let schema = schema_builder.build();
-        let index = Index::create_in_ram(schema);
+        let mut index = Index::create_in_ram(schema);
+        index.settings_mut().manual_doc_id_mapping = true;
         let segment = index.new_segment();
         let order = index.schema().get_field("order").unwrap();
         let text = index.schema().get_field("text").unwrap();
         let mut segment_writer =
-            super::SegmentWriter::for_segment_with_doc_id_mapping(15_000_000, segment.clone())
-                .unwrap();
+            super::SegmentWriter::for_segment(15_000_000, segment.clone()).unwrap();
         for (opstamp, text_opt) in texts.iter().enumerate() {
             let mut doc = TantivyDocument::default();
             doc.add_u64(order, opstamp as u64);

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -167,16 +167,17 @@ impl SegmentWriter {
     ///
     /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Vec<u64>> {
+        let settings = self.segment_serializer.segment().index().settings();
         // Ensure the segment writer was created in remap mode so the docstore can be reordered.
-        if !self
-            .segment_serializer
-            .segment()
-            .index()
-            .settings()
-            .manual_doc_id_mapping
-        {
+        if !settings.manual_doc_id_mapping {
             return Err(TantivyError::InvalidArgument(
                 "IndexSettings::manual_doc_id_mapping must be set to true".to_string(),
+            ));
+        }
+        if settings.sort_by_field.is_some() {
+            return Err(TantivyError::InvalidArgument(
+                "IndexSettings::manual_doc_id_mapping cannot be combined with sort_by_field"
+                    .to_string(),
             ));
         }
 
@@ -1225,6 +1226,41 @@ mod tests {
         let (_index, _segment, segment_writer) =
             build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b"), Some("c")]);
         // Mapping only covers 2 of the 3 documents.
+        let mapping = DocIdMapping::new_permutation(vec![1, 0]).unwrap();
+        let err = segment_writer
+            .finalize_with_doc_id_mapping(&mapping)
+            .unwrap_err();
+        assert!(
+            matches!(err, TantivyError::InvalidArgument(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_finalize_with_doc_id_mapping_rejects_sort_by_field() {
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_u64_field("order", FAST | STORED);
+        let schema = schema_builder.build();
+        let mut index = Index::create_in_ram(schema);
+        index.settings_mut().manual_doc_id_mapping = true;
+        index.settings_mut().sort_by_field = Some(crate::IndexSortByField {
+            field: "order".to_string(),
+            order: crate::Order::Asc,
+        });
+        let segment = index.new_segment();
+        let order = index.schema().get_field("order").unwrap();
+        let mut segment_writer =
+            super::SegmentWriter::for_segment(15_000_000, segment.clone()).unwrap();
+        for opstamp in 0..2 {
+            let mut doc = TantivyDocument::default();
+            doc.add_u64(order, opstamp as u64);
+            segment_writer
+                .add_document(crate::indexer::AddOperation {
+                    opstamp: opstamp as u64,
+                    document: doc,
+                })
+                .unwrap();
+        }
         let mapping = DocIdMapping::new_permutation(vec![1, 0]).unwrap();
         let err = segment_writer
             .finalize_with_doc_id_mapping(&mapping)

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -1,5 +1,5 @@
 use columnar::MonotonicallyMappableToU64;
-use common::{BitSet, JsonPathWriter};
+use common::JsonPathWriter;
 use itertools::Itertools;
 use tokenizer_api::BoxTokenStream;
 
@@ -177,16 +177,6 @@ impl SegmentWriter {
                 self.max_doc,
                 mapping.len()
             )));
-        }
-
-        // Check that the mapping is a permutation of the segment doc ids.
-        let mut seen_doc_ids = BitSet::with_max_value(self.max_doc);
-        for old_doc_id in mapping.iter_old_doc_ids() {
-            if old_doc_id >= self.max_doc || !seen_doc_ids.insert(old_doc_id) {
-                return Err(TantivyError::InvalidArgument(
-                    "Mapping must be a permutation of the segment doc ids".to_string(),
-                ));
-            }
         }
 
         self.finalize_inner(Some(mapping))

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -147,7 +147,7 @@ impl SegmentWriter {
             .manual_doc_id_mapping
         {
             return Err(TantivyError::InvalidArgument(
-                "IndexSettings::manual_doc_id_mapping must be set to false".to_string(),
+                "IndexSettings::manual_doc_id_mapping must be set to false. With manual_doc_id_mapping, you need to call finalize_with_doc_id_mapping".to_string(),
             ));
         }
 

--- a/src/indexer/segment_writer.rs
+++ b/src/indexer/segment_writer.rs
@@ -150,10 +150,7 @@ impl SegmentWriter {
         self.finalize_inner(mapping.as_ref())
     }
 
-    /// Lay on disk the current content of the `SegmentWriter` using the given doc id mapping.
-    ///
-    /// The mapping must cover all documents in this segment and maps the segment's original doc ids
-    /// to the doc ids that should be written on disk.
+    /// Lay on disk the current content of the `SegmentWriter` using the provided doc id mapping.
     ///
     /// Finalize consumes the `SegmentWriter`, so that it cannot be used afterwards.
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Vec<u64>> {
@@ -1215,38 +1212,7 @@ mod tests {
         let (_index, _segment, segment_writer) =
             build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b"), Some("c")]);
         // Mapping only covers 2 of the 3 documents.
-        let mapping = DocIdMapping::from_new_id_to_old_id(vec![1, 0]);
-        let err = segment_writer
-            .finalize_with_doc_id_mapping(&mapping)
-            .unwrap_err();
-        assert!(
-            matches!(err, TantivyError::InvalidArgument(_)),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[test]
-    fn test_finalize_with_doc_id_mapping_rejects_out_of_range() {
-        let (_index, _segment, segment_writer) =
-            build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b")]);
-        // Doc id 5 does not exist in this segment.
-        let mapping = DocIdMapping::from_new_id_to_old_id(vec![5, 0]);
-        let err = segment_writer
-            .finalize_with_doc_id_mapping(&mapping)
-            .unwrap_err();
-        assert!(
-            matches!(err, TantivyError::InvalidArgument(_)),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[test]
-    fn test_finalize_with_doc_id_mapping_rejects_duplicates() {
-        let (_index, _segment, segment_writer) =
-            build_segment_writer_with_doc_id_mapping(&[Some("a"), Some("b"), Some("c")]);
-        // Old doc id 0 appears twice while doc id 2 is missing. The length still matches
-        // `max_doc`, so this must be caught by the permutation check.
-        let mapping = DocIdMapping::from_new_id_to_old_id(vec![0, 1, 0]);
+        let mapping = DocIdMapping::new_permutation(vec![1, 0]).unwrap();
         let err = segment_writer
             .finalize_with_doc_id_mapping(&mapping)
             .unwrap_err();
@@ -1271,7 +1237,7 @@ mod tests {
         let max_doc = segment_writer.max_doc();
 
         // Reverse the documents. New doc id i maps to old doc id (3 - i).
-        let mapping = DocIdMapping::from_new_id_to_old_id(vec![3, 2, 1, 0]);
+        let mapping = DocIdMapping::new_permutation(vec![3, 2, 1, 0])?;
         segment_writer.finalize_with_doc_id_mapping(&mapping)?;
 
         let segment = segment.with_max_doc(max_doc);

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -4,7 +4,7 @@ use crate::indexer::operation::AddOperation;
 use crate::indexer::segment_updater::save_metas;
 use crate::indexer::{DocIdMapping, SegmentWriter};
 use crate::schema::document::Document;
-use crate::{Directory, Index, IndexMeta, Opstamp, Segment, TantivyDocument};
+use crate::{Directory, Index, IndexMeta, IndexSettings, Opstamp, Segment, TantivyDocument};
 
 #[doc(hidden)]
 pub struct SingleSegmentIndexWriter<D: Document = TantivyDocument> {
@@ -45,7 +45,9 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         } = self;
         let max_doc = segment_writer.max_doc();
         segment_writer.finalize()?;
-        Self::finalize_inner(segment, max_doc)
+        let remapping_required = segment.index().settings().sort_by_field.is_some();
+        let index_settings = segment.index().settings().clone();
+        Self::finalize_inner(segment, max_doc, remapping_required, index_settings)
     }
 
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Index> {
@@ -56,14 +58,26 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         } = self;
         let max_doc = segment_writer.max_doc();
         segment_writer.finalize_with_doc_id_mapping(mapping)?;
-        Self::finalize_inner(segment, max_doc)
+        let mut index_settings = segment.index().settings().clone();
+        index_settings.manual_doc_id_mapping = false;
+        let mut index = Self::finalize_inner(segment, max_doc, true, index_settings)?;
+        index.settings_mut().manual_doc_id_mapping = false;
+        Ok(index)
     }
 
-    fn finalize_inner(segment: Segment, max_doc: u32) -> crate::Result<Index> {
+    fn finalize_inner(
+        segment: Segment,
+        max_doc: u32,
+        remapping_required: bool,
+        index_settings: IndexSettings,
+    ) -> crate::Result<Index> {
         let segment: Segment = segment.with_max_doc(max_doc);
+        if remapping_required {
+            segment.meta().untrack_temp_docstore();
+        }
         let index = segment.index();
         let index_meta = IndexMeta {
-            index_settings: index.settings().clone(),
+            index_settings,
             segments: vec![segment.meta().clone()],
             schema: index.schema(),
             opstamp: 0,

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::indexer::operation::AddOperation;
 use crate::indexer::segment_updater::save_metas;
-use crate::indexer::SegmentWriter;
+use crate::indexer::{DocIdMapping, SegmentWriter};
 use crate::schema::document::Document;
 use crate::{Directory, Index, IndexMeta, Opstamp, Segment, TantivyDocument};
 
@@ -38,9 +38,29 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
     }
 
     pub fn finalize(self) -> crate::Result<Index> {
-        let max_doc = self.segment_writer.max_doc();
-        self.segment_writer.finalize()?;
-        let segment: Segment = self.segment.with_max_doc(max_doc);
+        let Self {
+            segment,
+            segment_writer,
+            ..
+        } = self;
+        let max_doc = segment_writer.max_doc();
+        segment_writer.finalize()?;
+        Self::finalize_inner(segment, max_doc)
+    }
+
+    pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Index> {
+        let Self {
+            segment,
+            segment_writer,
+            ..
+        } = self;
+        let max_doc = segment_writer.max_doc();
+        segment_writer.finalize_with_doc_id_mapping(mapping)?;
+        Self::finalize_inner(segment, max_doc)
+    }
+
+    fn finalize_inner(segment: Segment, max_doc: u32) -> crate::Result<Index> {
+        let segment: Segment = segment.with_max_doc(max_doc);
         let index = segment.index();
         let index_meta = IndexMeta {
             index_settings: index.settings().clone(),
@@ -51,6 +71,6 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         };
         save_metas(&index_meta, index.directory())?;
         index.directory().sync_directory()?;
-        Ok(segment.index().clone())
+        Ok(index.clone())
     }
 }

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -72,19 +72,31 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         index_settings: IndexSettings,
     ) -> crate::Result<Index> {
         let segment: Segment = segment.with_max_doc(max_doc);
+        let segment_meta = segment.meta();
+        let mut index = segment.index().clone();
+
         if remapping_required {
-            segment.meta().untrack_temp_docstore();
+            // Untrack the temp docstore file from the segment metadata.
+            segment_meta.untrack_temp_docstore();
         }
-        let index = segment.index();
+
         let index_meta = IndexMeta {
             index_settings,
-            segments: vec![segment.meta().clone()],
+            segments: vec![segment_meta.clone()],
             schema: index.schema(),
             opstamp: 0,
             payload: None,
         };
         save_metas(&index_meta, index.directory())?;
         index.directory().sync_directory()?;
-        Ok(index.clone())
+
+        if remapping_required {
+            // Run the garbage collector to remove the temp docstore file from the directory.
+            let mut living_files = segment_meta.list_files();
+            living_files.insert(crate::core::META_FILEPATH.to_path_buf());
+            index.directory_mut().garbage_collect(|| living_files)?;
+        }
+
+        Ok(index)
     }
 }

--- a/src/indexer/single_segment_index_writer.rs
+++ b/src/indexer/single_segment_index_writer.rs
@@ -4,7 +4,7 @@ use crate::indexer::operation::AddOperation;
 use crate::indexer::segment_updater::save_metas;
 use crate::indexer::{DocIdMapping, SegmentWriter};
 use crate::schema::document::Document;
-use crate::{Directory, Index, IndexMeta, IndexSettings, Opstamp, Segment, TantivyDocument};
+use crate::{Directory, Index, IndexMeta, Opstamp, Segment, TantivyDocument};
 
 #[doc(hidden)]
 pub struct SingleSegmentIndexWriter<D: Document = TantivyDocument> {
@@ -45,9 +45,8 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         } = self;
         let max_doc = segment_writer.max_doc();
         segment_writer.finalize()?;
-        let remapping_required = segment.index().settings().sort_by_field.is_some();
-        let index_settings = segment.index().settings().clone();
-        Self::finalize_inner(segment, max_doc, remapping_required, index_settings)
+        let did_remapping = segment.index().settings().sort_by_field.is_some();
+        Self::finalize_inner(segment, max_doc, did_remapping, false)
     }
 
     pub fn finalize_with_doc_id_mapping(self, mapping: &DocIdMapping) -> crate::Result<Index> {
@@ -58,30 +57,29 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         } = self;
         let max_doc = segment_writer.max_doc();
         segment_writer.finalize_with_doc_id_mapping(mapping)?;
-        let mut index_settings = segment.index().settings().clone();
-        index_settings.manual_doc_id_mapping = false;
-        let mut index = Self::finalize_inner(segment, max_doc, true, index_settings)?;
-        index.settings_mut().manual_doc_id_mapping = false;
-        Ok(index)
+        Self::finalize_inner(segment, max_doc, true, true)
     }
 
     fn finalize_inner(
         segment: Segment,
         max_doc: u32,
-        remapping_required: bool,
-        index_settings: IndexSettings,
+        did_remapping: bool,
+        clear_manual_doc_id_mapping: bool,
     ) -> crate::Result<Index> {
         let segment: Segment = segment.with_max_doc(max_doc);
         let segment_meta = segment.meta();
         let mut index = segment.index().clone();
+        if clear_manual_doc_id_mapping {
+            index.settings_mut().manual_doc_id_mapping = false;
+        }
 
-        if remapping_required {
+        if did_remapping {
             // Untrack the temp docstore file from the segment metadata.
             segment_meta.untrack_temp_docstore();
         }
 
         let index_meta = IndexMeta {
-            index_settings,
+            index_settings: index.settings().clone(),
             segments: vec![segment_meta.clone()],
             schema: index.schema(),
             opstamp: 0,
@@ -90,7 +88,7 @@ impl<D: Document> SingleSegmentIndexWriter<D> {
         save_metas(&index_meta, index.directory())?;
         index.directory().sync_directory()?;
 
-        if remapping_required {
+        if did_remapping {
             // Run the garbage collector to remove the temp docstore file from the directory.
             let mut living_files = segment_meta.list_files();
             living_files.insert(crate::core::META_FILEPATH.to_path_buf());


### PR DESCRIPTION
## What

Adds manual doc id mapping finalization for segment writers. Callers can provide a checked `DocIdMapping` at finalize time, and Tantivy serializes postings, fast fields, fieldnorms, docstore, and opstamps in the mapped doc id order.

## Why

Index sorting already remaps doc ids internally from `sort_by_field`. This PR exposes the same finalization machinery for callers that compute their own doc id order, while keeping the temporary docstore path opt-in.

## Changes

- Expose `DocIdMapping` as public type.
- Add `DocIdMapping::new_permutation(...)` as the public constructor for caller-provided mappings.
- Add `SegmentWriter::finalize_with_doc_id_mapping(&DocIdMapping)`.
- Add `SingleSegmentIndexWriter::finalize_with_doc_id_mapping(&DocIdMapping)`.
- Add hidden, non-persisted `IndexSettings::manual_doc_id_mapping` (`#[serde(skip)]`) to opt into the temporary docstore path needed by manual mapping.
- Extend `SegmentSerializer::for_segment(...)` so it writes docs to `TempStore` when either `sort_by_field` is configured or `manual_doc_id_mapping` is enabled.
- Make `common::BitSet::insert()` return whether the set changed, and use that for duplicate detection in mapping validation.

## Design notes

`manual_doc_id_mapping` is intentionally a hidden, non-persisted `IndexSettings` flag. It is only used at segment construction time to select the temporary docstore path required by manual remapping, and is skipped from `meta.json`.

An alternative would be to avoid putting this runtime-only option in `IndexSettings` and instead add separate `SegmentWriter::for_segment` / `SegmentSerializer::for_segment` variants that explicitly request the temp docstore path. That would make the dependency more local, but it also requires threading a new construction mode through the segment writer/serializer setup and splitting the existing single constructor path. Given that index sorting already uses the same remapping machinery, keeping one constructor path and gating the temp docstore behavior through a hidden runtime flag is the smaller change.

To keep this from becoming a durable index invariant:

- `manual_doc_id_mapping` is `#[serde(skip)]`.
- It cannot be combined with `sort_by_field`.
- It is cleared from the returned `Index` after `finalize_with_doc_id_mapping`.

## Notes

- `manual_doc_id_mapping` is a runtime construction flag only; it is not written to `meta.json`.

## Test plan

- [x] `cargo test`