### PR TITLE
chore: downgrade all info! logs to debug!

### DIFF
--- a/src/directory/managed_directory.rs
+++ b/src/directory/managed_directory.rs
@@ -110,7 +110,7 @@ impl ManagedDirectory {
         &mut self,
         get_living_files: L,
     ) -> crate::Result<GarbageCollectionResult> {
-        info!("Garbage collect");
+        debug!("Garbage collect");
         let mut files_to_delete = vec![];
 
         // It is crucial to get the living files after acquiring the
@@ -157,7 +157,7 @@ impl ManagedDirectory {
         for file_to_delete in files_to_delete {
             match self.delete(&file_to_delete) {
                 Ok(_) => {
-                    info!("Deleted {file_to_delete:?}");
+                    debug!("Deleted {file_to_delete:?}");
                     deleted_files.push(file_to_delete);
                 }
                 Err(file_error) => {

--- a/src/directory/mmap_directory/file_watcher.rs
+++ b/src/directory/mmap_directory/file_watcher.rs
@@ -51,7 +51,7 @@ impl FileWatcher {
                             .map(|current_checksum| current_checksum != checksum)
                             .unwrap_or(true);
                         if metafile_has_changed {
-                            info!("Meta file {path:?} was modified");
+                            debug!("Meta file {path:?} was modified");
                             current_checksum_opt = Some(checksum);
                             // We actually ignore callbacks failing here.
                             // We just wait for the end of their execution.

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -193,7 +193,7 @@ fn index_documents<D: Document>(
         }
         let mem_usage = segment_writer.mem_usage();
         if mem_usage >= memory_budget - MARGIN_IN_BYTES {
-            info!(
+            debug!(
                 "Buffer limit reached, flushing segment with maxdoc={}.",
                 segment_writer.max_doc()
             );
@@ -562,7 +562,7 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// The opstamp at the last commit is returned.
     pub fn rollback(&mut self) -> crate::Result<Opstamp> {
-        info!("Rolling back to opstamp {}", self.committed_opstamp);
+        debug!("Rolling back to opstamp {}", self.committed_opstamp);
         // marks the segment updater as killed. From now on, all
         // segment updates will be ignored.
         self.segment_updater.kill();
@@ -626,7 +626,7 @@ impl<D: Document> IndexWriter<D> {
         //
         // This will move uncommitted segments to the state of
         // committed segments.
-        info!("Preparing commit");
+        debug!("Preparing commit");
 
         // this will drop the current document channel
         // and recreate a new one.
@@ -644,7 +644,7 @@ impl<D: Document> IndexWriter<D> {
 
         let commit_opstamp = self.stamper.stamp();
         let prepared_commit = PreparedCommit::new(self, commit_opstamp);
-        info!("Prepared commit {commit_opstamp}");
+        debug!("Prepared commit {commit_opstamp}");
         Ok(prepared_commit)
     }
 

--- a/src/indexer/prepared_commit.rs
+++ b/src/indexer/prepared_commit.rs
@@ -45,7 +45,7 @@ impl<'a, D: Document> PreparedCommit<'a, D> {
     /// this operation is not at all really light.
     /// At this point deletes have not been flushed yet.
     pub fn commit_future(self) -> FutureResult<Opstamp> {
-        info!("committing {}", self.opstamp);
+        debug!("committing {}", self.opstamp);
         self.index_writer
             .segment_updater()
             .schedule_commit(self.opstamp, self.payload)

--- a/src/indexer/segment_updater.rs
+++ b/src/indexer/segment_updater.rs
@@ -36,7 +36,7 @@ const PANIC_CAUGHT: &str = "Panic caught in merge thread";
 ///
 /// This method is not part of tantivy's public API
 pub(crate) fn save_metas(metas: &IndexMeta, directory: &dyn Directory) -> crate::Result<()> {
-    info!("save metas");
+    debug!("save metas");
     let mut buffer = serde_json::to_vec_pretty(metas)?;
     // Just adding a new line at the end of the buffer.
     writeln!(&mut buffer)?;
@@ -72,7 +72,7 @@ impl Deref for SegmentUpdater {
 fn garbage_collect_files(
     segment_updater: SegmentUpdater,
 ) -> crate::Result<GarbageCollectionResult> {
-    info!("Running garbage collection");
+    debug!("Running garbage collection");
     let mut index = segment_updater.index.clone();
     index
         .directory_mut()
@@ -510,7 +510,7 @@ impl SegmentUpdater {
             }
         };
 
-        info!("Starting merge  - {:?}", merge_operation.segment_ids());
+        debug!("Starting merge  - {:?}", merge_operation.segment_ids());
 
         let (scheduled_result, merging_future_send) =
             FutureResult::create("Merge operation failed.");
@@ -624,7 +624,7 @@ impl SegmentUpdater {
             .as_ref()
             .map(|after_merge_segment_entry| after_merge_segment_entry.meta().clone());
         self.schedule_task(move || {
-            info!(
+            debug!(
                 "End merge {:?}",
                 after_merge_segment_entry.as_ref().map(|entry| entry.meta())
             );


### PR DESCRIPTION
As discussed in #3004, tantivy as a library should not emit info-level logs by default. All `info!` calls are converted to `debug!` across 5 files:

- `src/directory/managed_directory.rs` — Garbage collect + file deletion logs
- `src/directory/mmap_directory/file_watcher.rs` — Meta file modification log
- `src/indexer/index_writer.rs` — Buffer flush, rollback, commit logs
- `src/indexer/prepared_commit.rs` — Commit log
- `src/indexer/segment_updater.rs` — Save metas, garbage collection, merge logs

As noted by @nwin in #3004, index creation/opening events could remain at info level in the future, but those are not currently logged so all existing info! calls are safe to downgrade.

Closes #3004