### PR TITLE
Convert BMW implementations into publicly-available PruningScorers

### DIFF
--- a/src/indexer/delete_queue.rs
+++ b/src/indexer/delete_queue.rs
@@ -245,12 +245,21 @@ mod tests {
 
     use super::{DeleteOperation, DeleteQueue};
     use crate::index::SegmentReader;
-    use crate::query::{Explanation, Scorer, Weight};
+    use crate::query::{Explanation, PruningScorer, Scorer, Weight};
     use crate::{DocId, Score};
 
     struct DummyWeight;
     impl Weight for DummyWeight {
         fn scorer(&self, _reader: &SegmentReader, _boost: Score) -> crate::Result<Box<dyn Scorer>> {
+            Err(crate::TantivyError::InternalError("dummy impl".to_owned()))
+        }
+
+        fn pruning_scorer(
+            &self,
+            _reader: &SegmentReader,
+            _boost: Score,
+            _init_threshold: Score,
+        ) -> crate::Result<Box<dyn PruningScorer>> {
             Err(crate::TantivyError::InternalError("dummy impl".to_owned()))
         }
 

--- a/src/query/boolean_query/block_wand_intersection.rs
+++ b/src/query/boolean_query/block_wand_intersection.rs
@@ -1,7 +1,21 @@
+use crate::fieldnorm::FieldNormReader;
 use crate::postings::compression::COMPRESSION_BLOCK_SIZE;
+use crate::query::scorer::PruningScorer;
 use crate::query::term_query::TermScorer;
-use crate::query::Scorer;
+use crate::query::{Bm25Weight, Scorer};
 use crate::{DocId, DocSet, Score, TERMINATED};
+
+#[cfg(test)]
+pub(crate) fn block_wand_intersection(
+    scorers: Vec<TermScorer>,
+    threshold: Score,
+    callback: &mut dyn FnMut(DocId, Score) -> Score,
+) {
+    use crate::query::weight::for_each_pruning_scorer;
+
+    let mut scorer = BlockWandIntersectionScorer::new(scorers, threshold);
+    for_each_pruning_scorer(&mut scorer, callback);
+}
 
 /// Block-max pruning for top-K over intersection of term scorers.
 ///
@@ -16,165 +30,250 @@ use crate::{DocId, DocSet, Score, TERMINATED};
 /// # Preconditions
 /// - `scorers` has at least 2 elements
 /// - All scorers read frequencies (`FreqReadingOption::ReadFreq`)
-pub(crate) fn block_wand_intersection(
-    mut scorers: Vec<TermScorer>,
-    mut threshold: Score,
-    callback: &mut dyn FnMut(DocId, Score) -> Score,
-) {
-    assert!(scorers.len() >= 2);
+pub struct BlockWandIntersectionScorer {
+    leader: TermScorer,
+    secondaries: Vec<TermScorer>,
 
-    // Sort by cost (ascending). scorers[0] becomes the "leader" (rarest term).
-    scorers.sort_by_key(TermScorer::size_hint);
+    maximum_possible_score: Score,
+    secondary_block_max_scores: Box<[f32]>,
+    secondary_suffix_block_max: Box<[f32]>,
+    fieldnorm_reader: FieldNormReader,
+    bm25_weight: Bm25Weight,
 
-    let (leader, secondaries) = scorers.split_first_mut().unwrap();
+    candidate_doc_ids: [u32; COMPRESSION_BLOCK_SIZE],
+    candidate_scores: [f32; COMPRESSION_BLOCK_SIZE],
+    num_candidates: usize,
+    candidate_idx: usize,
 
-    // Precompute global max scores for early termination checks.
-    let leader_max_score: Score = leader.max_score();
-    let secondaries_global_max_sum: Score = secondaries.iter().map(TermScorer::max_score).sum();
+    threshold: Score,
+    current: (DocId, Score),
+    internal_doc: DocId,
+    window_end: DocId,
+}
+impl BlockWandIntersectionScorer {
+    /// Construction positions `current` on the first match
+    pub fn new(mut scorers: Vec<TermScorer>, threshold: Score) -> Self {
+        assert!(scorers.len() >= 2);
 
-    // Early exit: no document can possibly beat the threshold.
-    if leader_max_score + secondaries_global_max_sum <= threshold {
-        return;
+        // Sort by cost (ascending). scorers[0] becomes the "leader" (rarest term).
+        scorers.sort_by_key(TermScorer::size_hint);
+        let leader = scorers.remove(0);
+        let secondaries = scorers;
+        let secondaries_len = secondaries.len();
+
+        let secondaries_global_max_sum: Score = secondaries.iter().map(TermScorer::max_score).sum();
+        let maximum_possible_score = leader.max_score() + secondaries_global_max_sum;
+
+        // Borrow fieldnorm reader and BM25 weight before the main loop.
+        // These are immutable references to disjoint fields from block_cursor,
+        // but Rust's borrow checker can't see through method calls, so we
+        // extract them once upfront.
+        let fieldnorm_reader = leader.fieldnorm_reader().clone();
+        let bm25_weight = leader.bm25_weight().clone();
+
+        let internal_doc = leader.doc();
+
+        let mut scorer = Self {
+            leader,
+            secondaries,
+            maximum_possible_score,
+            secondary_block_max_scores: vec![0.0f32; secondaries_len].into_boxed_slice(),
+            secondary_suffix_block_max: vec![0.0f32; secondaries_len].into_boxed_slice(),
+            fieldnorm_reader,
+            bm25_weight,
+            candidate_doc_ids: [0u32; COMPRESSION_BLOCK_SIZE],
+            candidate_scores: [0f32; COMPRESSION_BLOCK_SIZE],
+            num_candidates: 0,
+            candidate_idx: 0,
+            threshold,
+            current: (0, Score::MIN),
+            internal_doc,
+            window_end: 0,
+        };
+        scorer.advance();
+        scorer
     }
 
-    // Borrow fieldnorm reader and BM25 weight before the main loop.
-    // These are immutable references to disjoint fields from block_cursor,
-    // but Rust's borrow checker can't see through method calls, so we
-    // extract them once upfront.
-    let fieldnorm_reader = leader.fieldnorm_reader().clone();
-    let bm25_weight = leader.bm25_weight().clone();
-
-    let mut doc = leader.doc();
-
-    let mut secondary_block_max_scores: Box<[f32]> =
-        vec![0.0f32; secondaries.len()].into_boxed_slice();
-    let mut secondary_suffix_block_max: Box<[f32]> =
-        vec![0.0f32; secondaries.len()].into_boxed_slice();
-
-    while doc < TERMINATED {
-        // --- Phase 1: Block-level pruning ---
-        //
-        // Position all skip readers on the block containing `doc`.
-        // seek_block is cheap: it only advances the skip reader, no block decompression.
-        leader.seek_block(doc);
-        let leader_block_max: Score = leader.block_max_score();
-
-        // Compute the window end as the minimum last_doc_in_block across all scorers.
-        // This ensures the block_max values are valid for all docs in [doc, window_end].
-        // Different scorers have independently aligned blocks, so we must use the
-        // smallest window where all block_max values hold.
-        let mut window_end: DocId = leader.last_doc_in_block();
-
-        let mut secondary_block_max_sum: Score = 0.0;
-        let num_secondaries = secondaries.len();
-        for (idx, secondary) in secondaries.iter_mut().enumerate() {
-            secondary.block_cursor().seek_block(doc);
-            if !secondary.block_cursor().has_remaining_docs() {
-                return;
-            }
-            window_end = window_end.min(secondary.last_doc_in_block());
-            let bms = secondary.block_max_score();
-            secondary_block_max_scores[idx] = bms;
-            secondary_block_max_sum += bms;
-        }
-
-        if leader_block_max + secondary_block_max_sum <= threshold {
-            // The entire window cannot beat the threshold. Skip past it.
-            doc = window_end + 1;
-            continue;
-        }
-
-        // --- Phase 2: Batch processing within the window ---
-        //
-        // Score-first approach: decode the leader's block, filter by threshold,
-        // then check intersection membership only for survivors. This avoids expensive
-        // secondary seeks for docs that can't beat the threshold.
-        let block_cursor = leader.block_cursor();
-        // seek loads the block and returns the in-block index of the first doc >= `doc`.
-        let start_idx = block_cursor.seek(doc);
-
-        // Use the branchless binary search on the doc decoder to find the first
-        // index past window_end.
-        let end_idx = block_cursor
-            .doc_decoder
-            .seek_within_block(window_end + 1)
-            .min(block_cursor.block_len());
-
-        let block_docs = &block_cursor.doc_decoder.output_array()[start_idx..end_idx];
-        let block_freqs = &block_cursor.freq_output_array()[start_idx..end_idx];
-
-        // Pass 1: Batch-compute leader BM25 scores and branchlessly filter
-        // candidates that can't beat the threshold.
-        //
-        // The trick: always write to the buffer at `num_candidates`, then
-        // conditionally advance the count. The compiler can turn this into
-        // a cmov instead of a branch, avoiding misprediction costs.
-        let score_threshold = threshold - secondary_block_max_sum;
-        let mut candidate_doc_ids = [0u32; COMPRESSION_BLOCK_SIZE];
-        let mut candidate_scores = [0.0f32; COMPRESSION_BLOCK_SIZE];
-        let mut num_candidates = 0usize;
-
-        for (candidate_doc, term_freq) in
-            block_docs.iter().copied().zip(block_freqs.iter().copied())
-        {
-            let fieldnorm_id = fieldnorm_reader.fieldnorm_id(candidate_doc);
-            let leader_score = bm25_weight.score(fieldnorm_id, term_freq);
-            candidate_doc_ids[num_candidates] = candidate_doc;
-            candidate_scores[num_candidates] = leader_score;
-            num_candidates += (leader_score > score_threshold) as usize;
-        }
-
-        // Precompute suffix sums: suffix[i] = sum of block_max for secondaries[i+1..].
-        // Used in Phase 2 to prune candidates that can't beat threshold even with
-        // remaining secondaries contributing their block_max.
-        if num_candidates == 0 {
-            doc = window_end + 1;
-            continue;
-        }
-
-        let mut running = 0.0f32;
-        for idx in (0..num_secondaries).rev() {
-            secondary_suffix_block_max[idx] = running;
-            running += secondary_block_max_scores[idx];
-        }
-
+    fn handle_candidates(&mut self) -> Option<DocId> {
         // Pass 2: Check intersection membership only for survivors.
         // score_threshold may be stale (threshold can increase from callbacks),
         // but that's conservative — we may check a few extra candidates, never miss one.
-        'next_candidate: for candidate_idx in 0..num_candidates {
-            let candidate_doc = candidate_doc_ids[candidate_idx];
-            let mut total_score: Score = candidate_scores[candidate_idx];
+        'next_candidate: while self.candidate_idx < self.num_candidates {
+            let candidate_doc = self.candidate_doc_ids[self.candidate_idx];
+            let mut total_score: Score = self.candidate_scores[self.candidate_idx];
 
-            for (secondary_idx, secondary) in secondaries.iter_mut().enumerate() {
+            for (secondary_idx, secondary) in self.secondaries.iter_mut().enumerate() {
                 // If a previous candidate already advanced this secondary past
                 // candidate_doc, the candidate can't be in the intersection.
                 if secondary.doc() > candidate_doc {
+                    self.candidate_idx += 1;
                     continue 'next_candidate;
                 }
                 let seek_result = secondary.seek(candidate_doc);
                 if seek_result != candidate_doc {
+                    self.candidate_idx += 1;
                     continue 'next_candidate;
                 }
                 total_score += secondary.score();
 
                 // Prune: even if all remaining secondaries score at their block max,
                 // can we still beat the threshold?
-                if total_score + secondary_suffix_block_max[secondary_idx] <= threshold {
+                if total_score + self.secondary_suffix_block_max[secondary_idx] <= self.threshold {
+                    self.candidate_idx += 1;
                     continue 'next_candidate;
                 }
             }
 
             // All secondaries matched.
-            if total_score > threshold {
-                threshold = callback(candidate_doc, total_score);
+            if total_score > self.threshold {
+                self.current = (candidate_doc, total_score);
+                self.candidate_idx += 1;
+                return Some(candidate_doc);
+            }
+            self.candidate_idx += 1;
+        }
+        None
+    }
+}
+impl Scorer for BlockWandIntersectionScorer {
+    #[inline]
+    fn score(&mut self) -> Score {
+        self.current.1
+    }
+}
+impl PruningScorer for BlockWandIntersectionScorer {
+    #[inline]
+    fn set_threshold(&mut self, score: Score) {
+        self.threshold = score;
+    }
+}
+impl DocSet for BlockWandIntersectionScorer {
+    fn advance(&mut self) -> DocId {
+        if self.maximum_possible_score <= self.threshold {
+            self.current = (TERMINATED, Score::MIN);
+            return TERMINATED;
+        }
 
-                if leader_max_score + secondaries_global_max_sum <= threshold {
-                    return;
-                }
+        // check for leftover candidates to handle
+        if self.num_candidates > 0 {
+            if let Some(doc_id) = self.handle_candidates() {
+                return doc_id;
+            } else {
+                // no remaining candidates, so reset and advance the internal doc
+                self.num_candidates = 0;
+                self.internal_doc = self.window_end + 1;
             }
         }
 
-        doc = window_end + 1;
+        while self.internal_doc < TERMINATED {
+            // --- Phase 1: Block-level pruning ---
+            //
+            // Position all skip readers on the block containing `doc`.
+            // seek_block is cheap: it only advances the skip reader, no block decompression.
+            self.leader.seek_block(self.internal_doc);
+            let leader_block_max: Score = self.leader.block_max_score();
+
+            // Compute the window end as the minimum last_doc_in_block across all scorers.
+            // This ensures the block_max values are valid for all docs in [doc, window_end].
+            // Different scorers have independently aligned blocks, so we must use the
+            // smallest window where all block_max values hold.
+            self.window_end = self.leader.last_doc_in_block();
+
+            let mut secondary_block_max_sum: Score = 0.0;
+            let num_secondaries = self.secondaries.len();
+            for (idx, secondary) in self.secondaries.iter_mut().enumerate() {
+                secondary.block_cursor().seek_block(self.internal_doc);
+                if !secondary.block_cursor().has_remaining_docs() {
+                    self.current = (TERMINATED, Score::MIN);
+                    return TERMINATED;
+                }
+                self.window_end = self.window_end.min(secondary.last_doc_in_block());
+                let bms = secondary.block_max_score();
+                self.secondary_block_max_scores[idx] = bms;
+                secondary_block_max_sum += bms;
+            }
+
+            if leader_block_max + secondary_block_max_sum <= self.threshold {
+                // The entire window cannot beat the threshold. Skip past it.
+                self.internal_doc = self.window_end + 1;
+                continue;
+            }
+
+            // --- Phase 2: Batch processing within the window ---
+            //
+            // Score-first approach: decode the leader's block, filter by threshold,
+            // then check intersection membership only for survivors. This avoids expensive
+            // secondary seeks for docs that can't beat the threshold.
+            let block_cursor = self.leader.block_cursor();
+            // seek loads the block and returns the in-block index of the first doc >= `doc`.
+            let start_idx = block_cursor.seek(self.internal_doc);
+
+            // Use the branchless binary search on the doc decoder to find the first
+            // index past window_end.
+            let end_idx = block_cursor
+                .doc_decoder
+                .seek_within_block(self.window_end + 1)
+                .min(block_cursor.block_len());
+
+            let block_docs = &block_cursor.doc_decoder.output_array()[start_idx..end_idx];
+            let block_freqs = &block_cursor.freq_output_array()[start_idx..end_idx];
+
+            // Pass 1: Batch-compute leader BM25 scores and branchlessly filter
+            // candidates that can't beat the threshold.
+            //
+            // The trick: always write to the buffer at `num_candidates`, then
+            // conditionally advance the count. The compiler can turn this into
+            // a cmov instead of a branch, avoiding misprediction costs.
+            let score_threshold = self.threshold - secondary_block_max_sum;
+
+            let mut num_candidates = 0usize;
+            for (candidate_doc, term_freq) in
+                block_docs.iter().copied().zip(block_freqs.iter().copied())
+            {
+                let fieldnorm_id = self.fieldnorm_reader.fieldnorm_id(candidate_doc);
+                let leader_score = self.bm25_weight.score(fieldnorm_id, term_freq);
+                self.candidate_doc_ids[num_candidates] = candidate_doc;
+                self.candidate_scores[num_candidates] = leader_score;
+                num_candidates += (leader_score > score_threshold) as usize;
+            }
+            self.num_candidates = num_candidates;
+            self.candidate_idx = 0;
+
+            // Precompute suffix sums: suffix[i] = sum of block_max for secondaries[i+1..].
+            // Used in Phase 2 to prune candidates that can't beat threshold even with
+            // remaining secondaries contributing their block_max.
+            if self.num_candidates == 0 {
+                self.internal_doc = self.window_end + 1;
+                continue;
+            }
+
+            let mut running = 0.0f32;
+            for idx in (0..num_secondaries).rev() {
+                self.secondary_suffix_block_max[idx] = running;
+                running += self.secondary_block_max_scores[idx];
+            }
+
+            if let Some(doc_id) = self.handle_candidates() {
+                return doc_id;
+            }
+            // no candidates left, reset and advance internal doc
+            self.num_candidates = 0;
+            self.internal_doc = self.window_end + 1;
+        }
+
+        self.current = (TERMINATED, Score::MIN);
+        TERMINATED
+    }
+
+    #[inline]
+    fn doc(&self) -> DocId {
+        self.current.0
+    }
+
+    /// The number of elements yielded by a PruningScorer depends on the threshold and cannot be
+    /// computed ahead of time, so just defer to the leader, as it will be the smallest.
+    fn size_hint(&self) -> u32 {
+        self.leader.size_hint()
     }
 }
 

--- a/src/query/boolean_query/block_wand_union.rs
+++ b/src/query/boolean_query/block_wand_union.rs
@@ -169,33 +169,6 @@ pub fn block_wand_single_scorer(
     for_each_pruning_scorer(&mut scorer, callback);
 }
 
-struct TermScorerWithMaxScore {
-    scorer: Box<TermScorer>,
-    max_score: Score,
-}
-
-impl From<TermScorer> for TermScorerWithMaxScore {
-    fn from(scorer: TermScorer) -> Self {
-        let scorer = Box::new(scorer);
-        let max_score = scorer.max_score();
-        TermScorerWithMaxScore { scorer, max_score }
-    }
-}
-
-impl Deref for TermScorerWithMaxScore {
-    type Target = TermScorer;
-
-    fn deref(&self) -> &Self::Target {
-        &self.scorer
-    }
-}
-
-impl DerefMut for TermScorerWithMaxScore {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.scorer
-    }
-}
-
 /// Implements the WAND (Weak AND) algorithm for dynamic pruning
 /// described in the paper "Faster Top-k Document Retrieval Using Block-Max Indexes".
 /// Link: <http://engineering.nyu.edu/~suel/papers/bmw.pdf>
@@ -416,6 +389,33 @@ impl DocSet for BlockWandSingleScorer {
     /// computed ahead of time, so just defer to the internal scorer
     fn size_hint(&self) -> u32 {
         self.scorer.size_hint()
+    }
+}
+
+struct TermScorerWithMaxScore {
+    scorer: Box<TermScorer>,
+    max_score: Score,
+}
+
+impl From<TermScorer> for TermScorerWithMaxScore {
+    fn from(scorer: TermScorer) -> Self {
+        let scorer = Box::new(scorer);
+        let max_score = scorer.max_score();
+        TermScorerWithMaxScore { scorer, max_score }
+    }
+}
+
+impl Deref for TermScorerWithMaxScore {
+    type Target = TermScorer;
+
+    fn deref(&self) -> &Self::Target {
+        &self.scorer
+    }
+}
+
+impl DerefMut for TermScorerWithMaxScore {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.scorer
     }
 }
 

--- a/src/query/boolean_query/block_wand_union.rs
+++ b/src/query/boolean_query/block_wand_union.rs
@@ -1,6 +1,9 @@
 use std::ops::{Deref, DerefMut};
 
+use crate::query::scorer::PruningScorer;
 use crate::query::term_query::TermScorer;
+#[cfg(test)]
+use crate::query::weight::for_each_pruning_scorer;
 use crate::query::Scorer;
 use crate::{DocId, DocSet, Score, TERMINATED};
 
@@ -142,151 +145,277 @@ fn advance_all_scorers_on_pivot(term_scorers: &mut Vec<TermScorerWithMaxScore>, 
     term_scorers.sort_by_key(|scorer| scorer.doc());
 }
 
-/// Implements the WAND (Weak AND) algorithm for dynamic pruning
-/// described in the paper "Faster Top-k Document Retrieval Using Block-Max Indexes".
-/// Link: <http://engineering.nyu.edu/~suel/papers/bmw.pdf>
+#[cfg(test)]
 pub fn block_wand(
     mut scorers: Vec<TermScorer>,
-    mut threshold: Score,
+    threshold: Score,
     callback: &mut dyn FnMut(u32, Score) -> Score,
 ) {
-    scorers.retain(|scorer| scorer.doc() < TERMINATED);
     if scorers.len() == 1 {
         let scorer = scorers.pop().unwrap();
         return block_wand_single_scorer(scorer, threshold, callback);
     }
-    let mut scorers: Vec<TermScorerWithMaxScore> = scorers
-        .iter_mut()
-        .map(TermScorerWithMaxScore::from)
-        .collect();
-    // At this point we need to ensure that the scorers are sorted!
-    scorers.sort_by_key(|scorer| scorer.doc());
-    while let Some((before_pivot_len, pivot_len, pivot_doc)) =
-        find_pivot_doc(&scorers[..], threshold)
-    {
-        debug_assert!(scorers.iter().map(|scorer| scorer.doc()).is_sorted());
-        debug_assert_ne!(pivot_doc, TERMINATED);
-        debug_assert!(before_pivot_len < pivot_len);
-
-        let block_max_score_upperbound: Score = scorers[..pivot_len]
-            .iter_mut()
-            .map(|scorer| {
-                scorer.seek_block(pivot_doc);
-                scorer.block_max_score()
-            })
-            .sum();
-
-        // Beware after shallow advance, skip readers can be in advance compared to
-        // the segment posting lists.
-        //
-        // `block_segment_postings.load_block()` need to be called separately.
-        if block_max_score_upperbound <= threshold {
-            // Block max condition was not reached
-            // We could get away by simply advancing the scorers to DocId + 1 but it would
-            // be inefficient. The optimization requires proper explanation and was
-            // isolated in a different function.
-            block_max_was_too_low_advance_one_scorer(&mut scorers, pivot_len);
-            continue;
-        }
-
-        // Block max condition is observed.
-        //
-        // Let's try and advance all scorers before the pivot to the pivot.
-        if !align_scorers(&mut scorers, pivot_doc, before_pivot_len) {
-            // At least of the scorer does not contain the pivot.
-            //
-            // Let's stop scoring this pivot and go through the pivot selection again.
-            // Note that the current pivot is not necessarily a bad candidate and it
-            // may be picked again.
-            continue;
-        }
-
-        // At this point, all scorers are positioned on the doc.
-        let score = scorers[..pivot_len]
-            .iter_mut()
-            .map(|scorer| scorer.score())
-            .sum();
-
-        if score > threshold {
-            threshold = callback(pivot_doc, score);
-        }
-        // let's advance all of the scorers that are currently positioned on the pivot.
-        advance_all_scorers_on_pivot(&mut scorers, pivot_len);
-    }
+    let mut scorer = BlockWandUnionScorer::new(scorers, threshold);
+    for_each_pruning_scorer(&mut scorer, callback);
 }
 
-/// Specialized version of [`block_wand`] for a single scorer.
-/// In this case, the algorithm is simple, readable and faster (~ x3)
-/// than the generic algorithm.
-/// The algorithm behaves as follows:
-/// - While we don't hit the end of the docset:
-///   - While the block max score is under the `threshold`, go to the next block.
-///   - On a block, advance until the end and execute `callback` when the doc score is greater or
-///     equal to the `threshold`.
+#[cfg(test)]
 pub fn block_wand_single_scorer(
-    mut scorer: TermScorer,
-    mut threshold: Score,
+    scorer: TermScorer,
+    threshold: Score,
     callback: &mut dyn FnMut(u32, Score) -> Score,
 ) {
-    let mut doc = scorer.doc();
-    loop {
-        // We position the scorer on a block that can reach
-        // the threshold.
-        while scorer.block_max_score() <= threshold {
-            let last_doc_in_block = scorer.last_doc_in_block();
-            if last_doc_in_block == TERMINATED {
-                return;
-            }
-            doc = last_doc_in_block + 1;
-            scorer.seek_block(doc);
-        }
-        // Seek will effectively load that block.
-        doc = scorer.seek(doc);
-        if doc == TERMINATED {
-            break;
-        }
-        loop {
-            let score = scorer.score();
-            if score > threshold {
-                threshold = callback(doc, score);
-            }
-            debug_assert!(doc <= scorer.last_doc_in_block());
-            if doc == scorer.last_doc_in_block() {
-                break;
-            }
-            doc = scorer.advance();
-            if doc == TERMINATED {
-                return;
-            }
-        }
-        doc += 1;
-        scorer.seek_block(doc);
-    }
+    let mut scorer = BlockWandSingleScorer::new(scorer, threshold);
+    for_each_pruning_scorer(&mut scorer, callback);
 }
 
-struct TermScorerWithMaxScore<'a> {
-    scorer: &'a mut TermScorer,
+struct TermScorerWithMaxScore {
+    scorer: Box<TermScorer>,
     max_score: Score,
 }
 
-impl<'a> From<&'a mut TermScorer> for TermScorerWithMaxScore<'a> {
-    fn from(scorer: &'a mut TermScorer) -> Self {
+impl From<TermScorer> for TermScorerWithMaxScore {
+    fn from(scorer: TermScorer) -> Self {
+        let scorer = Box::new(scorer);
         let max_score = scorer.max_score();
         TermScorerWithMaxScore { scorer, max_score }
     }
 }
 
-impl Deref for TermScorerWithMaxScore<'_> {
+impl Deref for TermScorerWithMaxScore {
     type Target = TermScorer;
 
     fn deref(&self) -> &Self::Target {
-        self.scorer
+        &self.scorer
     }
 }
 
-impl DerefMut for TermScorerWithMaxScore<'_> {
+impl DerefMut for TermScorerWithMaxScore {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.scorer
+        &mut self.scorer
+    }
+}
+
+/// Implements the WAND (Weak AND) algorithm for dynamic pruning
+/// described in the paper "Faster Top-k Document Retrieval Using Block-Max Indexes".
+/// Link: <http://engineering.nyu.edu/~suel/papers/bmw.pdf>
+///
+/// # Preconditions
+/// - All scorers read frequencies (`FreqReadingOption::ReadFreq`)
+pub struct BlockWandUnionScorer {
+    scorers: Vec<TermScorerWithMaxScore>,
+    threshold: Score,
+    current: (DocId, Score),
+}
+impl BlockWandUnionScorer {
+    /// Construction positions `current` on the first match
+    pub fn new(mut scorers: Vec<TermScorer>, threshold: Score) -> Self {
+        debug_assert!(scorers.len() > 1);
+        scorers.retain(|scorer| scorer.doc() < TERMINATED);
+        let mut scorers: Vec<TermScorerWithMaxScore> = scorers
+            .into_iter()
+            .map(TermScorerWithMaxScore::from)
+            .collect();
+        // At this point we need to ensure that the scorers are sorted!
+        scorers.sort_by_key(|scorer| scorer.doc());
+
+        let mut scorer = Self {
+            scorers,
+            threshold,
+            current: (0, Score::MIN),
+        };
+        // advance to fill current with actual (doc id, score)
+        scorer.advance();
+        scorer
+    }
+}
+impl Scorer for BlockWandUnionScorer {
+    #[inline]
+    fn score(&mut self) -> Score {
+        self.current.1
+    }
+}
+impl PruningScorer for BlockWandUnionScorer {
+    #[inline]
+    fn set_threshold(&mut self, score: Score) {
+        self.threshold = score;
+    }
+}
+impl DocSet for BlockWandUnionScorer {
+    fn advance(&mut self) -> DocId {
+        // hoist threshold into a local while we loop to avoid going to memory
+        let threshold = self.threshold;
+        while let Some((before_pivot_len, pivot_len, pivot_doc)) =
+            find_pivot_doc(&self.scorers[..], threshold)
+        {
+            debug_assert!(self.scorers.iter().map(|scorer| scorer.doc()).is_sorted());
+            debug_assert_ne!(pivot_doc, TERMINATED);
+            debug_assert!(before_pivot_len < pivot_len);
+
+            let block_max_score_upperbound: Score = self.scorers[..pivot_len]
+                .iter_mut()
+                .map(|scorer| {
+                    scorer.seek_block(pivot_doc);
+                    scorer.block_max_score()
+                })
+                .sum();
+
+            // Beware after shallow advance, skip readers can be in advance compared to
+            // the segment posting lists.
+            //
+            // `block_segment_postings.load_block()` need to be called separately.
+            if block_max_score_upperbound <= threshold {
+                // Block max condition was not reached
+                // We could get away by simply advancing the scorers to DocId + 1 but it would
+                // be inefficient. The optimization requires proper explanation and was
+                // isolated in a different function.
+                block_max_was_too_low_advance_one_scorer(&mut self.scorers, pivot_len);
+                continue;
+            }
+
+            // Block max condition is observed.
+            //
+            // Let's try and advance all scorers before the pivot to the pivot.
+            if !align_scorers(&mut self.scorers, pivot_doc, before_pivot_len) {
+                // At least of the scorer does not contain the pivot.
+                //
+                // Let's stop scoring this pivot and go through the pivot selection again.
+                // Note that the current pivot is not necessarily a bad candidate and it
+                // may be picked again.
+                continue;
+            }
+
+            // At this point, all scorers are positioned on the doc.
+            let score = self.scorers[..pivot_len]
+                .iter_mut()
+                .map(|scorer| scorer.score())
+                .sum();
+
+            if score > threshold {
+                self.current = (pivot_doc, score);
+                // let's advance all of the scorers that are currently positioned on the pivot.
+                advance_all_scorers_on_pivot(&mut self.scorers, pivot_len);
+                return pivot_doc;
+            } else {
+                // let's advance all of the scorers that are currently positioned on the pivot.
+                advance_all_scorers_on_pivot(&mut self.scorers, pivot_len);
+            }
+        }
+
+        self.current = (TERMINATED, Score::MIN);
+        TERMINATED
+    }
+
+    #[inline]
+    fn doc(&self) -> DocId {
+        self.current.0
+    }
+
+    /// The number of elements returned by a PruningScorer depends on the threshold and cannot be
+    /// computed ahead of time, so just defer to the largest internal scorer
+    fn size_hint(&self) -> u32 {
+        self.scorers
+            .iter()
+            .map(|s| s.scorer.size_hint())
+            .max()
+            .unwrap_or(0u32)
+    }
+}
+
+/// Specialized version of [`BlockWandUnionScorer`] for a single scorer.
+/// In this case, the algorithm is simple, readable and faster (~ x3)
+/// than the generic algorithm.
+/// The algorithm behaves as follows:
+/// - While we don't hit the end of the docset:
+///   - While the block max score is under the `threshold`, go to the next block.
+///   - On a block, advance until the end and execute return the current doc when the doc score is
+///     greater or equal to the `threshold`.
+pub struct BlockWandSingleScorer {
+    scorer: TermScorer,
+    threshold: Score,
+    current: (DocId, Score),
+}
+impl BlockWandSingleScorer {
+    /// Construction positions `current` on the first match
+    pub fn new(term_scorer: TermScorer, threshold: Score) -> Self {
+        let mut scorer = Self {
+            scorer: term_scorer,
+            threshold,
+            current: (0, Score::MIN),
+        };
+        // advance to fill current
+        scorer.advance();
+        scorer
+    }
+}
+impl Scorer for BlockWandSingleScorer {
+    #[inline]
+    fn score(&mut self) -> Score {
+        self.current.1
+    }
+}
+impl PruningScorer for BlockWandSingleScorer {
+    #[inline]
+    fn set_threshold(&mut self, score: Score) {
+        self.threshold = score;
+    }
+}
+
+impl DocSet for BlockWandSingleScorer {
+    fn advance(&mut self) -> DocId {
+        let mut doc = self.scorer.doc();
+        // hoist threshold to a local so we avoid going to memory in the loop
+        let threshold = self.threshold;
+        'outer: loop {
+            // We position the scorer on a block that can reach
+            // the threshold.
+            while self.scorer.block_max_score() <= threshold {
+                let last_doc_in_block = self.scorer.last_doc_in_block();
+                if last_doc_in_block == TERMINATED {
+                    self.current = (TERMINATED, Score::MIN);
+                    return TERMINATED;
+                }
+                doc = last_doc_in_block + 1;
+                self.scorer.seek_block(doc);
+            }
+            // Seek will effectively load that block.
+            doc = self.scorer.seek(doc);
+            if doc == TERMINATED {
+                self.current = (TERMINATED, Score::MIN);
+                return TERMINATED;
+            }
+            loop {
+                let score = self.scorer.score();
+                if score > threshold {
+                    self.current = (doc, score);
+                    self.scorer.advance();
+                    break 'outer;
+                }
+                debug_assert!(doc <= self.scorer.last_doc_in_block());
+                if doc == self.scorer.last_doc_in_block() {
+                    break;
+                }
+                doc = self.scorer.advance();
+                if doc == TERMINATED {
+                    self.current = (TERMINATED, Score::MIN);
+                    return TERMINATED;
+                }
+            }
+            doc += 1;
+            self.scorer.seek_block(doc);
+        }
+        self.doc()
+    }
+
+    #[inline]
+    fn doc(&self) -> DocId {
+        self.current.0
+    }
+
+    /// The number of elements returned by a PruningScorer depends on the threshold and cannot be
+    /// computed ahead of time, so just defer to the internal scorer
+    fn size_hint(&self) -> u32 {
+        self.scorer.size_hint()
     }
 }
 

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -1,18 +1,22 @@
 use std::collections::HashMap;
 
-use crate::docset::COLLECT_BLOCK_BUFFER_LEN;
+use crate::docset::{DocSet, COLLECT_BLOCK_BUFFER_LEN};
 use crate::index::SegmentReader;
 use crate::postings::FreqReadingOption;
+use crate::query::boolean_query::{
+    BlockWandIntersectionScorer, BlockWandSingleScorer, BlockWandUnionScorer,
+};
 use crate::query::disjunction::Disjunction;
 use crate::query::explanation::does_not_match;
 use crate::query::score_combiner::{DoNothingCombiner, ScoreCombiner};
+use crate::query::scorer::BasicPruningScorer;
 use crate::query::term_query::TermScorer;
 use crate::query::weight::{for_each_docset_buffered, for_each_pruning_scorer, for_each_scorer};
 use crate::query::{
     intersect_scorers, AllScorer, BufferedUnionScorer, EmptyScorer, Exclude, Explanation, Occur,
     RequiredOptionalScorer, Scorer, Weight,
 };
-use crate::{DocId, Score};
+use crate::{DocId, Score, TERMINATED};
 
 enum SpecializedScorer {
     TermUnion(Vec<TermScorer>),
@@ -480,6 +484,36 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         }
     }
 
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn crate::query::scorer::PruningScorer>> {
+        let scorer = self.complex_scorer(reader, boost, &self.score_combiner_fn)?;
+        match scorer {
+            SpecializedScorer::TermUnion(mut scorers) => {
+                // Drop already-exhausted scorers so a lone survivor uses the
+                // (~3x faster) single-scorer specialization
+                scorers.retain(|scorer| scorer.doc() < TERMINATED);
+                match scorers.len() {
+                    0 => Ok(Box::new(EmptyScorer)),
+                    1 => Ok(Box::new(BlockWandSingleScorer::new(
+                        scorers.pop().unwrap(),
+                        init_threshold,
+                    ))),
+                    _ => Ok(Box::new(BlockWandUnionScorer::new(scorers, init_threshold))),
+                }
+            }
+            SpecializedScorer::TermIntersection(scorers) => Ok(Box::new(
+                BlockWandIntersectionScorer::new(scorers, init_threshold),
+            )),
+            SpecializedScorer::Other(scorer) => {
+                Ok(Box::new(BasicPruningScorer::new(scorer, init_threshold)))
+            }
+        }
+    }
+
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
         if scorer.seek(doc) != doc {
@@ -533,6 +567,57 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         Ok(())
     }
 
+    /// Calls `callback` with all of the `(doc, score)` for which score
+    /// is exceeding a given threshold.
+    ///
+    /// This method is useful for the TopDocs collector.
+    /// For all docsets, the blanket implementation has the benefit
+    /// of prefiltering (doc, score) pairs, avoiding the
+    /// virtual dispatch cost.
+    ///
+    /// More importantly, it makes it possible for scorers to implement
+    /// important optimization (e.g. BlockWAND).
+    ///
+    /// Overrides the blanket implementation to drive the concrete pruning scorer
+    /// directly, rather than through a `Box<dyn PruningScorer>`. Monomorphizing
+    /// `for_each_pruning_scorer` over the concrete scorer type keeps
+    /// `advance`/`score`/`set_threshold` statically dispatched (and inlinable) in
+    /// the hot loop, so the callback is the only dynamic call
+    fn for_each_pruning(
+        &self,
+        threshold: Score,
+        reader: &SegmentReader,
+        callback: &mut dyn FnMut(DocId, Score) -> Score,
+    ) -> crate::Result<()> {
+        let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
+        match scorer {
+            SpecializedScorer::TermUnion(mut scorers) => {
+                scorers.retain(|scorer| scorer.doc() < TERMINATED);
+                match scorers.len() {
+                    0 => {}
+                    1 => {
+                        let mut scorer =
+                            BlockWandSingleScorer::new(scorers.pop().unwrap(), threshold);
+                        for_each_pruning_scorer(&mut scorer, callback);
+                    }
+                    _ => {
+                        let mut scorer = BlockWandUnionScorer::new(scorers, threshold);
+                        for_each_pruning_scorer(&mut scorer, callback);
+                    }
+                }
+            }
+            SpecializedScorer::TermIntersection(scorers) => {
+                let mut scorer = BlockWandIntersectionScorer::new(scorers, threshold);
+                for_each_pruning_scorer(&mut scorer, callback);
+            }
+            SpecializedScorer::Other(scorer) => {
+                let mut scorer = BasicPruningScorer::new(scorer, threshold);
+                for_each_pruning_scorer(&mut scorer, callback);
+            }
+        }
+        Ok(())
+    }
+
     fn for_each_no_score(
         &self,
         reader: &SegmentReader,
@@ -563,37 +648,6 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
             }
             SpecializedScorer::Other(mut scorer) => {
                 for_each_docset_buffered(scorer.as_mut(), &mut buffer, callback);
-            }
-        }
-        Ok(())
-    }
-
-    /// Calls `callback` with all of the `(doc, score)` for which score
-    /// is exceeding a given threshold.
-    ///
-    /// This method is useful for the TopDocs collector.
-    /// For all docsets, the blanket implementation has the benefit
-    /// of prefiltering (doc, score) pairs, avoiding the
-    /// virtual dispatch cost.
-    ///
-    /// More importantly, it makes it possible for scorers to implement
-    /// important optimization (e.g. BlockWAND for union).
-    fn for_each_pruning(
-        &self,
-        threshold: Score,
-        reader: &SegmentReader,
-        callback: &mut dyn FnMut(DocId, Score) -> Score,
-    ) -> crate::Result<()> {
-        let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
-        match scorer {
-            SpecializedScorer::TermUnion(term_scorers) => {
-                super::block_wand(term_scorers, threshold, callback);
-            }
-            SpecializedScorer::TermIntersection(term_scorers) => {
-                super::block_wand_intersection(term_scorers, threshold, callback);
-            }
-            SpecializedScorer::Other(mut scorer) => {
-                for_each_pruning_scorer(scorer.as_mut(), threshold, callback);
             }
         }
         Ok(())

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -567,6 +567,41 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         Ok(())
     }
 
+    fn for_each_no_score(
+        &self,
+        reader: &SegmentReader,
+        callback: &mut dyn FnMut(&[DocId]),
+    ) -> crate::Result<()> {
+        let scorer = self.complex_scorer(reader, 1.0, || DoNothingCombiner)?;
+        let num_docs = reader.num_docs();
+        let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
+
+        match scorer {
+            SpecializedScorer::TermUnion(mut term_scorers) => {
+                if term_scorers.len() == 1 {
+                    let mut term_scorer = term_scorers.pop().unwrap();
+                    for_each_docset_buffered(&mut term_scorer, &mut buffer, callback);
+                } else {
+                    let mut union_scorer =
+                        BufferedUnionScorer::build(term_scorers, &self.score_combiner_fn, num_docs);
+                    for_each_docset_buffered(&mut union_scorer, &mut buffer, callback);
+                }
+            }
+            SpecializedScorer::TermIntersection(term_scorers) => {
+                let boxed_scorers: Vec<Box<dyn Scorer>> = term_scorers
+                    .into_iter()
+                    .map(|term_scorer| Box::new(term_scorer) as Box<dyn Scorer>)
+                    .collect();
+                let mut intersection = intersect_scorers(boxed_scorers, num_docs);
+                for_each_docset_buffered(intersection.as_mut(), &mut buffer, callback);
+            }
+            SpecializedScorer::Other(mut scorer) => {
+                for_each_docset_buffered(scorer.as_mut(), &mut buffer, callback);
+            }
+        }
+        Ok(())
+    }
+
     /// Calls `callback` with all of the `(doc, score)` for which score
     /// is exceeding a given threshold.
     ///
@@ -613,41 +648,6 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
             SpecializedScorer::Other(scorer) => {
                 let mut scorer = BasicPruningScorer::new(scorer, threshold);
                 for_each_pruning_scorer(&mut scorer, callback);
-            }
-        }
-        Ok(())
-    }
-
-    fn for_each_no_score(
-        &self,
-        reader: &SegmentReader,
-        callback: &mut dyn FnMut(&[DocId]),
-    ) -> crate::Result<()> {
-        let scorer = self.complex_scorer(reader, 1.0, || DoNothingCombiner)?;
-        let num_docs = reader.num_docs();
-        let mut buffer = [0u32; COLLECT_BLOCK_BUFFER_LEN];
-
-        match scorer {
-            SpecializedScorer::TermUnion(mut term_scorers) => {
-                if term_scorers.len() == 1 {
-                    let mut term_scorer = term_scorers.pop().unwrap();
-                    for_each_docset_buffered(&mut term_scorer, &mut buffer, callback);
-                } else {
-                    let mut union_scorer =
-                        BufferedUnionScorer::build(term_scorers, &self.score_combiner_fn, num_docs);
-                    for_each_docset_buffered(&mut union_scorer, &mut buffer, callback);
-                }
-            }
-            SpecializedScorer::TermIntersection(term_scorers) => {
-                let boxed_scorers: Vec<Box<dyn Scorer>> = term_scorers
-                    .into_iter()
-                    .map(|term_scorer| Box::new(term_scorer) as Box<dyn Scorer>)
-                    .collect();
-                let mut intersection = intersect_scorers(boxed_scorers, num_docs);
-                for_each_docset_buffered(intersection.as_mut(), &mut buffer, callback);
-            }
-            SpecializedScorer::Other(mut scorer) => {
-                for_each_docset_buffered(scorer.as_mut(), &mut buffer, callback);
             }
         }
         Ok(())

--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -3,8 +3,8 @@ mod block_wand_union;
 mod boolean_query;
 mod boolean_weight;
 
-pub(crate) use self::block_wand_intersection::block_wand_intersection;
-pub(crate) use self::block_wand_union::{block_wand, block_wand_single_scorer};
+pub use self::block_wand_intersection::BlockWandIntersectionScorer;
+pub use self::block_wand_union::{BlockWandSingleScorer, BlockWandUnionScorer};
 pub use self::boolean_query::BooleanQuery;
 pub use self::boolean_weight::BooleanWeight;
 

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use super::scorer::PruningScorer;
 use crate::docset::{SeekDangerResult, COLLECT_BLOCK_BUFFER_LEN};
 use crate::fastfield::AliveBitSet;
 use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
@@ -69,6 +70,16 @@ impl BoostWeight {
 impl Weight for BoostWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         self.weight.scorer(reader, boost * self.boost)
+    }
+
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn PruningScorer>> {
+        self.weight
+            .pruning_scorer(reader, boost * self.boost, init_threshold)
     }
 
     fn explain(&self, reader: &SegmentReader, doc: u32) -> crate::Result<Explanation> {

--- a/src/query/empty_query.rs
+++ b/src/query/empty_query.rs
@@ -1,3 +1,4 @@
+use super::scorer::PruningScorer;
 use super::Scorer;
 use crate::docset::TERMINATED;
 use crate::index::SegmentReader;
@@ -30,6 +31,15 @@ impl Weight for EmptyWeight {
         Ok(Box::new(EmptyScorer))
     }
 
+    fn pruning_scorer(
+        &self,
+        _reader: &SegmentReader,
+        _boost: Score,
+        _init_threshold: Score,
+    ) -> crate::Result<Box<dyn PruningScorer>> {
+        Ok(Box::new(EmptyScorer))
+    }
+
     fn explain(&self, _reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         Err(does_not_match(doc))
     }
@@ -59,6 +69,10 @@ impl Scorer for EmptyScorer {
     fn score(&mut self) -> Score {
         0.0
     }
+}
+
+impl PruningScorer for EmptyScorer {
+    fn set_threshold(&mut self, _score: Score) {}
 }
 
 #[cfg(test)]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -38,7 +38,10 @@ pub use self::all_query::{AllQuery, AllScorer, AllWeight};
 pub use self::automaton_weight::AutomatonWeight;
 pub use self::bitset::BitSetDocSet;
 pub use self::bm25::{Bm25StatisticsProvider, Bm25Weight};
-pub use self::boolean_query::{BooleanQuery, BooleanWeight};
+pub use self::boolean_query::{
+    BlockWandIntersectionScorer, BlockWandSingleScorer, BlockWandUnionScorer, BooleanQuery,
+    BooleanWeight,
+};
 pub use self::boost_query::{BoostQuery, BoostWeight};
 pub use self::const_score_query::{ConstScoreQuery, ConstScorer};
 pub use self::disjunction_max_query::DisjunctionMaxQuery;
@@ -60,10 +63,10 @@ pub use self::range_query::*;
 pub use self::regex_query::RegexQuery;
 pub use self::reqopt_scorer::RequiredOptionalScorer;
 pub use self::score_combiner::{DisjunctionMaxCombiner, ScoreCombiner, SumCombiner};
-pub use self::scorer::Scorer;
+pub use self::scorer::{PruningScorer, Scorer};
 pub use self::set_query::TermSetQuery;
-pub use self::term_query::TermQuery;
-pub use self::union::BufferedUnionScorer;
+pub use self::term_query::{TermQuery, TermScorer};
+pub use self::union::{BufferedUnionScorer, SimpleUnion};
 #[cfg(test)]
 pub use self::vec_docset::VecDocSet;
 pub use self::weight::Weight;

--- a/src/query/phrase_query/phrase_weight.rs
+++ b/src/query/phrase_query/phrase_weight.rs
@@ -4,6 +4,7 @@ use crate::index::SegmentReader;
 use crate::postings::SegmentPostings;
 use crate::query::bm25::Bm25Weight;
 use crate::query::explanation::does_not_match;
+use crate::query::scorer::{BasicPruningScorer, PruningScorer};
 use crate::query::{EmptyScorer, Explanation, Scorer, Weight};
 use crate::schema::{IndexRecordOption, Term};
 use crate::{DocId, DocSet, Score};
@@ -77,6 +78,22 @@ impl Weight for PhraseWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         if let Some(scorer) = self.phrase_scorer(reader, boost)? {
             Ok(Box::new(scorer))
+        } else {
+            Ok(Box::new(EmptyScorer))
+        }
+    }
+
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn PruningScorer>> {
+        if let Some(scorer) = self.phrase_scorer(reader, boost)? {
+            Ok(Box::new(BasicPruningScorer::new(
+                Box::new(scorer),
+                init_threshold,
+            )))
         } else {
             Ok(Box::new(EmptyScorer))
         }

--- a/src/query/phrase_query/regex_phrase_weight.rs
+++ b/src/query/phrase_query/regex_phrase_weight.rs
@@ -9,6 +9,7 @@ use crate::index::SegmentReader;
 use crate::postings::{LoadedPostings, Postings, SegmentPostings, TermInfo};
 use crate::query::bm25::Bm25Weight;
 use crate::query::explanation::does_not_match;
+use crate::query::scorer::{BasicPruningScorer, PruningScorer};
 use crate::query::union::{BitSetPostingUnion, SimpleUnion};
 use crate::query::{AutomatonWeight, BitSetDocSet, EmptyScorer, Explanation, Scorer, Weight};
 use crate::schema::{Field, IndexRecordOption};
@@ -272,6 +273,22 @@ impl Weight for RegexPhraseWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         if let Some(scorer) = self.phrase_scorer(reader, boost)? {
             Ok(Box::new(scorer))
+        } else {
+            Ok(Box::new(EmptyScorer))
+        }
+    }
+
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn PruningScorer>> {
+        if let Some(scorer) = self.phrase_scorer(reader, boost)? {
+            Ok(Box::new(BasicPruningScorer::new(
+                Box::new(scorer),
+                init_threshold,
+            )))
         } else {
             Ok(Box::new(EmptyScorer))
         }

--- a/src/query/scorer.rs
+++ b/src/query/scorer.rs
@@ -24,7 +24,11 @@ impl Scorer for Box<dyn Scorer> {
     }
 }
 
+/// A `Scorer` that prunes its document set by a minimum score threshold
 pub trait PruningScorer: Scorer {
+    /// Updates the threshold used for pruning. Pruning logic generally
+    /// assumes that calls to this function will provide monotonically-
+    /// increasing scores.
     fn set_threshold(&mut self, score: Score);
 }
 

--- a/src/query/scorer.rs
+++ b/src/query/scorer.rs
@@ -3,7 +3,7 @@ use std::ops::DerefMut;
 use downcast_rs::impl_downcast;
 
 use crate::docset::DocSet;
-use crate::Score;
+use crate::{DocId, Score, TERMINATED};
 
 /// Scored set of documents matching a query within a specific segment.
 ///
@@ -21,5 +21,81 @@ impl Scorer for Box<dyn Scorer> {
     #[inline]
     fn score(&mut self) -> Score {
         self.deref_mut().score()
+    }
+}
+
+pub trait PruningScorer: Scorer {
+    fn set_threshold(&mut self, score: Score);
+}
+
+impl_downcast!(PruningScorer);
+
+impl Scorer for Box<dyn PruningScorer> {
+    #[inline]
+    fn score(&mut self) -> Score {
+        self.deref_mut().score()
+    }
+}
+
+impl PruningScorer for Box<dyn PruningScorer> {
+    #[inline]
+    fn set_threshold(&mut self, score: Score) {
+        self.deref_mut().set_threshold(score);
+    }
+}
+
+pub struct BasicPruningScorer {
+    scorer: Box<dyn Scorer>,
+    threshold: Score,
+    current: (DocId, Score),
+}
+impl BasicPruningScorer {
+    pub fn new(scorer: Box<dyn Scorer>, threshold: Score) -> Self {
+        let mut pruning = Self {
+            scorer,
+            threshold,
+            current: (0, Score::MIN),
+        };
+        pruning.advance();
+        pruning
+    }
+}
+impl Scorer for BasicPruningScorer {
+    #[inline]
+    fn score(&mut self) -> Score {
+        self.current.1
+    }
+}
+impl PruningScorer for BasicPruningScorer {
+    #[inline]
+    fn set_threshold(&mut self, score: Score) {
+        self.threshold = score;
+    }
+}
+impl DocSet for BasicPruningScorer {
+    #[inline]
+    fn doc(&self) -> crate::DocId {
+        self.current.0
+    }
+
+    fn advance(&mut self) -> crate::DocId {
+        let mut doc_id = self.scorer.doc();
+        while doc_id != TERMINATED {
+            let score = self.scorer.score();
+            if score > self.threshold {
+                self.current = (doc_id, score);
+                self.scorer.advance();
+                return doc_id;
+            }
+            doc_id = self.scorer.advance();
+        }
+        self.current = (TERMINATED, Score::MIN);
+        TERMINATED
+    }
+
+    /// The number of elements yielded by a PruningScorer depends on the threshold and cannot be
+    /// computed ahead of time, so just defer to the inner scorer.
+    fn size_hint(&self) -> u32 {
+        self.scorer.size_hint()
     }
 }

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -85,44 +85,6 @@ impl Weight for TermWeight {
         }
     }
 
