### PR TITLE
Fix: do not drive a non-summing score combiner with Block-WAND

### DIFF
--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -585,10 +585,25 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         callback: &mut dyn FnMut(DocId, Score) -> Score,
     ) -> crate::Result<()> {
         let scorer = self.complex_scorer(reader, 1.0, &self.score_combiner_fn)?;
+        let num_docs = reader.num_docs();
         match scorer {
+            // Block-WAND scores by summing the matching terms, so it may only
+            // drive a combiner that sums. Anything else (dis_max) still needs
+            // every matching term and falls back to the plain union.
             SpecializedScorer::TermUnion(term_scorers) => {
-                super::block_wand(term_scorers, threshold, callback);
+                if TScoreCombiner::SUPPORTS_BLOCK_WAND {
+                    super::block_wand(term_scorers, threshold, callback);
+                } else {
+                    let mut union_scorer =
+                        BufferedUnionScorer::build(term_scorers, &self.score_combiner_fn, num_docs);
+                    for_each_pruning_scorer(&mut union_scorer, threshold, callback);
+                }
             }
+            // An intersection sums its term scores whatever the combiner:
+            // `Intersection::score` hard-codes the sum and `into_box_scorer`
+            // routes `TermIntersection` through it, so the combiner only ever
+            // shapes how *should* clauses combine. Block-WAND's summing
+            // therefore matches the unpruned scorer here for every combiner.
             SpecializedScorer::TermIntersection(term_scorers) => {
                 super::block_wand_intersection(term_scorers, threshold, callback);
             }

--- a/src/query/disjunction_max_query.rs
+++ b/src/query/disjunction_max_query.rs
@@ -128,3 +128,133 @@ impl DisjunctionMaxQuery {
         DisjunctionMaxQuery::with_tie_breaker(disjuncts, 0.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::collector::TopDocs;
+    use crate::query::{DisjunctionMaxQuery, Query, QueryParser, TermQuery};
+    use crate::schema::{IndexRecordOption, Schema, TEXT};
+    use crate::{Index, Term};
+
+    /// `TopDocs` prunes through `Weight::for_each_pruning`, which hands a union
+    /// of term scorers to Block-WAND. Block-WAND sums the matching terms, so
+    /// driving a dis_max query that way scored a document matching in two
+    /// fields as the sum of both instead of the better of the two.
+    #[test]
+    fn test_dismax_is_not_summed_by_block_wand() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let title = schema_builder.add_text_field("title", TEXT);
+        let body = schema_builder.add_text_field("body", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut writer = index.writer_for_tests()?;
+        // "alpha" appears in two titles and two bodies, so it scores the same
+        // in either field, and doc 1 is the one matching in both
+        writer.add_document(doc!(title => "alpha", body => "beta"))?;
+        writer.add_document(doc!(title => "alpha", body => "alpha"))?;
+        writer.add_document(doc!(title => "beta", body => "alpha"))?;
+        writer.commit()?;
+        let searcher = index.reader()?.searcher();
+
+        let clause = |field| {
+            Box::new(TermQuery::new(
+                Term::from_field_text(field, "alpha"),
+                IndexRecordOption::WithFreqs,
+            )) as Box<dyn Query>
+        };
+        let query = DisjunctionMaxQuery::new(vec![clause(title), clause(body)]);
+        let top = searcher.search(&query, &TopDocs::with_limit(3).order_by_score())?;
+        assert_eq!(top.len(), 3);
+        // every document scores its single best field, so all three tie
+        for (score, _) in &top {
+            assert!(
+                (score - top[0].0).abs() < 1e-5,
+                "dis_max must take the best field, got {top:?}"
+            );
+        }
+
+        // and the tie breaker adds exactly its fraction of the other field
+        let query = DisjunctionMaxQuery::with_tie_breaker(vec![clause(title), clause(body)], 0.3);
+        let top = searcher.search(&query, &TopDocs::with_limit(3).order_by_score())?;
+        assert!(
+            (top[0].0 - top[2].0 * 1.3).abs() < 1e-5,
+            "tie_breaker must add 30% of the other field, got {top:?}"
+        );
+        let _ = QueryParser::for_index(&index, vec![title]);
+        Ok(())
+    }
+
+    /// A `TermIntersection` (all clauses required) sums its term scores on the
+    /// unpruned path whatever the combiner — `Intersection::score` hard-codes
+    /// the sum; the combiner only shapes how *should* clauses combine. The
+    /// pruning path must produce identical scores, which is why
+    /// `block_wand_intersection` may drive a non-summing combiner too.
+    #[test]
+    fn test_term_intersection_pruning_matches_unpruned_scorer() -> crate::Result<()> {
+        use crate::query::score_combiner::DisjunctionMaxCombiner;
+        use crate::query::{BooleanWeight, EnableScoring, Occur, Weight};
+        use crate::schema::Field;
+        use crate::{DocSet, Score, TERMINATED};
+
+        let mut schema_builder = Schema::builder();
+        let text = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut writer = index.writer_for_tests()?;
+        // both terms in every doc, with varying frequencies so scores differ
+        for i in 0..100 {
+            let mut doc_text = String::from("alpha beta");
+            for _ in 0..i % 7 {
+                doc_text.push_str(" alpha");
+            }
+            for _ in 0..i % 3 {
+                doc_text.push_str(" beta");
+            }
+            writer.add_document(doc!(text => doc_text))?;
+        }
+        writer.commit()?;
+        let searcher = index.reader()?.searcher();
+        let reader = searcher.segment_reader(0);
+
+        let clause = |field: Field, term: &str| -> crate::Result<(Occur, Box<dyn Weight>)> {
+            let query = TermQuery::new(
+                Term::from_field_text(field, term),
+                IndexRecordOption::WithFreqs,
+            );
+            Ok((
+                Occur::Must,
+                query.weight(EnableScoring::enabled_from_searcher(&searcher))?,
+            ))
+        };
+        let weight = BooleanWeight::with_minimum_number_should_match(
+            vec![clause(text, "alpha")?, clause(text, "beta")?],
+            0,
+            true,
+            Box::new(|| DisjunctionMaxCombiner::with_tie_breaker(0.3)),
+        );
+
+        let mut unpruned: Vec<(u32, Score)> = Vec::new();
+        let mut scorer = weight.scorer(reader, 1.0)?;
+        while scorer.doc() != TERMINATED {
+            unpruned.push((scorer.doc(), scorer.score()));
+            scorer.advance();
+        }
+        assert_eq!(unpruned.len(), 100);
+
+        let mut pruned: Vec<(u32, Score)> = Vec::new();
+        weight.for_each_pruning(Score::MIN, reader, &mut |doc, score| {
+            pruned.push((doc, score));
+            Score::MIN
+        })?;
+
+        assert_eq!(pruned.len(), unpruned.len());
+        for (&(pruned_doc, pruned_score), &(doc, score)) in pruned.iter().zip(unpruned.iter()) {
+            assert_eq!(pruned_doc, doc);
+            assert!(
+                (pruned_score - score).abs() < 1e-5,
+                "doc {doc}: pruning scored {pruned_score}, plain scorer {score}"
+            );
+        }
+        Ok(())
+    }
+}

--- a/src/query/score_combiner.rs
+++ b/src/query/score_combiner.rs
@@ -4,6 +4,15 @@ use crate::Score;
 /// The `ScoreCombiner` trait defines how to compute
 /// an overall score given a list of scores.
 pub trait ScoreCombiner: Default + Clone + Send + Copy + 'static {
+    /// Whether Block-WAND may drive this combiner.
+    ///
+    /// Block-WAND prunes blocks by comparing the *sum* of the per-term block
+    /// maxima against the threshold, and scores the surviving documents the
+    /// same way. That is only the right answer for a combiner that sums. A
+    /// combiner aggregating any other way (dis_max takes the maximum) has to
+    /// see every matching term, so it must not be pruned this way.
+    const SUPPORTS_BLOCK_WAND: bool = false;
+
     /// Aggregates the score combiner with the given scorer.
     ///
     /// The `ScoreCombiner` may decide to call `.scorer.score()`
@@ -42,6 +51,8 @@ pub struct SumCombiner {
 }
 
 impl ScoreCombiner for SumCombiner {
+    const SUPPORTS_BLOCK_WAND: bool = true;
+
     fn update<TScorer: Scorer>(&mut self, scorer: &mut TScorer) {
         self.score += scorer.score();
     }


### PR DESCRIPTION
## Problem

`BooleanWeight::for_each_pruning` hands a union of term scorers straight to `block_wand`, whatever the weight's score combiner. Block-WAND prunes on the **sum** of the per-term block maxima and scores the survivors the same way, so it silently replaces the combiner with a sum.

A `DisjunctionMaxQuery` collected through `TopDocs` therefore scores a document matching in two fields as the **sum** of both fields instead of the better of the two, and ignores the tie breaker.

The union only reaches that path when every clause reads term frequencies, which is why the bug hid: a query asking for `Basic` postings falls back to `BufferedUnionScorer`, which does honor the combiner.

## Fix

`ScoreCombiner` now declares whether Block-WAND may drive it (`SUPPORTS_BLOCK_WAND`, default `false`). Only `SumCombiner` opts in; everything else falls back to the plain `BufferedUnionScorer` driven through `for_each_pruning_scorer`, which still prunes on the threshold but makes no assumption about how scores combine.

The **intersection** specialization needs no fallback: `Intersection::score` sums its children whatever the combiner (`into_box_scorer` routes `TermIntersection` through the same `intersect_scorers` on the unpruned path), so the combiner only ever shapes how *should* clauses combine, and `block_wand_intersection`'s summing already matches the unpruned scorer for every combiner. Making the intersection combiner-aware instead would create a new mismatch between `for_each_pruning` and `scorer()`.

## Tests

- `test_dismax_is_not_summed_by_block_wand`: three docs where "alpha" scores identically in either field — with dis_max all three must tie (best field only), and with `tie_breaker: 0.3` the doc matching both fields must score exactly `1.3x`. Fails on current main (doc matching both fields wins with a summed score), passes with this change.
- `test_term_intersection_pruning_matches_unpruned_scorer`: a must+must `BooleanWeight<DisjunctionMaxCombiner>` (the only way a non-summing combiner reaches `TermIntersection`) — `for_each_pruning` must produce exactly the docs and scores of a manual walk of `weight.scorer()`. Pins that Block-WAND's intersection stays consistent with the unpruned path for non-summing combiners.