### PR TITLE
try to use select-nth instead of full sort in segment level agg top-k selection

### DIFF
--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -56,6 +56,7 @@ fn bench_agg(mut group: InputGroup<Index>) {
     register!(group, percentiles_f64);
     register!(group, terms_7);
     register!(group, terms_all_unique);
+    register!(group, terms_all_unique_order_by_key);
     register!(group, terms_150_000);
     register!(group, terms_many_top_1000);
     register!(group, terms_many_order_by_term);
@@ -294,6 +295,13 @@ fn terms_7(index: &Index) {
 fn terms_all_unique(index: &Index) {
     let agg_req = json!({
         "my_texts": { "terms": { "field": "text_all_unique_terms" } },
+    });
+    execute_agg(index, agg_req);
+}
+
+fn terms_all_unique_order_by_key(index: &Index) {
+    let agg_req = json!({
+        "my_texts": { "terms": { "field": "text_all_unique_terms", "order": { "_key": "asc" } } },
     });
     execute_agg(index, agg_req);
 }

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1072,17 +1072,17 @@ where
                     let num_buckets = entries.len() as u64;
                     let num_docs = entries.iter().map(|(_, b)| b.count as u64).sum();
                     total_doc_count = Some(num_docs);
-                    let near_unique =
+                    let many_buckets_with_same_count =
                         num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
                     if term_req.req.order.order == Order::Desc {
-                        if near_unique {
+                        if many_buckets_with_same_count {
                             entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.1.count));
                         } else {
                             entries.select_nth_unstable_by_key(segment_size, |b| {
                                 std::cmp::Reverse(b.1.count)
                             });
                         }
-                    } else if near_unique {
+                    } else if many_buckets_with_same_count {
                         entries.sort_unstable_by_key(|b| b.1.count);
                     } else {
                         entries.select_nth_unstable_by_key(segment_size, |b| b.1.count);

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -981,19 +981,27 @@ where
     ) -> crate::Result<IntermediateBucketResult> {
         let mut entries: Vec<(u64, Bucket)> = term_buckets.into_vec();
 
+        let segment_size = term_req.req.segment_size as usize;
+
+        // select_nth_unstable_by_key(segment_size, ...) places the (k+1)-th element at
+        // entries[segment_size] and guarantees entries[0..segment_size] are the top-k,
+        // unordered. We need this to properly compute term_doc_count_before_cutoff.
         match &term_req.req.order.target {
             OrderTarget::Key => {
                 // We rely on the fact, that term ordinals match the order of the strings
                 // TODO: We could have a special collector, that keeps only TOP n results at any
                 // time.
-                if term_req.req.order.order == Order::Desc {
-                    entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.0));
-                } else {
-                    entries.sort_unstable_by_key(|bucket| bucket.0);
+                if entries.len() > segment_size {
+                    if term_req.req.order.order == Order::Desc {
+                        entries
+                            .select_nth_unstable_by_key(segment_size, |b| std::cmp::Reverse(b.0));
+                    } else {
+                        entries.select_nth_unstable_by_key(segment_size, |b| b.0);
+                    }
                 }
             }
             OrderTarget::SubAggregation(sub_agg_path) => {
-                // Peek segment-level metric values, sort, then fall through to
+                // Peek segment-level metric values, select top-k, then fall through to
                 // `cut_off_buckets`. Like Elasticsearch, we always cut off when ordering
                 // by a sub-agg: top-K results are approximate and may differ from the
                 // global ordering, especially for non-monotonic metrics like avg/min.
@@ -1003,7 +1011,7 @@ where
                     ))
                 })?;
                 let (agg_name, agg_prop) = get_agg_name_and_property(sub_agg_path);
-                // Fetch values up-front; otherwise sort would re-compute per comparison
+                // Fetch values up-front; otherwise sort would re-compute per call
                 let mut keyed: Vec<(f64, (u64, Bucket))> = entries
                     .into_iter()
                     .map(|bucket| {
@@ -1013,28 +1021,34 @@ where
                         (metric_value, bucket)
                     })
                     .collect();