-    /// Calls `callback` with all of the `(doc, score)` for which score
-    /// is exceeding a given threshold.
-    ///
-    /// This method is useful for the TopDocs collector.
-    /// For all docsets, the blanket implementation has the benefit
-    /// of prefiltering (doc, score) pairs, avoiding the
-    /// virtual dispatch cost.
-    ///
-    /// More importantly, it makes it possible for scorers to implement
-    /// important optimization (e.g. BlockWAND for union).
-    ///
-    /// Overrides the blanket implementation to drive the concrete
-    /// [`BlockWandSingleScorer`] directly, rather than through a
-    /// `Box<dyn PruningScorer>`. This monomorphizes `for_each_pruning_scorer`
-    /// over the concrete scorer so `advance`/`score`/`set_threshold` are
-    /// statically dispatched (and inlinable) in the hot loop.
-    fn for_each_pruning(
-        &self,
-        threshold: Score,
-        reader: &SegmentReader,
-        callback: &mut dyn FnMut(DocId, Score) -> Score,
-    ) -> crate::Result<()> {
-        let specialized_scorer = self.specialized_scorer(reader, 1.0)?;
-        match specialized_scorer {
-            TermOrEmptyOrAllScorer::TermScorer(term_scorer) => {
-                let mut scorer = BlockWandSingleScorer::new(*term_scorer, threshold);
-                for_each_pruning_scorer(&mut scorer, callback);
-            }
-            TermOrEmptyOrAllScorer::Empty => {}
-            TermOrEmptyOrAllScorer::AllMatch(_) => {
-                return Err(TantivyError::InvalidArgument(
-                    "for each pruning should only be called if scoring is enabled".to_string(),
-                ));
-            }
-        }
-        Ok(())
-    }
-
     /// Iterates through all of the document matched by the DocSet
     /// `DocSet` and push the scored documents to the collector.
     fn for_each(
@@ -161,6 +123,44 @@ impl Weight for TermWeight {
             }
         };
 
