### PR TITLE
make BucketId optional in aggregations

### DIFF
--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -249,12 +249,13 @@ impl HistogramBounds {
     }
 }
 
-/// The per-bucket identifier stored in a [`SegmentHistogramBucketEntry`].
+/// The per-bucket identifier stored alongside a bucket's count (e.g. in a
+/// [`SegmentHistogramBucketEntry`] or a term-agg `Bucket`).
 ///
-/// It is [`BucketId`] when the histogram has sub aggregations (which key their state by it), and
+/// It is [`BucketId`] when the aggregation has sub aggregations (which key their state by it), and
 /// the zero-sized `()` when it does not. Without sub aggregations the id is never read, so storing
-/// `()` drops 8 bytes per bucket (24 -> 16) and turns id assignment into a no-op.
-pub trait BucketIdSlot: Copy + Default + std::fmt::Debug + PartialEq {
+/// `()` drops the id bytes per bucket and turns id assignment into a no-op.
+pub trait BucketIdSlot: Copy + Default + std::fmt::Debug + PartialEq + 'static {
     /// Assigns the next id from the provider, called once when a bucket is first filled.
     fn assign(provider: &mut BucketIdProvider) -> Self;
     /// Resolves to the `BucketId` for sub-aggregation bookkeeping.

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -10,15 +10,15 @@ use common::{BitSet, TinySet};
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
-use super::{CustomOrder, Order, OrderTarget};
+use super::{BucketIdSlot, CustomOrder, Order, OrderTarget};
 use crate::aggregation::agg_data::{
     build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
 };
 use crate::aggregation::agg_limits::MemoryConsumption;
 use crate::aggregation::agg_req::Aggregations;
 use crate::aggregation::buffered_sub_aggs::{
-    BufferedSubAggs, HighCardSubAggBuffer, LowCardBufferedSubAggs, LowCardSubAggBuffer,
-    SubAggBuffer,
+    BufferedSubAggs, HighCardBufferedSubAggs, HighCardSubAggBuffer, LowCardBufferedSubAggs,
+    LowCardSubAggBuffer, SubAggBuffer,
 };
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
@@ -404,18 +404,22 @@ pub(crate) fn build_segment_term_collector(
 
     let mut bucket_id_provider = BucketIdProvider::default();
     // Decide which bucket storage is best suited for this aggregation.
+    //
+    // Every storage is generic over its `Bucket` id slot (see `BucketIdSlot`): with sub
+    // aggregations it stores a real `BucketId` (to key the buffered sub-aggs), without them the
+    // zero-sized `()`, which shrinks each bucket and turns id assignment into a no-op.
+    let num_terms = max_column_val + 1;
     if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC && !has_sub_aggregations {
-        let term_buckets = VecTermBucketsNoAgg::new(max_column_val + 1, &mut bucket_id_provider);
-        let collector: SegmentTermCollector<_, HighCardSubAggBuffer> = SegmentTermCollector {
-            parent_buckets: vec![term_buckets],
-            sub_agg: None,
+        let term_buckets = VecTermBuckets::<()>::new(num_terms, &mut bucket_id_provider);
+        Ok(boxed_high_card_collector(
+            term_buckets,
+            None,
             bucket_id_provider,
-            max_term_id: max_column_val,
+            max_column_val,
             terms_req_data,
-        };
-        Ok(Box::new(collector))
+        ))
     } else if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC {
-        let term_buckets = VecTermBuckets::new(max_column_val + 1, &mut bucket_id_provider);
+        let term_buckets = VecTermBuckets::<BucketId>::new(num_terms, &mut bucket_id_provider);
         let sub_agg = sub_agg_collector.map(LowCardBufferedSubAggs::new);
         let collector: SegmentTermCollector<_, LowCardSubAggBuffer> = SegmentTermCollector {
             parent_buckets: vec![term_buckets],
@@ -426,53 +430,98 @@ pub(crate) fn build_segment_term_collector(
         };
         Ok(Box::new(collector))
     } else if max_column_val < 8_000_000 && is_top_level {
-        let term_buckets: PagedTermMap =
-            PagedTermMap::new(max_column_val + 1, &mut bucket_id_provider);
         // Build sub-aggregation blueprint (flat pairs)
         let sub_agg = sub_agg_collector.map(BufferedSubAggs::new);
-        let collector: SegmentTermCollector<PagedTermMap, HighCardSubAggBuffer> =
-            SegmentTermCollector {
-                parent_buckets: vec![term_buckets],
+        if has_sub_aggregations {
+            let term_buckets = PagedTermMap::<BucketId>::new(num_terms, &mut bucket_id_provider);
+            Ok(boxed_high_card_collector(
+                term_buckets,
                 sub_agg,
                 bucket_id_provider,
-                max_term_id: max_column_val,
+                max_column_val,
                 terms_req_data,
-            };
-        Ok(Box::new(collector))
+            ))
+        } else {
+            let term_buckets = PagedTermMap::<()>::new(num_terms, &mut bucket_id_provider);
+            Ok(boxed_high_card_collector(
+                term_buckets,
+                sub_agg,
+                bucket_id_provider,
+                max_column_val,
+                terms_req_data,
+            ))
+        }
     } else {
-        let term_buckets: HashMapTermBuckets = HashMapTermBuckets::default();
         // Build sub-aggregation blueprint (flat pairs)
         let sub_agg = sub_agg_collector.map(BufferedSubAggs::new);
-        let collector: SegmentTermCollector<HashMapTermBuckets, HighCardSubAggBuffer> =
-            SegmentTermCollector {
-                parent_buckets: vec![term_buckets],
+        if has_sub_aggregations {
+            let term_buckets = HashMapTermBuckets::<BucketId>::default();
+            Ok(boxed_high_card_collector(
+                term_buckets,
                 sub_agg,
                 bucket_id_provider,
-                max_term_id: max_column_val,
+                max_column_val,
                 terms_req_data,
-            };
-        Ok(Box::new(collector))
-    }
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-struct Bucket {
-    pub count: u32,
-    pub bucket_id: BucketId,
-}
-
-impl Bucket {
-    #[inline(always)]
-    fn new(bucket_id: BucketId) -> Self {
-        Self {
-            count: 0,
-            bucket_id,
+            ))
+        } else {
+            let term_buckets = HashMapTermBuckets::<()>::default();
+            Ok(boxed_high_card_collector(
+                term_buckets,
+                sub_agg,
+                bucket_id_provider,
+                max_column_val,
+                terms_req_data,
+            ))
         }
     }
 }
 
-/// Abstraction over the storage used for term buckets (counts only).
+/// Boxes a term collector backed by the high-cardinality sub-agg buffer. Lets the storage branches
+/// above pick the `Bucket` id slot (`BucketId` vs `()`) without repeating the collector literal.
+fn boxed_high_card_collector<M: TermAggregationMap>(
+    term_buckets: M,
+    sub_agg: Option<HighCardBufferedSubAggs>,
+    bucket_id_provider: BucketIdProvider,
+    max_term_id: u64,
+    terms_req_data: TermsAggReqData,
+) -> Box<dyn SegmentAggregationCollector> {
+    Box::new(SegmentTermCollector::<M, HighCardSubAggBuffer> {
+        parent_buckets: vec![term_buckets],
+        sub_agg,
+        bucket_id_provider,
+        max_term_id,
+        terms_req_data,
+    })
+}
+
+/// A term bucket: its doc count plus a [`BucketIdSlot`] identifying it for sub-aggregations.
+///
+/// `B` is [`BucketId`] when the terms agg has sub aggregations and the zero-sized `()` when it does
+/// not, so `Bucket<()>` is just the count (see [`BucketIdSlot`]).
+#[derive(Debug, Clone, Copy, Default)]
+struct Bucket<B> {
+    pub count: u32,
+    pub bucket_id: B,
+}
+
+impl<B: BucketIdSlot> Bucket<B> {
+    /// Creates an empty bucket, assigning it the next id from `bucket_id_provider` (a no-op for the
+    /// `()` slot, which leaves the provider untouched).
+    #[inline(always)]
+    fn new(bucket_id_provider: &mut BucketIdProvider) -> Self {
+        Self {
+            count: 0,
+            bucket_id: B::assign(bucket_id_provider),
+        }
+    }
+}
+
+/// Abstraction over the storage used for term buckets (counts plus a [`BucketIdSlot`]).
 trait TermAggregationMap: Clone + Debug + 'static {
+    /// The per-bucket id slot: [`BucketId`] with sub aggregations, `()` without (see
+    /// [`BucketIdSlot`]).
+    type Slot: BucketIdSlot;
+
     /// Whether `into_vec` returns entries already sorted by term ord, ascending.
     const SORTED_BY_ORD: bool;
 
@@ -482,20 +531,21 @@ trait TermAggregationMap: Clone + Debug + 'static {
     /// Estimate the memory consumption of this struct in bytes.
     fn get_memory_consumption(&self) -> usize;
 
-    /// Increments the count and returns the bucket_id associated to a given term_id.
-    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> BucketId;
+    /// Increments the count and returns the bucket id slot associated to a given term_id.
+    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider)
+        -> Self::Slot;
 
     /// Returns the term aggregation as a vector of (term_id, bucket) pairs,
     /// in any order.
-    fn into_vec(self) -> Vec<(u64, Bucket)>;
+    fn into_vec(self) -> Vec<(u64, Bucket<Self::Slot>)>;
 }
 
 #[derive(Clone, Debug)]
-struct HashMapTermBuckets {
-    bucket_map: FxHashMap<u64, Bucket>,
+struct HashMapTermBuckets<B> {
+    bucket_map: FxHashMap<u64, Bucket<B>>,
 }
 
-impl Default for HashMapTermBuckets {
+impl<B> Default for HashMapTermBuckets<B> {
     #[inline(always)]
     fn default() -> Self {
         Self {
@@ -510,14 +560,14 @@ const PAGE_MASK: usize = PAGE_SIZE - 1;
 const BITMASK_LEN: usize = PAGE_SIZE / 64;
 
 #[derive(Clone, Debug)]
-struct Page {
+struct Page<B> {
     /// Bitmask indicating which offsets are present.
     /// It is chunked into TinySet words.
     presence: [TinySet; BITMASK_LEN],
-    data: [Bucket; PAGE_SIZE],
+    data: [Bucket<B>; PAGE_SIZE],
 }
 
-impl Page {
+impl<B: BucketIdSlot> Page<B> {
     fn new() -> Self {
         Self {
             presence: [TinySet::empty(); BITMASK_LEN],
@@ -540,7 +590,7 @@ impl Page {
     }
 
     // Flattened iteration logic
-    fn collect_items(&self, base_term_id: u64, result: &mut Vec<(u64, Bucket)>) {
+    fn collect_items(&self, base_term_id: u64, result: &mut Vec<(u64, Bucket<B>)>) {
         for (bucket_pos, &tiny_set) in self.presence.iter().enumerate() {
             let base_offset = bucket_pos * 64;
 
@@ -566,15 +616,15 @@ impl Page {
 /// directories only. Therefore, this implementation is only enabled for top-level aggregations
 /// TODO: pass expected number of buckets from parent instead of strict is_top_level flag.
 #[derive(Clone, Debug, Default)]
-struct PagedTermMap {
+struct PagedTermMap<B> {
     // Fixed size vector based on max_term_id
-    pages: Vec<Option<Box<Page>>>,
+    pages: Vec<Option<Box<Page<B>>>>,
     mem_usage: usize,
 }
 
-impl PagedTermMap {}
+impl<B: BucketIdSlot> TermAggregationMap for PagedTermMap<B> {
+    type Slot = B;
 
-impl TermAggregationMap for PagedTermMap {
     const SORTED_BY_ORD: bool = true;
 
     #[inline]
@@ -583,7 +633,7 @@ impl TermAggregationMap for PagedTermMap {
     }
 
     #[inline]
-    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> BucketId {
+    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> B {
         let term_id = term_id as usize;
         let page_idx = term_id >> PAGE_SHIFT;
         let offset = term_id & PAGE_MASK;
@@ -593,7 +643,7 @@ impl TermAggregationMap for PagedTermMap {
             Some(p) => p,
             None => {
                 let new_page = Box::new(Page::new());
-                self.mem_usage += std::mem::size_of::<Page>();
+                self.mem_usage += std::mem::size_of::<Page<B>>();
                 self.pages[page_idx] = Some(new_page);
                 self.pages[page_idx].as_mut().unwrap()
             }
@@ -604,17 +654,15 @@ impl TermAggregationMap for PagedTermMap {
             bucket.count += 1;
             bucket.bucket_id
         } else {
-            let new_id = bucket_id_provider.next_bucket_id();
-            page.data[offset] = Bucket {
-                count: 1,
-                bucket_id: new_id,
-            };
+            let mut bucket = Bucket::new(bucket_id_provider);
+            bucket.count = 1;
+            page.data[offset] = bucket;
             page.set_present(offset);
-            new_id
+            bucket.bucket_id
         }
     }
 
-    fn into_vec(self) -> Vec<(u64, Bucket)> {
+    fn into_vec(self) -> Vec<(u64, Bucket<B>)> {
         // estimate 16 entries per non-empty page
         let estimated_count = self.pages.iter().filter(|p| p.is_some()).count() * 16;
         let mut result = Vec::with_capacity(estimated_count);
@@ -638,13 +686,15 @@ impl TermAggregationMap for PagedTermMap {
         // Memory cost: num_pages * 8 bytes
         let pages = vec![None; num_pages];
 
-        let mem_usage = pages.capacity() * std::mem::size_of::<Option<Box<Page>>>();
+        let mem_usage = pages.capacity() * std::mem::size_of::<Option<Box<Page<B>>>>();
 
         Self { pages, mem_usage }
     }
 }
 
-impl TermAggregationMap for HashMapTermBuckets {
+impl<B: BucketIdSlot> TermAggregationMap for HashMapTermBuckets<B> {
+    type Slot = B;
+
     const SORTED_BY_ORD: bool = false;
 
     #[inline]
@@ -653,16 +703,16 @@ impl TermAggregationMap for HashMapTermBuckets {
     }
 
     #[inline(always)]
-    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> BucketId {
+    fn term_entry(&mut self, term_id: u64, bucket_id_provider: &mut BucketIdProvider) -> B {
         let bucket = self
             .bucket_map
             .entry(term_id)
-            .or_insert_with(|| Bucket::new(bucket_id_provider.next_bucket_id()));
+            .or_insert_with(|| Bucket::new(bucket_id_provider));
         bucket.count += 1;
         bucket.bucket_id
     }
 
-    fn into_vec(self) -> Vec<(u64, Bucket)> {
+    fn into_vec(self) -> Vec<(u64, Bucket<B>)> {
         self.bucket_map.into_iter().collect()
     }
 
@@ -674,69 +724,13 @@ impl TermAggregationMap for HashMapTermBuckets {
 
 /// An optimized term map implementation for a compact set of term ordinals.
 #[derive(Clone, Debug)]
-struct VecTermBucketsNoAgg {
-    buckets: Vec<u32>,
+struct VecTermBuckets<B> {
+    buckets: Vec<Bucket<B>>,
 }
 
-impl TermAggregationMap for VecTermBucketsNoAgg {
-    const SORTED_BY_ORD: bool = true;
+impl<B: BucketIdSlot> TermAggregationMap for VecTermBuckets<B> {
+    type Slot = B;
 
-    /// Estimate the memory consumption of this struct in bytes.
-    fn get_memory_consumption(&self) -> usize {
-        // We do not include `std::mem::size_of::<Self>()`
-        // It is already measure by the parent aggregation.
-        //
-        self.buckets.capacity() * std::mem::size_of::<u32>()
-    }
-
-    /// Add an occurrence of the given term id.
-    #[inline(always)]
-    fn term_entry(&mut self, term_id: u64, _bucket_id_provider: &mut BucketIdProvider) -> BucketId {
-        let term_id_usize = term_id as usize;
-        debug_assert!(
-            term_id_usize < self.buckets.len(),
-            "term_id {} out of bounds for VecTermBuckets (len={})",
-            term_id,
-            self.buckets.len()
-        );
-        let count = unsafe { self.buckets.get_unchecked_mut(term_id_usize) };
-        *count += 1;
-        0 // unused
-    }
-
-    fn into_vec(self) -> Vec<(u64, Bucket)> {
-        self.buckets
-            .into_iter()
-            .enumerate()
-            .filter(|(_term_id, count)| *count > 0)
-            .map(|(term_id, count)| {
-                (
-                    term_id as u64,
-                    Bucket {
-                        count,
-                        bucket_id: 0, // unused, there are no sub-aggregations
-                    },
-                )
-            })
-            .collect()
-    }
-
-    fn new(num_terms: u64, _bucket_id_provider: &mut BucketIdProvider) -> Self {
-        Self {
-            buckets: std::iter::repeat_with(|| 0)
-                .take(num_terms as usize)
-                .collect(),
-        }
-    }
-}
-
-/// An optimized term map implementation for a compact set of term ordinals.
-#[derive(Clone, Debug)]
-struct VecTermBuckets {
-    buckets: Vec<Bucket>,
-}
-
-impl TermAggregationMap for VecTermBuckets {
     const SORTED_BY_ORD: bool = true;
 
     /// Estimate the memory consumption of this struct in bytes.
@@ -745,12 +739,12 @@ impl TermAggregationMap for VecTermBuckets {
         // It is already measure by the parent aggregation.
         //
         // The root aggregation mem size is not measure but we do not care.
-        self.buckets.capacity() * std::mem::size_of::<Bucket>()
+        self.buckets.capacity() * std::mem::size_of::<Bucket<B>>()
     }
 
     /// Add an occurrence of the given term id.
     #[inline(always)]
-    fn term_entry(&mut self, term_id: u64, _bucket_id_provider: &mut BucketIdProvider) -> BucketId {
+    fn term_entry(&mut self, term_id: u64, _bucket_id_provider: &mut BucketIdProvider) -> B {
         let term_id_usize = term_id as usize;
         debug_assert!(
             term_id_usize < self.buckets.len(),
@@ -763,7 +757,7 @@ impl TermAggregationMap for VecTermBuckets {
         bucket.bucket_id
     }
 
-    fn into_vec(self) -> Vec<(u64, Bucket)> {
+    fn into_vec(self) -> Vec<(u64, Bucket<B>)> {
         self.buckets
             .into_iter()
             .enumerate()
@@ -774,7 +768,9 @@ impl TermAggregationMap for VecTermBuckets {
 
     fn new(num_terms: u64, bucket_id_provider: &mut BucketIdProvider) -> Self {
         VecTermBuckets {
-            buckets: std::iter::repeat_with(|| Bucket::new(bucket_id_provider.next_bucket_id()))
+            // Assigns an id per term up front from the shared provider; for the `()` slot this is a
+            // no-op and leaves the provider untouched.
+            buckets: std::iter::repeat_with(|| Bucket::new(bucket_id_provider))
                 .take(num_terms as usize)
                 .collect(),
         }
@@ -959,17 +955,20 @@ fn reborrow_opt_collector<'a>(
     }
 }
 
-fn into_intermediate_bucket_entry(
-    bucket: Bucket,
+fn into_intermediate_bucket_entry<B: BucketIdSlot>(
+    bucket: Bucket<B>,
     sub_agg_collector: Option<&mut dyn SegmentAggregationCollector>,
     agg_data: &AggregationsSegmentCtx,
 ) -> crate::Result<IntermediateTermBucketEntry> {
     let mut sub_aggregation_res = IntermediateAggregationResults::default();
     if let Some(sub_agg_collector) = sub_agg_collector {
+        // The `bucket_id` is only read here, when a sub-agg collector is present — which is exactly
+        // when the slot is a real `BucketId` (never `()`), so `to_bucket_id` never hits its
+        // `unreachable!`.
         sub_agg_collector.add_intermediate_aggregation_result(
             agg_data,
             &mut sub_aggregation_res,
-            bucket.bucket_id,
+            bucket.bucket_id.to_bucket_id(),
         )?;
     }
     Ok(IntermediateTermBucketEntry {
@@ -995,7 +994,7 @@ where
         term_buckets: TermMap,
         agg_data: &AggregationsSegmentCtx,
     ) -> crate::Result<IntermediateBucketResult> {
-        let mut entries: Vec<(u64, Bucket)> = term_buckets.into_vec();
+        let mut entries: Vec<(u64, Bucket<TermMap::Slot>)> = term_buckets.into_vec();
 
         let segment_size = term_req.req.segment_size as usize;
 
@@ -1041,11 +1040,19 @@ where
                 })?;
                 let (agg_name, agg_prop) = get_agg_name_and_property(sub_agg_path);
                 // Fetch values up-front; otherwise sort would re-compute per call
-                let mut keyed: Vec<(f64, (u64, Bucket))> = entries
+                let mut keyed: Vec<_> = entries
                     .into_iter()
                     .map(|bucket| {
+                        // Reached only when ordering by a sub-agg, i.e. sub aggregations exist and
+                        // the slot is a real `BucketId`, so `to_bucket_id` never hits
+                        // `unreachable!`.
                         let metric_value = coll
-                            .compute_metric_value(bucket.1.bucket_id, agg_name, agg_prop, agg_data)
+                            .compute_metric_value(
+                                bucket.1.bucket_id.to_bucket_id(),
+                                agg_name,
+                                agg_prop,
+                                agg_data,
+                            )
                             .unwrap_or(0.0);
                         (metric_value, bucket)
                     })
@@ -1118,7 +1125,8 @@ where
             // Sort by term ord
             entries.sort_unstable_by_key(|bucket| bucket.0);
 
-            let (term_ids, buckets): (Vec<u64>, Vec<Bucket>) = entries.into_iter().unzip();
+            let (term_ids, buckets): (Vec<u64>, Vec<Bucket<TermMap::Slot>>) =
+                entries.into_iter().unzip();
 
             let intermediate_entries: Vec<IntermediateTermBucketEntry> = buckets
                 .into_iter()
@@ -1268,8 +1276,10 @@ impl<TermMap: TermAggregationMap, B: SubAggBuffer> SegmentTermCollector<TermMap,
         sub_agg: &mut BufferedSubAggs<B>,
     ) {
         for (doc, term_id) in iter {
+            // This path only runs when a sub-agg buffer is present, so the slot is a real
+            // `BucketId` and `to_bucket_id` never hits `unreachable!`.
             let bucket_id = term_buckets.term_entry(term_id, bucket_id_provider);
-            sub_agg.push(bucket_id, doc);
+            sub_agg.push(bucket_id.to_bucket_id(), doc);
         }
     }
 
@@ -1295,7 +1305,7 @@ impl GetDocCount for (String, IntermediateTermBucketEntry) {
     }
 }
 
-impl GetDocCount for (u64, Bucket) {
+impl<B: BucketIdSlot> GetDocCount for (u64, Bucket<B>) {
     fn doc_count(&self) -> u64 {
         self.1.count as u64
     }
@@ -1349,7 +1359,7 @@ mod tests {
         exec_request, exec_request_with_query, exec_request_with_query_and_memory_limit,
         get_test_index_from_terms, get_test_index_from_values_and_terms,
     };
-    use crate::aggregation::{AggregationLimitsGuard, DistributedAggregationCollector};
+    use crate::aggregation::{AggregationLimitsGuard, BucketId, DistributedAggregationCollector};
     use crate::indexer::NoMergePolicy;
     use crate::query::AllQuery;
     use crate::schema::{IntoIpv6Addr, Schema, FAST, INDEXED, STRING, TEXT};
@@ -1358,7 +1368,8 @@ mod tests {
     #[test]
     fn paged_term_map_reuses_buckets_and_counts() {
         let mut bucket_id_provider = BucketIdProvider::default();
-        let mut map = PagedTermMap::new((PAGE_SIZE * 2) as u64, &mut bucket_id_provider);
+        let mut map =
+            PagedTermMap::<BucketId>::new((PAGE_SIZE * 2) as u64, &mut bucket_id_provider);
 
         let bucket_first = map.term_entry(5, &mut bucket_id_provider);
         let bucket_second_page = map.term_entry((PAGE_SIZE + 7) as u64, &mut bucket_id_provider);

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -408,7 +408,11 @@ pub(crate) fn build_segment_term_collector(
     // Every storage is generic over its `Bucket` id slot (see `BucketIdSlot`): with sub
     // aggregations it stores a real `BucketId` (to key the buffered sub-aggs), without them the
     // zero-sized `()`, which shrinks each bucket and turns id assignment into a no-op.
-    let num_terms = max_column_val + 1;
+    //
+    // Only the dense Vec/Paged storages below (all gated to `max_column_val < 8_000_000`) use
+    // `num_terms`. `saturating_add` guards the HashMap fallback, where `max_column_val` is a raw
+    // numeric column value that can reach `u64::MAX`; term ordinals never come close.
+    let num_terms = max_column_val.saturating_add(1);
     if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC && !has_sub_aggregations {
         let term_buckets = VecTermBuckets::<()>::new(num_terms, &mut bucket_id_provider);
         Ok(boxed_high_card_collector(
@@ -1401,6 +1405,40 @@ mod tests {
             assert_eq!(bucket.bucket_id, expected_bucket_id);
             assert_eq!(bucket.count, expected_count);
         }
+    }
+
+    #[test]
+    fn terms_aggregation_u64_max_value_does_not_overflow() -> crate::Result<()> {
+        // Regression: a numeric fast field whose max value is `u64::MAX` must reach the HashMap
+        // storage without panicking on `max_column_val + 1` (the dense-storage term count), which
+        // overflows in debug builds before that fallback is chosen.
+        let mut schema_builder = Schema::builder();
+        let score_fieldtype = crate::schema::NumericOptions::default().set_fast();
+        let score_field = schema_builder.add_u64_field("score", score_fieldtype);
+        let index = Index::create_in_ram(schema_builder.build());
+        {
+            let mut index_writer = index.writer_with_num_threads(1, 20_000_000)?;
+            index_writer.set_merge_policy(Box::new(NoMergePolicy));
+            index_writer.add_document(doc!(score_field => u64::MAX))?;
+            index_writer.add_document(doc!(score_field => u64::MAX))?;
+            index_writer.add_document(doc!(score_field => 0u64))?;
+            index_writer.commit()?;
+        }
+
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "my_scores": {
+                "terms": { "field": "score" },
+            }
+        }))
+        .unwrap();
+
+        let res = exec_request(agg_req, &index)?;
+        assert_eq!(res["my_scores"]["buckets"][0]["key"], u64::MAX as f64);
+        assert_eq!(res["my_scores"]["buckets"][0]["doc_count"], 2);
+        assert_eq!(res["my_scores"]["buckets"][1]["key"], 0.0);
+        assert_eq!(res["my_scores"]["buckets"][1]["doc_count"], 1);
+        assert_eq!(res["my_scores"]["sum_other_doc_count"], 0);
+        Ok(())
     }
 
     #[test]

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -413,52 +413,57 @@ pub(crate) fn build_segment_term_collector(
     // `num_terms`. `saturating_add` guards the HashMap fallback, where `max_column_val` is a raw
     // numeric column value that can reach `u64::MAX`; term ordinals never come close.
     let num_terms = max_column_val.saturating_add(1);
-    if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC && !has_sub_aggregations {
-        let term_buckets = VecTermBuckets::<()>::new(num_terms, &mut bucket_id_provider);
-        Ok(boxed_high_card_collector(
-            term_buckets,
-            None,
-            bucket_id_provider,
-            max_column_val,
-            terms_req_data,
-        ))
-    } else if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC {
-        let term_buckets = VecTermBuckets::<BucketId>::new(num_terms, &mut bucket_id_provider);
-        let sub_agg = sub_agg_collector.map(LowCardBufferedSubAggs::new);
-        let collector: SegmentTermCollector<_, LowCardSubAggBuffer> = SegmentTermCollector {
-            parent_buckets: vec![term_buckets],
-            sub_agg,
-            bucket_id_provider,
-            max_term_id: max_column_val,
-            terms_req_data,
-        };
-        Ok(Box::new(collector))
-    } else if max_column_val < 8_000_000 && is_top_level {
-        // Build sub-aggregation blueprint (flat pairs)
-        let sub_agg = sub_agg_collector.map(BufferedSubAggs::new);
+    if is_top_level && max_column_val < MAX_NUM_TERMS_FOR_VEC {
+        // Low cardinality: dense `Vec` storage. With sub aggregations it pairs with the `LowCard`
+        // buffer, which groups docs in a per-bucket `Vec` — a better fit for the few buckets here
+        // than the partitioned `HighCard` buffer the branches below use (docs arrive in doc order,
+        // so `HighCard` would only merge consecutive same-bucket docs).
         if has_sub_aggregations {
-            let term_buckets = PagedTermMap::<BucketId>::new(num_terms, &mut bucket_id_provider);
-            Ok(boxed_high_card_collector(
-                term_buckets,
-                sub_agg,
+            let term_buckets = VecTermBuckets::<BucketId>::new(num_terms, &mut bucket_id_provider);
+            let collector: SegmentTermCollector<_, LowCardSubAggBuffer> = SegmentTermCollector {
+                parent_buckets: vec![term_buckets],
+                sub_agg: sub_agg_collector.map(LowCardBufferedSubAggs::new),
                 bucket_id_provider,
-                max_column_val,
+                max_term_id: max_column_val,
                 terms_req_data,
-            ))
+            };
+            Ok(Box::new(collector))
         } else {
-            let term_buckets = PagedTermMap::<()>::new(num_terms, &mut bucket_id_provider);
+            let term_buckets = VecTermBuckets::<()>::new(num_terms, &mut bucket_id_provider);
             Ok(boxed_high_card_collector(
                 term_buckets,
-                sub_agg,
+                None,
                 bucket_id_provider,
                 max_column_val,
                 terms_req_data,
             ))
         }
     } else {
-        // Build sub-aggregation blueprint (flat pairs)
+        // Higher cardinality: every remaining storage uses the partitioned `HighCard` sub-agg
+        // buffer, so it is built once here.
         let sub_agg = sub_agg_collector.map(BufferedSubAggs::new);
-        if has_sub_aggregations {
+        if max_column_val < 8_000_000 && is_top_level {
+            if has_sub_aggregations {
+                let term_buckets =
+                    PagedTermMap::<BucketId>::new(num_terms, &mut bucket_id_provider);
+                Ok(boxed_high_card_collector(
+                    term_buckets,
+                    sub_agg,
+                    bucket_id_provider,
+                    max_column_val,
+                    terms_req_data,
+                ))
+            } else {
+                let term_buckets = PagedTermMap::<()>::new(num_terms, &mut bucket_id_provider);
+                Ok(boxed_high_card_collector(
+                    term_buckets,
+                    sub_agg,
+                    bucket_id_provider,
+                    max_column_val,
+                    terms_req_data,
+                ))
+            }
+        } else if has_sub_aggregations {
             let term_buckets = HashMapTermBuckets::<BucketId>::default();
             Ok(boxed_high_card_collector(
                 term_buckets,

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -109,7 +109,7 @@ impl SegmentAggregationCollector for SegmentTermHistogramCollector {
             &self.counts,
         );
         let name = self.terms_req_data.name.clone();
-        let bucket = SegmentTermCollector::<VecTermBuckets, LowCardSubAggBuffer>::into_intermediate_bucket_result(
+        let bucket = SegmentTermCollector::<VecTermBuckets<BucketId>, LowCardSubAggBuffer>::into_intermediate_bucket_result(
             &self.terms_req_data,
             Some(&mut histogram as &mut dyn SegmentAggregationCollector),
             term_buckets,


### PR DESCRIPTION
If term aggregations don't have sub-aggregations, we don't need to carry BucketId(u32). 

Up to 20% faster term aggregations.

```
terms_7                                            Memory: 46.5 KB             Avg: 2.3847ms (+0.40%)      Median: 2.3847ms (+0.40%)      [2.3847ms .. 2.3847ms]      
terms_all_unique                                   Memory: 11.5 MB (-9.94%)    Avg: 4.9595ms (-20.28%)     Median: 4.9595ms (-20.28%)     [4.9595ms .. 4.9595ms]      
terms_all_unique_order_by_key                      Memory: 11.5 MB (-9.94%)    Avg: 4.8312ms (-21.48%)     Median: 4.8312ms (-21.48%)     [4.8312ms .. 4.8312ms]      
terms_150_000                                      Memory: 2.7 MB (-9.90%)     Avg: 5.5785ms (-7.98%)      Median: 5.5785ms (-7.98%)      [5.5785ms .. 5.5785ms]      
terms_many_top_1000                                Memory: 5.3 MB              Avg: 8.3336ms (-8.30%)      Median: 8.3336ms (-8.30%)      [8.3336ms .. 8.3336ms]      
terms_many_order_by_term                           Memory: 2.7 MB (-9.96%)     Avg: 4.8004ms (-8.06%)      Median: 4.8004ms (-8.06%)      [4.8004ms .. 4.8004ms]      
terms_many_with_top_hits                           Memory: 48.9 MB (-0.00%)    Avg: 82.1816ms (-5.74%)     Median: 82.1816ms (-5.74%)     [82.1816ms .. 82.1816ms]    
terms_all_unique_with_avg_sub_agg                  Memory: 54.7 MB (-0.00%)    Avg: 19.1194ms (+3.12%)     Median: 19.1194ms (+3.12%)     [19.1194ms .. 19.1194ms]    
terms_many_with_avg_sub_agg                        Memory: 13.5 MB (-0.00%)    Avg: 17.1131ms (-3.18%)     Median: 17.1131ms (-3.18%)     [17.1131ms .. 17.1131ms]    
terms_status_with_avg_sub_agg                      Memory: 92.1 KB (-0.35%)    Avg: 5.5524ms (-0.47%)      Median: 5.5524ms (-0.47%)      [5.5524ms .. 5.5524ms]      
terms_status_with_terms_zipf_1000_sub_agg          Memory: 213.2 KB            Avg: 3.9585ms (+0.85%)      Median: 3.9585ms (+0.85%)      [3.9585ms .. 3.9585ms]      
terms_zipf_1000_with_terms_status_sub_agg          Memory: 724.4 KB            Avg: 11.7054ms (-6.49%)     Median: 11.7054ms (-6.49%)     [11.7054ms .. 11.7054ms]    
terms_status_with_histogram                        Memory: 139.0 KB            Avg: 2.4437ms (+1.73%)      Median: 2.4437ms (+1.73%)      [2.4437ms .. 2.4437ms]      
terms_status_with_date_histogram                   Memory: 145.9 KB            Avg: 2.3403ms (-1.91%)      Median: 2.3403ms (-1.91%)      [2.3403ms .. 2.3403ms]      
terms_status_with_date_histogram_hard_bounds       Memory: 145.4 KB            Avg: 2.4708ms (-1.25%)      Median: 2.4708ms (-1.25%)      [2.4708ms .. 2.4708ms]      
terms_zipf_1000                                    Memory: 75.8 KB             Avg: 2.1928ms (-0.24%)      Median: 2.1928ms (-0.24%)      [2.1928ms .. 2.1928ms]      
terms_zipf_1000_with_histogram                     Memory: 1.2 MB              Avg: 20.1602ms (-0.68%)     Median: 20.1602ms (-0.68%)     [20.1602ms .. 20.1602ms]    
terms_zipf_1000_with_avg_sub_agg                   Memory: 472.7 KB            Avg: 8.6617ms (-5.95%)      Median: 8.6617ms (-5.95%)      [8.6617ms .. 8.6617ms]      
terms_many_json_mixed_type_with_avg_sub_agg        Memory: 17.9 MB             Avg: 27.6967ms (-4.70%)     Median: 27.6967ms (-4.70%)     [27.6967ms .. 27.6967ms]    
terms_status_with_cardinality_agg                  Memory: 94.2 KB (+0.34%)    Avg: 3.1847ms (-2.56%)      Median: 3.1847ms (-2.56%)      [3.1847ms .. 3.1847ms]      
```