-                if term_req.req.order.order == Order::Desc {
-                    keyed.sort_unstable_by(|a, b| {
-                        b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
-                    });
-                } else {
-                    keyed.sort_unstable_by(|a, b| {
-                        a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal)
-                    });
+                if keyed.len() > segment_size {
+                    if term_req.req.order.order == Order::Desc {
+                        keyed.select_nth_unstable_by(segment_size, |a, b| {
+                            b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
+                        });
+                    } else {
+                        keyed.select_nth_unstable_by(segment_size, |a, b| {
+                            a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal)
+                        });
+                    }
                 }
                 entries = keyed.into_iter().map(|(_, e)| e).collect();
             }
             OrderTarget::Count => {
-                if term_req.req.order.order == Order::Desc {
-                    entries.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.1.count));
-                } else {
-                    entries.sort_unstable_by_key(|bucket| bucket.1.count);
+                if entries.len() > segment_size {
+                    if term_req.req.order.order == Order::Desc {
+                        entries.select_nth_unstable_by_key(segment_size, |b| {
+                            std::cmp::Reverse(b.1.count)
+                        });
+                    } else {
+                        entries.select_nth_unstable_by_key(segment_size, |b| b.1.count);
+                    }
                 }
             }
         }
 
         let (term_doc_count_before_cutoff, sum_other_doc_count) =
-            cut_off_buckets(&mut entries, term_req.req.segment_size as usize);
+            cut_off_buckets(&mut entries, segment_size);
 
         let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> = Default::default();
         dict.reserve(entries.len());

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -342,7 +342,7 @@ pub const MAX_NUM_TERMS_FOR_VEC: u64 = 100;
 /// Average docs-per-bucket below which term counts cluster too tightly (mostly 1s and 2s) for
 /// `select_nth_unstable` to beat `sort_unstable`'s adaptive paths, so we fall back to a full sort.
 /// This is very low on purpose, and meant to catch unique or mostly unique terms.
-const DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD: u32 = 2;
+const DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD: u64 = 2;
 
 /// Build a concrete `SegmentTermCollector` with either a Vec- or HashMap-backed
 /// bucket storage, depending on the column type and aggregation level.
@@ -999,6 +999,10 @@ where
 
         let segment_size = term_req.req.segment_size as usize;
 
+        // Total doc count over all buckets, computed is some case, and which can be reused by
+        // `cut_off_buckets` to derive `sum_other_doc_count` without a second pass.
+        let mut total_doc_count: Option<u64> = None;
+
         // select_nth_unstable_by_key(segment_size, ...) places the (k+1)-th element at
         // entries[segment_size] and guarantees entries[0..segment_size] are the top-k,
         // unordered. We need this to properly compute term_doc_count_before_cutoff.
@@ -1065,10 +1069,10 @@ where
                 if entries.len() > segment_size {
                     // unique or near-unique fields create big runs of sorted values (ones),
                     // which is defavorable to quickselect. use the then faster sort_unstable.
-                    let num_buckets = entries.len() as u32;
-                    let num_docs: u32 = entries.iter().map(|(_, b)| b.count).sum();
-                    let near_unique =
-                        num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
+                    let num_buckets = entries.len() as u64;
+                    let num_docs = entries.iter().map(|(_, b)| b.count as u64).sum();
+                    total_doc_count = Some(num_docs);
+                    let near_unique = num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
                     if term_req.req.order.order == Order::Desc {
                         if near_unique {
                             entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.1.count));
@@ -1087,7 +1091,7 @@ where
         }
 
         let (term_doc_count_before_cutoff, sum_other_doc_count) =
-            cut_off_buckets(&mut entries, segment_size);
+            cut_off_buckets(&mut entries, segment_size, total_doc_count);
 
         let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> = Default::default();
         dict.reserve(entries.len());
@@ -1296,19 +1300,33 @@ impl GetDocCount for (u64, Bucket) {
     }
 }
 