+        Ok(())
+    }
+
+    /// Calls `callback` with all of the `(doc, score)` for which score
+    /// is exceeding a given threshold.
+    ///
+    /// This method is useful for the TopDocs collector.
+    /// For all docsets, the blanket implementation has the benefit
+    /// of prefiltering (doc, score) pairs, avoiding the
+    /// virtual dispatch cost.
+    ///
+    /// More importantly, it makes it possible for scorers to implement
+    /// important optimization (e.g. BlockWAND for union).
+    ///
+    /// Overrides the blanket implementation to drive the concrete
+    /// [`BlockWandSingleScorer`] directly, rather than through a
+    /// `Box<dyn PruningScorer>`. This monomorphizes `for_each_pruning_scorer`
+    /// over the concrete scorer so `advance`/`score`/`set_threshold` are
+    /// statically dispatched (and inlinable) in the hot loop.
+    fn for_each_pruning(
+        &self,
+        threshold: Score,
+        reader: &SegmentReader,
+        callback: &mut dyn FnMut(DocId, Score) -> Score,
+    ) -> crate::Result<()> {
+        let specialized_scorer = self.specialized_scorer(reader, 1.0)?;
+        match specialized_scorer {
+            TermOrEmptyOrAllScorer::TermScorer(term_scorer) => {
+                let mut scorer = BlockWandSingleScorer::new(*term_scorer, threshold);
+                for_each_pruning_scorer(&mut scorer, callback);
+            }
+            TermOrEmptyOrAllScorer::Empty => {}
+            TermOrEmptyOrAllScorer::AllMatch(_) => {
+                return Err(TantivyError::InvalidArgument(
+                    "for each pruning should only be called if scoring is enabled".to_string(),
+                ));
+            }
+        }
         Ok(())
     }
 }

