### PR TITLE
reintroduce get_fast_field_tokenizer_name

### DIFF
--- a/src/schema/json_object_options.rs
+++ b/src/schema/json_object_options.rs
@@ -66,6 +66,15 @@ impl JsonObjectOptions {
         self.fast.is_some()
     }
 
+    /// Returns the tokenizer used for the fast field, if the json object
+    /// is a fast field and a tokenizer was configured for it.
+    #[inline]
+    pub fn get_fast_field_tokenizer_name(&self) -> Option<&str> {
+        self.fast
+            .as_ref()
+            .map(|fast_field_options| fast_field_options.tokenizer.as_str())
+    }
+
     /// Returns `true` iff dots in json keys should be expanded.
     ///
     /// When expand_dots is enabled, json object like

--- a/src/schema/text_options.rs
+++ b/src/schema/text_options.rs
@@ -118,6 +118,15 @@ impl TextOptions {
         self.fast.is_some()
     }
 
+    /// Returns the tokenizer used for the fast field, if the text field
+    /// is a fast field and a tokenizer was configured for it.
+    #[inline]
+    pub fn get_fast_field_tokenizer_name(&self) -> Option<&str> {
+        self.fast
+            .as_ref()
+            .map(|fast_field_options| fast_field_options.tokenizer.as_str())
+    }
+
     /// Returns true if values should be coerced to strings (numbers, null).
     #[inline]
     pub fn should_coerce(&self) -> bool {


### PR DESCRIPTION
they were removed in #3020, but these functions can still be useful, e.g. in quickwit