### PR TITLE
fix: resolve UB in MemoryArena by using safe indexing bounds checks

### DIFF
--- a/stacker/src/memory_arena.rs
+++ b/stacker/src/memory_arena.rs
@@ -138,11 +138,11 @@ impl MemoryArena {
     }
     #[inline]
     fn get_page(&self, page_id: usize) -> &Page {
-        unsafe { self.pages.get_unchecked(page_id) }
+        &self.pages[page_id]
     }
     #[inline]
     fn get_page_mut(&mut self, page_id: usize) -> &mut Page {
-        unsafe { self.pages.get_unchecked_mut(page_id) }
+        &mut self.pages[page_id]
     }
 
     #[inline]
@@ -216,8 +216,7 @@ impl Page {
 
     #[inline]
     fn slice(&self, local_addr: usize, len: usize) -> &[u8] {
-        let data = &self.slice_from(local_addr);
-        unsafe { data.get_unchecked(..len) }
+        &self.data[local_addr..local_addr + len]
     }
 
     #[inline]
@@ -231,8 +230,7 @@ impl Page {
 
     #[inline]
     fn slice_mut(&mut self, local_addr: usize, len: usize) -> &mut [u8] {
-        let data = &mut self.data[local_addr..];
-        unsafe { data.get_unchecked_mut(..len) }
+        &mut self.data[local_addr..local_addr + len]
     }
 
     #[inline]
@@ -324,5 +322,15 @@ mod tests {
 
         assert_eq!(arena.read::<MyTest>(addr_a), a);
         assert_eq!(arena.read::<MyTest>(addr_b), b);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_arena_read_out_of_bounds() {
+        use crate::Addr;
+        let arena = MemoryArena::default();
+        // A forged address pointing to a non-existent page
+        let forged = Addr::null_pointer().offset(0x0010_0001);
+        let _x: u64 = arena.read::<u64>(forged);
     }
 }


### PR DESCRIPTION
Fixes #2858.

This pull request resolves a soundness bug / undefined behavior reported in #2858.
The bug was caused by `MemoryArena::get_page`, `MemoryArena::get_page_mut`, `Page::slice`, and `Page::slice_mut` using `get_unchecked` and `get_unchecked_mut` on `local_addr` and `len` which could result in undefined behavior if passed forged addresses or if `size_of::<Item>()` extended beyond the page data limits.

By switching to standard slice indexing `&self.pages[page_id]` and `&self.data[local_addr..local_addr + len]`, we guarantee that if an out-of-bounds access happens, it panics instead of causing UB.

A test has been added to replicate the #2858 PoC and confirm it correctly panics as a bounds-checking protection rather than causing UB.