--- a/src/query/term_query/term_weight.rs
+++ b/src/query/term_query/term_weight.rs
@@ -4,8 +4,10 @@ use crate::fieldnorm::FieldNormReader;
 use crate::index::SegmentReader;
 use crate::postings::SegmentPostings;
 use crate::query::bm25::Bm25Weight;
+use crate::query::boolean_query::BlockWandSingleScorer;
 use crate::query::explanation::does_not_match;
-use crate::query::weight::{for_each_docset_buffered, for_each_scorer};
+use crate::query::scorer::BasicPruningScorer;
+use crate::query::weight::{for_each_docset_buffered, for_each_pruning_scorer, for_each_scorer};
 use crate::query::{AllScorer, AllWeight, EmptyScorer, Explanation, Scorer, Weight};
 use crate::schema::IndexRecordOption;
 use crate::{DocId, Score, TantivyError, Term};
@@ -38,6 +40,25 @@ impl Weight for TermWeight {
         Ok(self.specialized_scorer(reader, boost)?.into_boxed_scorer())
     }
 
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn crate::query::scorer::PruningScorer>> {
+        let specialized_scorer = self.specialized_scorer(reader, boost)?;
+        match specialized_scorer {
+            TermOrEmptyOrAllScorer::TermScorer(term_scorer) => Ok(Box::new(
+                BlockWandSingleScorer::new(*term_scorer, init_threshold),
+            )),
+            TermOrEmptyOrAllScorer::Empty => Ok(Box::new(EmptyScorer)),
+            TermOrEmptyOrAllScorer::AllMatch(all_scorer) => Ok(Box::new(BasicPruningScorer::new(
+                Box::new(all_scorer),
+                init_threshold,
+            ))),
+        }
+    }
+
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
         match self.specialized_scorer(reader, 1.0)? {
             TermOrEmptyOrAllScorer::TermScorer(mut term_scorer) => {
@@ -62,6 +83,44 @@ impl Weight for TermWeight {
             let term_info = inv_index.get_term_info(&self.term)?;
             Ok(term_info.map(|term_info| term_info.doc_freq).unwrap_or(0))
         }
+    }
+
+    /// Calls `callback` with all of the `(doc, score)` for which score
+    /// is exceeding a given threshold.
+    ///
+    /// This method is useful for the TopDocs collector.
+    /// For all docsets, the blanket implementation has the benefit
+    /// of prefiltering (doc, score) pairs, avoiding the
+    /// virtual dispatch cost.
+    ///
+    /// More importantly, it makes it possible for scorers to implement
+    /// important optimization (e.g. BlockWAND for union).
+    ///
+    /// Overrides the blanket implementation to drive the concrete
+    /// [`BlockWandSingleScorer`] directly, rather than through a
+    /// `Box<dyn PruningScorer>`. This monomorphizes `for_each_pruning_scorer`
+    /// over the concrete scorer so `advance`/`score`/`set_threshold` are
+    /// statically dispatched (and inlinable) in the hot loop.
+    fn for_each_pruning(
+        &self,
+        threshold: Score,
+        reader: &SegmentReader,
+        callback: &mut dyn FnMut(DocId, Score) -> Score,
+    ) -> crate::Result<()> {
+        let specialized_scorer = self.specialized_scorer(reader, 1.0)?;
+        match specialized_scorer {
+            TermOrEmptyOrAllScorer::TermScorer(term_scorer) => {
+                let mut scorer = BlockWandSingleScorer::new(*term_scorer, threshold);
+                for_each_pruning_scorer(&mut scorer, callback);
+            }
+            TermOrEmptyOrAllScorer::Empty => {}
+            TermOrEmptyOrAllScorer::AllMatch(_) => {
+                return Err(TantivyError::InvalidArgument(
+                    "for each pruning should only be called if scoring is enabled".to_string(),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Iterates through all of the document matched by the DocSet
@@ -102,41 +161,6 @@ impl Weight for TermWeight {
             }
         };
 
-        Ok(())
-    }
-
-    /// Calls `callback` with all of the `(doc, score)` for which score
-    /// is exceeding a given threshold.
-    ///
-    /// This method is useful for the TopDocs collector.
-    /// For all docsets, the blanket implementation has the benefit
-    /// of prefiltering (doc, score) pairs, avoiding the
-    /// virtual dispatch cost.
-    ///
-    /// More importantly, it makes it possible for scorers to implement
-    /// important optimization (e.g. BlockWAND for union).
-    fn for_each_pruning(
-        &self,
-        threshold: Score,
-        reader: &SegmentReader,
-        callback: &mut dyn FnMut(DocId, Score) -> Score,
-    ) -> crate::Result<()> {
-        let specialized_scorer = self.specialized_scorer(reader, 1.0)?;
-        match specialized_scorer {
-            TermOrEmptyOrAllScorer::TermScorer(term_scorer) => {
-                crate::query::boolean_query::block_wand_single_scorer(
-                    *term_scorer,
-                    threshold,
-                    callback,
-                );
-            }
-            TermOrEmptyOrAllScorer::Empty => {}
-            TermOrEmptyOrAllScorer::AllMatch(_) => {
-                return Err(TantivyError::InvalidArgument(
-                    "for each pruning should only be called if scoring is enabled".to_string(),
-                ));
-            }
-        }
         Ok(())
     }
 }

--- a/src/query/weight.rs
+++ b/src/query/weight.rs
@@ -1,3 +1,4 @@
+use super::scorer::{BasicPruningScorer, PruningScorer};
 use super::Scorer;
 use crate::docset::COLLECT_BLOCK_BUFFER_LEN;
 use crate::index::SegmentReader;
@@ -34,27 +35,18 @@ pub(crate) fn for_each_docset_buffered<T: DocSet + ?Sized>(
     }
 }
 
-/// Calls `callback` with all of the `(doc, score)` for which score
-/// is exceeding a given threshold.
+/// Iterates through all of the `(doc, score)` produced by a pruning scorer.
 ///
-/// This method is useful for the [`TopDocs`](crate::collector::TopDocs) collector.
-/// For all docsets, the blanket implementation has the benefit
-/// of prefiltering (doc, score) pairs, avoiding the
-/// virtual dispatch cost.
-///
-/// More importantly, it makes it possible for scorers to implement
-/// important optimization (e.g. BlockWAND for union).
-pub(crate) fn for_each_pruning_scorer<TScorer: Scorer + ?Sized>(
+/// `callback` returns the new threshold after each call, which is fed back into
+/// the scorer via [`PruningScorer::set_threshold`] so it can keep pruning.
+pub(crate) fn for_each_pruning_scorer<TScorer: PruningScorer + ?Sized>(
     scorer: &mut TScorer,
-    mut threshold: Score,
     callback: &mut dyn FnMut(DocId, Score) -> Score,
 ) {
     let mut doc = scorer.doc();
     while doc != TERMINATED {
-        let score = scorer.score();
-        if score > threshold {
-            threshold = callback(doc, score);
-        }
+        let new_threshold = callback(doc, scorer.score());
+        scorer.set_threshold(new_threshold);
         doc = scorer.advance();
     }
 }
@@ -70,6 +62,27 @@ pub trait Weight: Send + Sync + 'static {
     ///
     /// See [`Query`](crate::query::Query).
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>>;
+
+    /// Returns a pruning scorer for the given segment.
+    ///
+    /// `boost` is a multiplier to apply to the score. `init_threshold` is the
+    /// initial score threshold below which documents may be pruned.
+    ///
+    /// The default implementation wraps [`Weight::scorer`] in a
+    /// [`BasicPruningScorer`], which simply filters out `(doc, score)` pairs
+    /// below the current threshold. Scorers that can prune more aggressively
+    /// (e.g. BlockWAND over a union or intersection) override this.
+    fn pruning_scorer(
+        &self,
+        reader: &SegmentReader,
+        boost: Score,
+        init_threshold: Score,
+    ) -> crate::Result<Box<dyn PruningScorer>> {
+        Ok(Box::new(BasicPruningScorer::new(
+            self.scorer(reader, boost)?,
+            init_threshold,
+        )))
+    }
 
     /// Returns an [`Explanation`] for the given document.
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation>;
@@ -126,8 +139,8 @@ pub trait Weight: Send + Sync + 'static {
         reader: &SegmentReader,
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
-        let mut scorer = self.scorer(reader, 1.0)?;
-        for_each_pruning_scorer(scorer.as_mut(), threshold, callback);
+        let mut scorer = self.pruning_scorer(reader, 1.0, threshold)?;
+        for_each_pruning_scorer(scorer.as_mut(), callback);
         Ok(())
     }
 }


### PR DESCRIPTION
This PR closes #2390 by allowing external callers to choose if they want pruning or regular behavior from a scorer while keeping the applicability of the BMW optimization inside of the `Weight`. We (ParadeDB) recently used this change to apply BMW to certain joins where we use the scorer directly. (See [here](https://github.com/paradedb/paradedb/pull/5487)) 

This works by:
- Introduces a `PruningScorer` trait that extends a `Scorer` to support
setting a threshold.
- Adds a `pruning_scorer` method to the `Weight` trait, with a default
implementation returning a `BasicPruningScorer`.
- Moves the logic for all 3 (union, single, and intersection)
block-max-wand variants into `PruningScorer` implementations so that
they can be driven externally. I did this with as minimal changes as possible,. only changing what was necessary for external iteration. (mostly transferring loop state into a struct)
- Have `BooleanWeight::pruning_scorer` drive the BMW choice.
- Changes the visibility of the BMW scorers and their inputs to be
available to consumers of the library.

The internal code-paths to drive BMW are unchanged at the call to `for_each_pruning` and above.

Local runs of the relevant in-repo benchmarks show ~no performance differences.