+/// Truncates `entries` to the top `num_elem` and returns
+/// `(term_doc_count_before_cutoff, sum_other_doc_count)`.
+///
+/// When `total_doc_count` is `Some`, `sum_other_doc_count` is derived as `total - sum(kept)`, which
+/// only sums the `num_elem` kept entries instead of the (potentially far larger) cut-off tail.
 pub(crate) fn cut_off_buckets<T: GetDocCount + Debug>(
     entries: &mut Vec<T>,
     num_elem: usize,
+    total_doc_count: Option<u64>,
 ) -> (u64, u64) {
     let term_doc_count_before_cutoff = entries
         .get(num_elem)
         .map(|entry| entry.doc_count())
         .unwrap_or(0);
 
-    let sum_other_doc_count = entries
-        .get(num_elem..)
-        .map(|cut_off_range| cut_off_range.iter().map(|entry| entry.doc_count()).sum())
-        .unwrap_or(0);
+    let sum_other_doc_count = match total_doc_count {
+        // Reuse the precomputed total: sum_other = total - sum(kept top-k), summing only the
+        // (small) kept slice. Fewer than `num_elem` buckets means nothing is cut off, so 0.
+        Some(total) => entries
+            .get(..num_elem)
+            .map(|kept| total - kept.iter().map(|entry| entry.doc_count()).sum::<u64>())
+            .unwrap_or(0),
+        None => entries
+            .get(num_elem..)
+            .map(|cut_off_range| cut_off_range.iter().map(|entry| entry.doc_count()).sum())
+            .unwrap_or(0),
+    };
 
     entries.truncate(num_elem);
     (term_doc_count_before_cutoff, sum_other_doc_count)

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -339,6 +339,11 @@ impl TermsAggregationInternal {
 /// TODO: Benchmark to validate the threshold
 pub const MAX_NUM_TERMS_FOR_VEC: u64 = 100;
 
+/// Average docs-per-bucket below which term counts cluster too tightly (mostly 1s and 2s) for
+/// `select_nth_unstable` to beat `sort_unstable`'s adaptive paths, so we fall back to a full sort.
+/// This is very low on purpose, and meant to catch unique or mostly unique terms.
+const DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD: u32 = 2;
+
 /// Build a concrete `SegmentTermCollector` with either a Vec- or HashMap-backed
 /// bucket storage, depending on the column type and aggregation level.
 pub(crate) fn build_segment_term_collector(
@@ -468,6 +473,9 @@ impl Bucket {
 
 /// Abstraction over the storage used for term buckets (counts only).
 trait TermAggregationMap: Clone + Debug + 'static {
+    /// Whether `into_vec` returns entries already sorted by term ord, ascending.
+    const SORTED_BY_ORD: bool;
+
     /// Create a new instance with a strict upper bound on term ids.
     fn new(max_term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> Self;
 
@@ -567,6 +575,8 @@ struct PagedTermMap {
 impl PagedTermMap {}
 
 impl TermAggregationMap for PagedTermMap {
+    const SORTED_BY_ORD: bool = true;
+
     #[inline]
     fn get_memory_consumption(&self) -> usize {
         self.mem_usage + std::mem::size_of::<Self>()
@@ -635,6 +645,8 @@ impl TermAggregationMap for PagedTermMap {
 }
 
 impl TermAggregationMap for HashMapTermBuckets {
+    const SORTED_BY_ORD: bool = false;
+
     #[inline]
     fn get_memory_consumption(&self) -> usize {
         self.bucket_map.memory_consumption()
@@ -667,6 +679,8 @@ struct VecTermBucketsNoAgg {
 }
 
 impl TermAggregationMap for VecTermBucketsNoAgg {
+    const SORTED_BY_ORD: bool = true;
+
     /// Estimate the memory consumption of this struct in bytes.
     fn get_memory_consumption(&self) -> usize {
         // We do not include `std::mem::size_of::<Self>()`
@@ -723,6 +737,8 @@ struct VecTermBuckets {
 }
 
 impl TermAggregationMap for VecTermBuckets {
+    const SORTED_BY_ORD: bool = true;
+
     /// Estimate the memory consumption of this struct in bytes.
     fn get_memory_consumption(&self) -> usize {
         // We do not include `std::mem::size_of::<Self>()`
@@ -986,12 +1002,21 @@ where
         // select_nth_unstable_by_key(segment_size, ...) places the (k+1)-th element at
         // entries[segment_size] and guarantees entries[0..segment_size] are the top-k,
         // unordered. We need this to properly compute term_doc_count_before_cutoff.
+        // In some cases (already sorted entries), we are faster sorting everything and
+        // going through sort_unstable's fast path.
         match &term_req.req.order.target {
             OrderTarget::Key => {
                 // We rely on the fact, that term ordinals match the order of the strings
                 // TODO: We could have a special collector, that keeps only TOP n results at any
                 // time.
-                if entries.len() > segment_size {
+                if TermMap::SORTED_BY_ORD {
+                    // `into_vec` already returned entries sorted by ord ascending, we can just
+                    // revert if we want descending.
+                    if term_req.req.order.order == Order::Desc {
+                        entries.reverse();
+                    }
+                } else if entries.len() > segment_size {
+                    // Unsorted source: use select_nth
                     if term_req.req.order.order == Order::Desc {
                         entries
                             .select_nth_unstable_by_key(segment_size, |b| std::cmp::Reverse(b.0));
@@ -1022,6 +1047,8 @@ where
                     })
                     .collect();
                 if keyed.len() > segment_size {
+                    // there are situations where sort_unstable might be advantageous, but
+                    // detecting them isn't trivial, and these situation should be rare.
                     if term_req.req.order.order == Order::Desc {
                         keyed.select_nth_unstable_by(segment_size, |a, b| {
                             b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal)
@@ -1036,10 +1063,22 @@ where
             }
             OrderTarget::Count => {
                 if entries.len() > segment_size {
+                    // unique or near-unique fields create big runs of sorted values (ones),
+                    // which is defavorable to quickselect. use the then faster sort_unstable.
+                    let num_buckets = entries.len() as u32;
+                    let num_docs: u32 = entries.iter().map(|(_, b)| b.count).sum();
+                    let near_unique =
+                        num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
                     if term_req.req.order.order == Order::Desc {
-                        entries.select_nth_unstable_by_key(segment_size, |b| {
-                            std::cmp::Reverse(b.1.count)
-                        });
+                        if near_unique {
+                            entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.1.count));
+                        } else {
+                            entries.select_nth_unstable_by_key(segment_size, |b| {
+                                std::cmp::Reverse(b.1.count)
+                            });
+                        }
+                    } else if near_unique {
+                        entries.sort_unstable_by_key(|b| b.1.count);
                     } else {
                         entries.select_nth_unstable_by_key(segment_size, |b| b.1.count);
                     }

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1072,7 +1072,8 @@ where
                     let num_buckets = entries.len() as u64;
                     let num_docs = entries.iter().map(|(_, b)| b.count as u64).sum();
                     total_doc_count = Some(num_docs);
-                    let near_unique = num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
+                    let near_unique =
+                        num_docs < num_buckets * DOCS_PER_BUCKET_QUICKSELECT_THRESHOLD;
                     if term_req.req.order.order == Order::Desc {
                         if near_unique {
                             entries.sort_unstable_by_key(|b| std::cmp::Reverse(b.1.count));

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -807,7 +807,7 @@ impl IntermediateTermBucketResult {
         // This can be interesting, as a value of quality of the results, but not good to check the
         // actual error count for the returned terms.
         let (_term_doc_count_before_cutoff, sum_other_doc_count) =
-            cut_off_buckets(&mut buckets, req.size as usize);
+            cut_off_buckets(&mut buckets, req.size as usize, None);
 
         let doc_count_error_upper_bound = if req.show_term_doc_count_error {
             Some(self.doc_count_error_upper_bound)


### PR DESCRIPTION
this is an attempt at optimizing term aggregations by removing the sort and replacing it by a supposedly faster select_nth
for some reason it's slower on `terms_all_unique`. I suspected all buckets being equal, but after changing the sorting to _key, it's still slower, so idk why that benchmark actually get slower.

bench result binggan showed green/red 
```
full
terms_all_unique                                      Memory: 12.7 MB              Avg: 9.1016ms (+10.28%)     Median: 9.1072ms (+10.34%)     [9.0045ms .. 9.1969ms]        
terms_150_000                                         Memory: 3.0 MB               Avg: 9.4691ms (-5.46%)      Median: 9.4711ms (-5.41%)      [9.4202ms .. 9.5155ms]        
terms_many_top_1000                                   Memory: 5.2 MB               Avg: 15.1838ms (-3.47%)     Median: 15.1812ms (-3.54%)     [15.1078ms .. 15.3148ms]      
terms_many_with_top_hits                              Memory: 48.9 MB              Avg: 228.6939ms (-2.42%)    Median: 228.0995ms (-2.41%)    [222.2027ms .. 239.1052ms]    
terms_all_unique_with_avg_sub_agg                     Memory: 54.7 MB              Avg: 32.5578ms (+2.58%)     Median: 32.5744ms (+2.64%)     [31.7157ms .. 33.2035ms]      
terms_many_with_avg_sub_agg                           Memory: 13.5 MB              Avg: 31.9481ms (-6.21%)     Median: 31.1977ms (-5.69%)     [30.3651ms .. 34.4392ms]      
range_agg_with_term_agg_many                          Memory: 6.9 MB               Avg: 20.0822ms (-3.62%)     Median: 20.0814ms (-3.53%)     [19.9813ms .. 20.1616ms]      

dense
terms_all_unique                                      Memory: 12.7 MB              Avg: 12.5328ms (+10.54%)     Median: 12.5149ms (+10.30%)     [12.3717ms .. 12.8331ms]      
terms_150_000                                         Memory: 3.0 MB               Avg: 12.6641ms (-3.03%)      Median: 12.6526ms (-3.07%)      [12.5949ms .. 12.7456ms]      
terms_many_with_top_hits                              Memory: 49.4 MB              Avg: 233.5704ms (-4.58%)     Median: 232.6708ms (-4.26%)     [229.0237ms .. 244.1367ms]    
terms_all_unique_with_avg_sub_agg                     Memory: 56.0 MB              Avg: 38.8084ms (+2.94%)      Median: 38.7979ms (+2.98%)      [38.2402ms .. 39.5980ms]      
terms_many_with_avg_sub_agg                           Memory: 13.8 MB              Avg: 37.3928ms (-5.54%)      Median: 37.5853ms (-4.98%)      [35.8191ms .. 38.6754ms]      
terms_many_json_mixed_type_with_avg_sub_agg           Memory: 17.9 MB              Avg: 51.1925ms (-3.73%)      Median: 51.0890ms (-3.64%)      [50.7620ms .. 52.7191ms]      
terms_many_with_single_term_order_by_card             Memory: 48.9 MB              Avg: 227.4272ms (-7.87%)     Median: 225.6127ms (-8.10%)     [219.0632ms .. 250.0368ms]    
terms_many_with_single_term_2_order_by_card           Memory: 41.3 MB              Avg: 152.6406ms (-12.88%)    Median: 151.8498ms (-11.96%)    [149.8239ms .. 165.0004ms]    
range_agg_with_term_agg_many                          Memory: 6.9 MB               Avg: 26.0125ms (-2.91%)      Median: 25.9682ms (-2.94%)      [25.8363ms .. 26.4669ms]      


sparse
terms_many_with_top_hits                              Memory: 11.2 MB              Avg: 34.8001ms (-2.20%)    Median: 34.6982ms (-2.30%)    [34.4690ms .. 36.4585ms]    

multivalue
terms_all_unique                                      Memory: 12.6 MB              Avg: 17.3829ms (+5.82%)      Median: 17.3886ms (+5.72%)     [17.1535ms .. 17.5235ms]      
terms_150_000                                         Memory: 3.0 MB               Avg: 17.0332ms (-3.02%)      Median: 17.0364ms (-2.98%)     [16.9439ms .. 17.1729ms]      
terms_many_top_1000                                   Memory: 5.2 MB               Avg: 23.2856ms (-2.39%)      Median: 23.3348ms (-2.21%)     [22.8031ms .. 23.6608ms]      
terms_many_with_top_hits                              Memory: 48.9 MB              Avg: 249.7343ms (-5.73%)     Median: 249.1865ms (-5.61%)    [244.0439ms .. 260.3315ms]    
terms_many_with_avg_sub_agg                           Memory: 13.5 MB              Avg: 45.8467ms (-5.18%)      Median: 46.1055ms (-4.61%)     [44.5511ms .. 47.5698ms]      
terms_many_with_single_term_order_by_card             Memory: 49.0 MB              Avg: 243.5649ms (-6.07%)     Median: 242.5555ms (-5.65%)    [239.3785ms .. 253.4102ms]    
terms_many_with_single_term_2_order_by_card           Memory: 40.8 MB (-0.00%)     Avg: 159.7538ms (-10.01%)    Median: 159.7042ms (-9.80%)    [156.2324ms .. 168.2911ms]    
```