### PR TITLE
10% faster intersections: Use k-ary in block search

### DIFF
--- a/src/postings/block_search.rs
+++ b/src/postings/block_search.rs
@@ -1,36 +1,68 @@
 use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
 
-/// Search the first index containing an element greater or equal to
-/// the target.
+/// Returns the index of the first element in `arr` that is greater than or
+/// equal to `target`.
 ///
-/// The results should be equivalent to
-/// ```compile_fail
-/// block[..]
-//       .iter()
-//       .take_while(|&&val| val < target)
-//       .count()
+/// This is equivalent to:
+///
+/// ```ignore
+/// arr.iter().take_while(|&&val| val < target).count()
 /// ```
-/// 
-/// the `start` argument is just used to hint that the response is
-/// greater than beyond `start`. The implementation may or may not use
-/// it for optimization.
 ///
-/// # Assumption
+/// # Assumptions
 ///
-/// - The block is sorted. Some elements may appear several times. This is the case at the
-///   end of the last block for instance.
-/// - The target is assumed smaller or equal to the last element of the block.
-pub fn branchless_binary_search(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: u32) -> usize {
-    let mut start = 0;
-    let mut len = arr.len();
-    for _ in 0..7 {
-        len /= 2;
-        let pivot = unsafe { *arr.get_unchecked(start + len - 1) };
-        if pivot < target {
-            start += len;
+/// - `arr` is sorted in nondecreasing order. Values may be repeated; the last block is often padded
+///   with duplicates of its final value.
+/// - `target` is less than or equal to the last element in `arr`, so the result is always a valid
+///   index into the block.
+///
+/// # `K`
+///
+/// `K` is the branching factor. Each reduction probes `K - 1` segment-end
+/// pivots, keeps the matching segment, and finally linearly scans the remaining
+/// range. `K` must be one of `2`, `4`, `8`, `16`, `32`, or `64`.
+///
+/// The core idea vs a traditional binary search is that we can very cheaply scan blocks of
+/// numbers, since they are already in the CPU cache line.
+#[inline(always)]
+pub fn kary_search<const K: usize>(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: u32) -> usize {
+    const {
+        assert!(
+            matches!(K, 2 | 4 | 8 | 16 | 32 | 64),
+            "K must be one of 2, 4, 8, 16, 32, or 64"
+        );
+    };
+
+    let mut base = 0usize;
+    let mut range = COMPRESSION_BLOCK_SIZE;
+
+    loop {
+        let step = range / K;
+        if step == 0 {
+            break;
         }
+        debug_assert_eq!(range % K, 0);
+        // Count how many segment-end pivots are < target (branchless, unrolled).
+        let mut count = 0usize;
+        for i in 1..K {
+            count += (unsafe { *arr.get_unchecked(base + i * step - 1) } < target) as usize;
+        }
+        base += count * step;
+        range = step;
     }
-    start
+
+    // Linear scan over the ≤K remaining elements.
+    let mut count = 0usize;
+    for i in 0..range {
+        count += (unsafe { *arr.get_unchecked(base + i) } < target) as usize;
+    }
+    base + count
+}
+
+/// entry point used by postings; implemented as an 8-ary branchless search.
+#[inline]
+pub fn search_block(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: u32) -> usize {
+    kary_search::<8>(arr, target)
 }
 
 #[cfg(test)]
@@ -39,7 +71,7 @@ mod tests {
 
     use proptest::prelude::*;
 
-    use super::branchless_binary_search;
+    use super::{kary_search, search_block};
     use crate::docset::TERMINATED;
     use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
 
@@ -57,7 +89,7 @@ mod tests {
         assert_eq!(block.len(), COMPRESSION_BLOCK_SIZE);
         let mut output_buffer = [TERMINATED; COMPRESSION_BLOCK_SIZE];
         output_buffer[..block.len()].copy_from_slice(block);
-        assert_eq!(branchless_binary_search(&output_buffer, target), cursor);
+        assert_eq!(search_block(&output_buffer, target), cursor);
     }
 
     fn util_test_search_in_block_all(block: &[u32]) {
@@ -78,6 +110,45 @@ mod tests {
     fn test_search_in_branchless_binary_search() {
         let v: Vec<u32> = (0..COMPRESSION_BLOCK_SIZE).map(|i| i as u32 * 2).collect();
         util_test_search_in_block_all(&v[..]);
+    }
+
+    #[test]
+    fn test_search_in_branchless_binary_search_corner_cases() {
+        let all_same = vec![7u32; COMPRESSION_BLOCK_SIZE];
+        util_test_search_in_block_all(&all_same);
+
+        let repeated_across_pivots: Vec<u32> = (0..COMPRESSION_BLOCK_SIZE)
+            .map(|i| (i / 17) as u32)
+            .collect();
+        util_test_search_in_block_all(&repeated_across_pivots);
+
+        let mut padded_last_block = vec![0u32; COMPRESSION_BLOCK_SIZE];
+        for (i, value) in padded_last_block.iter_mut().enumerate() {
+            *value = if i < COMPRESSION_BLOCK_SIZE / 2 {
+                i as u32
+            } else {
+                TERMINATED
+            };
+        }
+        util_test_search_in_block_all(&padded_last_block);
+    }
+
+    #[test]
+    fn test_kary_search_allowed_branching_factors() {
+        let mut block = [TERMINATED; COMPRESSION_BLOCK_SIZE];
+        for (idx, value) in block.iter_mut().enumerate() {
+            *value = (idx / 3) as u32;
+        }
+
+        for target in [0, 1, 17, block[COMPRESSION_BLOCK_SIZE - 1]] {
+            let expected = search_in_block_trivial_but_slow(&block, target);
+            assert_eq!(kary_search::<2>(&block, target), expected);
+            assert_eq!(kary_search::<4>(&block, target), expected);
+            assert_eq!(kary_search::<8>(&block, target), expected);
+            assert_eq!(kary_search::<16>(&block, target), expected);
+            assert_eq!(kary_search::<32>(&block, target), expected);
+            assert_eq!(kary_search::<64>(&block, target), expected);
+        }
     }
 
     fn monotonous_block() -> impl Strategy<Value = Vec<u32>> {

--- a/src/postings/block_search.rs
+++ b/src/postings/block_search.rs
@@ -20,16 +20,26 @@ use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
 ///
 /// `K` is the branching factor. Each reduction probes `K - 1` segment-end
 /// pivots, keeps the matching segment, and finally linearly scans the remaining
-/// range. `K` must be one of `2`, `4`, `8`, `16`, `32`, or `64`.
+/// range. `K` must be one of `2`, `4`, `8`, `16`, or `32`.
 ///
-/// The core idea vs a traditional binary search is that we can very cheaply scan blocks of
-/// numbers, since they are already in the CPU cache line.
+/// This is the "k-ary search on a sorted array" variant of Schlegel, Gemulla & Lehner,
+/// "k-Ary Search on Modern Processors", DaMoN 2009 (<https://dl.acm.org/doi/10.1145/1565694.1565705>),
+/// specialized to a lower-bound (no equality early-exit) with a linear scan over the final
+/// `< K` elements. We do not use their linearized-tree (`k-ary-lt`) layout, which would require
+/// reordering the block.
+///
+/// The core idea vs a traditional binary search is that we can check multiple numbers in parallel,
+/// which better utilizes the CPU's instruction-level parallelism.
+///
+/// `kary_search::<8>` reduces in three steps: 128 -> 16 -> 2, then a 2-element scan. It could be
+/// done in only two steps (128 -> 16, then scanning all 16 contiguous elements). For that
+/// we need popcount for that to be fast though (TODO).
 #[inline(always)]
 pub fn kary_search<const K: usize>(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: u32) -> usize {
     const {
         assert!(
-            matches!(K, 2 | 4 | 8 | 16 | 32 | 64),
-            "K must be one of 2, 4, 8, 16, 32, or 64"
+            matches!(K, 2 | 4 | 8 | 16 | 32),
+            "K must be one of 2, 4, 8, 16, or 32"
         );
     };
 
@@ -45,7 +55,7 @@ pub fn kary_search<const K: usize>(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: 
         // Count how many segment-end pivots are < target (branchless, unrolled).
         let mut count = 0usize;
         for i in 1..K {
-            count += (unsafe { *arr.get_unchecked(base + i * step - 1) } < target) as usize;
+            count += (arr[base + i * step - 1] < target) as usize;
         }
         base += count * step;
         range = step;
@@ -54,7 +64,7 @@ pub fn kary_search<const K: usize>(arr: &[u32; COMPRESSION_BLOCK_SIZE], target: 
     // Linear scan over the ≤K remaining elements.
     let mut count = 0usize;
     for i in 0..range {
-        count += (unsafe { *arr.get_unchecked(base + i) } < target) as usize;
+        count += (arr[base + i] < target) as usize;
     }
     base + count
 }
@@ -147,7 +157,6 @@ mod tests {
             assert_eq!(kary_search::<8>(&block, target), expected);
             assert_eq!(kary_search::<16>(&block, target), expected);
             assert_eq!(kary_search::<32>(&block, target), expected);
-            assert_eq!(kary_search::<64>(&block, target), expected);
         }
     }
 

--- a/src/postings/compression/mod.rs
+++ b/src/postings/compression/mod.rs
@@ -158,7 +158,7 @@ impl BlockDecoder {
     /// Uses the padded buffer to enable branchless search.
     #[inline]
     pub(crate) fn seek_within_block(&self, target: u32) -> usize {
-        crate::postings::branchless_binary_search(&self.output, target)
+        crate::postings::search_block(&self.output, target)
     }
 
     #[inline]

--- a/src/postings/mod.rs
+++ b/src/postings/mod.rs
@@ -2,7 +2,7 @@
 
 mod block_search;
 
-pub(crate) use self::block_search::branchless_binary_search;
+pub(crate) use self::block_search::search_block;
 
 mod block_segment_postings;
 pub(crate) mod compression;


### PR DESCRIPTION
Replace `branchless_binary_search` with k-ary search.

Below is how 8-ary search works. The 7 probes can be better parallelized inside the CPU than a binary search.

The second step is a bit silly, a full scan over 16 elements should be better, but it would require compiling with popcnt or the resulting assembly is bad.
https://godbolt.org/z/5vfja3eed
  
```mermaid
  flowchart TB
      subgraph S1["Step 1 · window [0,128) · step 16 · probe last idx of each segment"]
          direction LR
          a0["seg0<br/>0–15<br/>probe@15<br/>&lt; target ✓"]:::lt
          a1["seg1<br/>16–31<br/>probe@31<br/>&lt; target ✓"]:::lt
          a2["seg2<br/>32–47<br/>probe@47<br/>&lt; target ✓"]:::lt
          a3["seg3<br/>48–63<br/>probe@63<br/>≥ target"]:::chosen
          a4["seg4<br/>64–79<br/>probe@79<br/>≥ target"]:::ge
          a5["seg5<br/>80–95<br/>probe@95<br/>≥ target"]:::ge
          a6["seg6<br/>96–111<br/>probe@111<br/>≥ target"]:::ge
          a7["seg7<br/>112–127<br/>no probe"]:::none
          a0 --- a1 --- a2 --- a3 --- a4 --- a5 --- a6 --- a7
      end

      S1 -->|"3 probes &lt; target → base = 3×16 = 48"| S2

      subgraph S2["Step 2 · window [48,64) · step 2 · probe last idx of each segment"]
          direction LR
          b0["48–49<br/>probe@49<br/>&lt; target ✓"]:::lt
          b1["50–51<br/>probe@51<br/>&lt; target ✓"]:::lt
          b2["52–53<br/>probe@53<br/>&lt; target ✓"]:::lt
          b3["54–55<br/>probe@55<br/>&lt; target ✓"]:::lt
          b4["56–57<br/>probe@57<br/>≥ target"]:::chosen
          b5["58–59<br/>probe@59<br/>≥ target"]:::ge
          b6["60–61<br/>probe@61<br/>≥ target"]:::ge
          b7["62–63<br/>no probe"]:::none
          b0 --- b1 --- b2 --- b3 --- b4 --- b5 --- b6 --- b7
      end

      S2 -->|"4 probes &lt; target → base = 48 + 4×2 = 56"| S3

      subgraph S3["Step 3 · window [56,58) · step = 2/8 = 0 → linear scan"]
          direction LR
          c0["idx 56<br/>scan"]:::scan
          c1["idx 57<br/>scan"]:::scan
          c0 --- c1
      end

      S3 -->|"return base + (#elems &lt; target)"| OUT["result index"]:::done

      classDef lt fill:#fce8e6,stroke:#d93025,color:#000;
      classDef ge fill:#e8f0fe,stroke:#4285f4,color:#000;
      classDef chosen fill:#e6f4ea,stroke:#34a853,stroke-width:3px,color:#000;
      classDef none fill:#f1f3f4,stroke:#9aa0a6,color:#666
      classDef scan fill:#fef7e0,stroke:#f9ab00,color:#000;
      classDef done fill:#e6f4ea,stroke:#34a853,color:#000;
  ```



Run on AMD 9800X3D (similar numbers on Mac M4)

<img width="1437" height="1201" alt="faster_intersect" src="https://github.com/user-attachments/assets/f8140813-4232-4581-a272-18a1799520f7" />
