### PR TITLE
Faster term aggregation result merges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ futures-channel = { version = "0.3.28", optional = true }
 fnv = "1.0.7"
 typetag = "0.2.21"
 unwrap-infallible = "1.0.0"
+serde-tuple-vec-map = "1.0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/quickwit-oss/tantivy"
 readme = "README.md"
 keywords = ["search", "information", "retrieval"]
 edition = "2021"
-rust-version = "1.86"
+rust-version = "1.87"
 exclude = ["benches/*.json", "benches/*.txt"]
 
 [dependencies]

--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -8,6 +8,7 @@ use rand_distr::Distribution;
 use serde_json::json;
 use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::AggregationCollector;
+use tantivy::indexer::NoMergePolicy;
 use tantivy::query::{AllQuery, Query, TermQuery};
 use tantivy::schema::{IndexRecordOption, Schema, TextFieldIndexing, FAST, STRING};
 use tantivy::{doc, DateTime, Index, Term};
@@ -52,6 +53,46 @@ fn main() {
         runner.set_name(input_name);
         bench_agg(&mut runner, &index, execute_filtered);
     }
+
+    bench_many_segments();
+}
+
+fn bench_many_segments() {
+    let mut runner = BenchRunner::new();
+    runner.add_plugin(PeakMemAllocPlugin::new(GLOBAL));
+    let index =
+        get_test_index_bench_with_num_segments(Cardinality::Full, 100).unwrap();
+    let mut group = runner.new_group();
+    group.set_name("100_segments");
+    for (benchmark_name, agg_req) in [
+        (
+            "terms_7",
+            terms_on_field("text_few_terms_status"),
+        ),
+        (
+            "terms_zipfs_1000",
+            terms_on_field("text_1000_terms_zipf"),
+        ),
+        (
+            "terms_150_000",
+            terms_on_field("text_many_terms"),
+        ),
+        (
+            "terms_all_unique",
+            terms_on_field("text_all_unique_terms"),
+        ),
+    ] {
+        group.register_with_input(benchmark_name, &index, move |index| {
+            execute_agg(index, agg_req.clone())
+        });
+    }
+    group.run();
+}
+
+fn terms_on_field(field: &str) -> AggregationRequest {
+    json!({
+        "terms": { "terms": { "field": field, "size": 100 } }
+    })
 }
 
 fn bench_agg(runner: &mut BenchRunner, index: &Index, execute_filtered: AggregationExecutor) {
@@ -985,12 +1026,26 @@ fn get_collector(agg_req: Aggregations) -> AggregationCollector {
 }
 
 fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
-    // Flag to reuse an on-disk index across runs. The generated data differs per cardinality, so
-    // the path must include the cardinality — otherwise one cardinality reuses another's index.
+    get_test_index_bench_with_num_segments(cardinality, 1)
+}
+
+fn get_test_index_bench_with_num_segments(
+    cardinality: Cardinality,
+    num_segments: usize,
+) -> tantivy::Result<Index> {
+    assert!(num_segments > 0);
+    assert!(num_segments == 1 || cardinality == Cardinality::Full);
+    assert_eq!(1_000_000 % num_segments, 0);
+    // Flag to reuse an on-disk index across runs. The generated data differs per cardinality and
+    // segment count, so the path must include both.
     let reuse_index = std::env::var("REUSE_AGG_BENCH_INDEX")
         .map(|v| v == "true")
         .unwrap_or(true);
-    let index_dir = format!("agg_bench/{cardinality:?}");
+    let index_dir = if num_segments == 1 {
+        format!("agg_bench/{cardinality:?}")
+    } else {
+        format!("agg_bench/{cardinality:?}_{num_segments}_segments")
+    };
     let mut schema_builder = Schema::builder();
     let text_fieldtype = tantivy::schema::TextOptions::default()
         .set_indexing_options(
@@ -1020,7 +1075,7 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
 
     if reuse_index && std::path::Path::new(&index_dir).try_exists()? {
         let index = Index::open_in_dir(&index_dir)?;
-        if index.schema() == schema {
+        if index.schema() == schema && index.searchable_segment_ids()?.len() == num_segments {
             return Ok(index);
         }
         drop(index);
@@ -1068,7 +1123,12 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
     {
         let mut rng = StdRng::from_seed([1u8; 32]);
         let mut filter_rng = StdRng::from_seed([2u8; 32]);
-        let mut index_writer = index.writer_with_num_threads(1, 200_000_000)?;
+        let mut index_writer = index.writer_with_num_threads(1, 400_000_000)?;
+        if num_segments > 1 {
+            index_writer.set_merge_policy(Box::new(NoMergePolicy));
+        }
+        let docs_per_segment = 1_000_000 / num_segments;
+        let mut num_indexed_docs = 0usize;
         // 1% steady-state match rate, with random clusters averaging four documents.
         const MATCH_RATE: f64 = 0.01;
         const CLUSTER_END_PROBABILITY: f64 = 0.25;
@@ -1083,6 +1143,10 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
             };
             document.add_text(filter_field, if filter_matches { "a" } else { "b" });
             index_writer.add_document(document)?;
+            num_indexed_docs += 1;
+            if num_segments > 1 && num_indexed_docs.is_multiple_of(docs_per_segment) {
+                index_writer.commit()?;
+            }
             Ok(())
         };
         // To make the different test cases comparable we just change one doc to force the
@@ -1170,6 +1234,7 @@ fn get_test_index_bench(cardinality: Cardinality) -> tantivy::Result<Index> {
         index_writer.commit()?;
     }
 
+    assert_eq!(index.searchable_segment_ids()?.len(), num_segments);
     Ok(index)
 }
 

--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -60,27 +60,14 @@ fn main() {
 fn bench_many_segments() {
     let mut runner = BenchRunner::new();
     runner.add_plugin(PeakMemAllocPlugin::new(GLOBAL));
-    let index =
-        get_test_index_bench_with_num_segments(Cardinality::Full, 100).unwrap();
+    let index = get_test_index_bench_with_num_segments(Cardinality::Full, 100).unwrap();
     let mut group = runner.new_group();
     group.set_name("100_segments");
     for (benchmark_name, agg_req) in [
-        (
-            "terms_7",
-            terms_on_field("text_few_terms_status"),
-        ),
-        (
-            "terms_zipfs_1000",
-            terms_on_field("text_1000_terms_zipf"),
-        ),
-        (
-            "terms_150_000",
-            terms_on_field("text_many_terms"),
-        ),
-        (
-            "terms_all_unique",
-            terms_on_field("text_all_unique_terms"),
-        ),
+        ("terms_7", terms_on_field("text_few_terms_status")),
+        ("terms_zipfs_1000", terms_on_field("text_1000_terms_zipf")),
+        ("terms_150_000", terms_on_field("text_many_terms")),
+        ("terms_all_unique", terms_on_field("text_all_unique_terms")),
     ] {
         group.register_with_input(benchmark_name, &index, move |index| {
             execute_agg(index, agg_req.clone())

--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -78,7 +78,7 @@ fn bench_many_segments() {
 
 fn terms_on_field(field: &str) -> AggregationRequest {
     json!({
-        "terms": { "terms": { "field": field, "size": 100 } }
+        "terms": { "terms": { "field": field, "size": 1000 } }
     })
 }
 

--- a/src/aggregation/agg_tests.rs
+++ b/src/aggregation/agg_tests.rs
@@ -1605,7 +1605,8 @@ fn test_percentile_order_segment_level() -> crate::Result<()> {
     assert!(
         buckets
             .entries
-            .contains_key(&IntermediateKey::Str("b".to_string())),
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("b".to_string())),
         "\"b\" (higher p50) should survive, not \"a\""
     );
     assert!(
@@ -1681,7 +1682,8 @@ fn test_percentile_order_prune_intermediate() -> crate::Result<()> {
     assert!(
         buckets
             .entries
-            .contains_key(&IntermediateKey::Str("b".to_string())),
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("b".to_string())),
         "\"b\" (higher p50) should survive, not \"a\""
     );
 

--- a/src/aggregation/bucket/filter.rs
+++ b/src/aggregation/bucket/filter.rs
@@ -1335,14 +1335,14 @@ mod tests {
                 "brands": {
                     "buckets": [
                         {
-                            "key": "samsung",
-                            "doc_count": 1,
-                            "avg_price": { "value": 799.0 }
-                        },
-                        {
                             "key": "apple",
                             "doc_count": 1,
                             "avg_price": { "value": 999.0 }
+                        },
+                        {
+                            "key": "samsung",
+                            "doc_count": 1,
+                            "avg_price": { "value": 799.0 }
                         }
                     ],
                     "sum_other_doc_count": 0,

--- a/src/aggregation/bucket/filter.rs
+++ b/src/aggregation/bucket/filter.rs
@@ -693,7 +693,7 @@ impl<B: SubAggBuffer> SegmentAggregationCollector for SegmentFilterCollector<B> 
 }
 
 /// Intermediate result for filter aggregation
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct IntermediateFilterBucketResult {
     /// Document count in this bucket
     pub doc_count: u64,

--- a/src/aggregation/bucket/multi_terms/mod.rs
+++ b/src/aggregation/bucket/multi_terms/mod.rs
@@ -1199,13 +1199,8 @@ fn resolve_column_value(
         ColumnType::I64 => Ok(IntermediateKey::I64(i64::from_u64(val))),
         _ => {
             // F64 and other numeric types
-            let f = f64::from_u64(val);
-            let normalized: NumericalValue = f.into();
-            Ok(match normalized.normalize() {
-                NumericalValue::U64(v) => IntermediateKey::U64(v),
-                NumericalValue::I64(v) => IntermediateKey::I64(v),
-                NumericalValue::F64(v) => IntermediateKey::F64(v),
-            })
+            let value = NumericalValue::from(f64::from_u64(val)).normalize();
+            Ok(value.into())
         }
     }
 }

--- a/src/aggregation/bucket/multi_terms/mod.rs
+++ b/src/aggregation/bucket/multi_terms/mod.rs
@@ -1206,7 +1206,7 @@ fn resolve_column_value(
 }
 
 /// Intermediate (segment-merged) result for multi_terms aggregation.
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct IntermediateMultiTermsBucketResult {
     /// Bucket entries keyed by composite `Vec<IntermediateKey>`.
     pub(crate) entries: FxHashMap<Vec<IntermediateKey>, IntermediateTermBucketEntry>,

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1325,8 +1325,11 @@ where
         let (term_doc_count_before_cutoff, sum_other_doc_count) =
             cut_off_buckets(&mut entries, segment_size, total_doc_count);
 
-        let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> = Default::default();
-        dict.reserve(entries.len());
+        // Collected entries, in unspecified order. The cross-segment merge keys entries by their
+        // own dictionary and the final result is sorted by the requested order, so segment-side
+        // order does not matter here.
+        let mut out: Vec<(IntermediateKey, IntermediateTermBucketEntry)> =
+            Vec::with_capacity(entries.len());
 
         if term_req.column_type == ColumnType::Str {
             let fallback_dict = Dictionary::empty();
@@ -1335,6 +1338,14 @@ where
                 .as_ref()
                 .map(|el| el.dictionary())
                 .unwrap_or_else(|| &fallback_dict);
+
+            // Collect into a map to dedup by key, then flush into `out`. Two cases need it: a real
+            // term may equal the `missing` placeholder, and the min_doc_count==0 fill must skip
+            // already-collected terms. A single-segment query returns this result directly (the
+            // cross-segment merge that would otherwise dedup never runs), so duplicate keys here
+            // would reach the final result unmerged.
+            let mut dict: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> =
+                FxHashMap::with_capacity_and_hasher(entries.len(), Default::default());
 
             if let Some((intermediate_key, bucket)) = extract_missing_value(&mut entries, term_req)
             {
@@ -1405,6 +1416,8 @@ where
                         });
                 }
             }
+
+            out.extend(dict);
         } else if term_req.column_type == ColumnType::DateTime {
             for (val, doc_count) in entries {
                 let intermediate_entry = into_intermediate_bucket_entry(
@@ -1414,7 +1427,7 @@ where
                 )?;
                 let val = i64::from_u64(val);
                 let date = format_date(val)?;
-                dict.insert(IntermediateKey::Str(date), intermediate_entry);
+                out.push((IntermediateKey::Str(date), intermediate_entry));
             }
         } else if term_req.column_type == ColumnType::Bool {
             for (val, doc_count) in entries {
@@ -1424,7 +1437,7 @@ where
                     agg_data,
                 )?;
                 let val = bool::from_u64(val);
-                dict.insert(IntermediateKey::Bool(val), intermediate_entry);
+                out.push((IntermediateKey::Bool(val), intermediate_entry));
             }
         } else if term_req.column_type == ColumnType::IpAddr {
             let compact_space_accessor = term_req
@@ -1449,7 +1462,7 @@ where
                 )?;
                 let val: u128 = compact_space_accessor.compact_to_u128(val as u32);
                 let val = Ipv6Addr::from_u128(val);
-                dict.insert(IntermediateKey::IpAddr(val), intermediate_entry);
+                out.push((IntermediateKey::IpAddr(val), intermediate_entry));
             }
         } else {
             for (key_val_u64, doc_count) in entries {
@@ -1470,15 +1483,16 @@ where
                     }
                 };
                 let key = IntermediateKey::from(key_val.normalize());
-                dict.insert(key, intermediate_entry);
+                out.push((key, intermediate_entry));
             }
         };
 
         Ok(IntermediateBucketResult::Terms {
             buckets: IntermediateTermBucketResult {
-                entries: dict,
+                entries: out,
                 sum_other_doc_count,
                 doc_count_error_upper_bound: term_doc_count_before_cutoff,
+                ..Default::default()
             },
         })
     }

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1465,7 +1465,9 @@ where
                 out.push((IntermediateKey::IpAddr(val), intermediate_entry));
             }
         } else if term_req.column_type == ColumnType::F64 {
-            // Distinct f64 encodings can normalize to the same public key, notably -0.0 and +0.0.
+            // -0.0 and +0.0 both normalize to I64(0). Sort by normalized key to merge their
+            // buckets below. Other distinct f64 encodings, including NaNs, remain distinct:
+            // NaNs are not normalized and IntermediateKey compares them using total_cmp.
             let normalized_key = |val: u64| -> IntermediateKey {
                 NumericalValue::from(f64::from_u64(val)).normalize().into()
             };

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1464,17 +1464,40 @@ where
                 let val = Ipv6Addr::from_u128(val);
                 out.push((IntermediateKey::IpAddr(val), intermediate_entry));
             }
-        } else {
-            for (key_val_u64, doc_count) in entries {
+        } else if term_req.column_type == ColumnType::F64 {
+            // Distinct f64 encodings can normalize to the same public key, notably -0.0 and +0.0.
+            let normalized_key = |val: u64| -> IntermediateKey {
+                NumericalValue::from(f64::from_u64(val)).normalize().into()
+            };
+            entries.sort_unstable_by_key(|(val, _)| normalized_key(*val));
+
+            for (val, bucket) in entries {
+                let key = normalized_key(val);
                 let intermediate_entry = into_intermediate_bucket_entry(
-                    doc_count,
+                    bucket,
+                    reborrow_opt_collector(&mut sub_agg_collector),
+                    agg_data,
+                )?;
+                match out.last_mut() {
+                    Some((previous_key, existing)) if previous_key == &key => {
+                        existing.doc_count += intermediate_entry.doc_count;
+                        existing
+                            .sub_aggregation
+                            .merge_fruits(intermediate_entry.sub_aggregation)?;
+                    }
+                    _ => out.push((key, intermediate_entry)),
+                }
+            }
+        } else {
+            for (val, bucket) in entries {
+                let intermediate_entry = into_intermediate_bucket_entry(
+                    bucket,
                     reborrow_opt_collector(&mut sub_agg_collector),
                     agg_data,
                 )?;
                 let key_val: NumericalValue = match term_req.column_type {
-                    ColumnType::U64 => key_val_u64.into(),
-                    ColumnType::I64 => i64::from_u64(key_val_u64).into(),
-                    ColumnType::F64 => f64::from_u64(key_val_u64).into(),
+                    ColumnType::U64 => val.into(),
+                    ColumnType::I64 => i64::from_u64(val).into(),
                     _ => {
                         return Err(TantivyError::SchemaError(format!(
                             "unknown key type: {}",
@@ -1482,8 +1505,7 @@ where
                         )))
                     }
                 };
-                let key = IntermediateKey::from(key_val.normalize());
-                out.push((key, intermediate_entry));
+                out.push((key_val.normalize().into(), intermediate_entry));
             }
         };
 
@@ -1756,6 +1778,43 @@ mod tests {
                 json!({"key": 1, "doc_count": 2}),
             ]
         );
+    }
+
+    #[test]
+    fn terms_aggregation_merges_normalized_f64_buckets_with_sub_aggregations() -> crate::Result<()>
+    {
+        let index = get_test_index_from_values_and_terms(
+            true,
+            &[vec![
+                (-0.0, "negative_zero".to_string()),
+                (0.0, "positive_zero".to_string()),
+            ]],
+        )?;
+        let agg_req: Aggregations = serde_json::from_value(json!({
+            "zeros": {
+                "terms": { "field": "score_f64" },
+                "aggs": {
+                    "signs": { "terms": { "field": "string_id" } }
+                }
+            }
+        }))?;
+
+        let result = exec_request(agg_req, &index)?;
+        let zero_buckets = result["zeros"]["buckets"].as_array().unwrap();
+        assert_eq!(zero_buckets.len(), 1, "unexpected result: {result}");
+        assert_eq!(zero_buckets[0]["key"], 0);
+        assert_eq!(zero_buckets[0]["doc_count"], 2);
+
+        let sign_buckets = zero_buckets[0]["signs"]["buckets"].as_array().unwrap();
+        assert_eq!(sign_buckets.len(), 2, "unexpected result: {result}");
+        for sign in ["negative_zero", "positive_zero"] {
+            let bucket = sign_buckets
+                .iter()
+                .find(|bucket| bucket["key"] == sign)
+                .unwrap_or_else(|| panic!("missing {sign:?} bucket in {result}"));
+            assert_eq!(bucket["doc_count"], 1);
+        }
+        Ok(())
     }
 
     #[test]

--- a/src/aggregation/bucket/term_missing_agg.rs
+++ b/src/aggregation/bucket/term_missing_agg.rs
@@ -1,5 +1,4 @@
 use columnar::{Column, ColumnType};
-use rustc_hash::FxHashMap;
 
 use crate::aggregation::agg_data::{
     build_segment_agg_collectors, AggRefNode, AggregationsSegmentCtx,
@@ -8,7 +7,7 @@ use crate::aggregation::bucket::term_agg::TermsAggregation;
 use crate::aggregation::buffered_sub_aggs::{BufferedSubAggs, HighCardBufferedSubAggs};
 use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults, IntermediateBucketResult,
-    IntermediateKey, IntermediateTermBucketEntry, IntermediateTermBucketResult,
+    IntermediateTermBucketEntry, IntermediateTermBucketResult,
 };
 use crate::aggregation::segment_agg_result::{BucketIdProvider, SegmentAggregationCollector};
 use crate::aggregation::BucketId;
@@ -93,9 +92,6 @@ impl SegmentAggregationCollector for TermMissingAgg {
             .as_ref()
             .expect("TermMissingAgg collector, but no missing found in agg req")
             .clone();
-        let mut entries: FxHashMap<IntermediateKey, IntermediateTermBucketEntry> =
-            Default::default();
-
         let missing_count = &self.missing_count_per_bucket[parent_bucket_id as usize];
         let mut missing_entry = IntermediateTermBucketEntry {
             doc_count: missing_count.missing_count as u64,
@@ -108,13 +104,14 @@ impl SegmentAggregationCollector for TermMissingAgg {
                 .add_intermediate_aggregation_result(agg_data, &mut res, missing_count.bucket_id)?;
             missing_entry.sub_aggregation = res;
         }
-        entries.insert(missing.into(), missing_entry);
+        let entries = vec![(missing.into(), missing_entry)];
 
         let bucket = IntermediateBucketResult::Terms {
             buckets: IntermediateTermBucketResult {
                 entries,
                 sum_other_doc_count: 0,
                 doc_count_error_upper_bound: 0,
+                ..Default::default()
             },
         };
 

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -46,7 +46,7 @@ pub enum PruneMode {
 /// intermediate results.
 ///
 /// Notice: This struct should not be de/serialized via JSON format.
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct IntermediateAggregationResults {
     pub(crate) aggs_res: FxHashMap<String, IntermediateAggregationResult>,
 }
@@ -382,7 +382,7 @@ pub(crate) fn empty_from_req(req: &Aggregation) -> IntermediateAggregationResult
 }
 
 /// An aggregation is either a bucket or a metric.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum IntermediateAggregationResult {
     /// Bucket variant
@@ -615,7 +615,7 @@ impl IntermediateMetricResult {
 
 /// The intermediate bucket results. Internally they can be easily merged via the keys of the
 /// buckets.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IntermediateBucketResult {
     /// This is the range entry for a bucket, which contains a key, count, from, to, and optionally
     /// sub_aggregations.
@@ -916,7 +916,7 @@ impl IntermediateBucketResult {
     }
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 /// Range aggregation including error counts
 pub struct IntermediateRangeBucketResult {
     pub(crate) buckets: FxHashMap<SerializedKey, IntermediateRangeBucketEntry>,
@@ -936,15 +936,6 @@ pub struct IntermediateTermBucketResult {
     /// every pairwise merge. Not serialized; rebuilt on demand.
     #[serde(skip)]
     pub(crate) key_to_idx_in_entries: FxHashMap<IntermediateKey, u32>,
-}
-
-// `key_to_idx_in_entries` is a transient acceleration structure and is excluded from equality.
-impl PartialEq for IntermediateTermBucketResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.entries == other.entries
-            && self.sum_other_doc_count == other.sum_other_doc_count
-            && self.doc_count_error_upper_bound == other.doc_count_error_upper_bound
-    }
 }
 
 impl IntermediateTermBucketResult {
@@ -1247,7 +1238,7 @@ fn merge_maps<V: MergeFruits + Clone, T: Eq + PartialEq + Hash>(
 
 /// This is the histogram entry for a bucket, which contains a key, count, and optionally
 /// sub_aggregations.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IntermediateHistogramBucketEntry {
     /// The unique the bucket is identified.
     pub key: f64,
@@ -1276,7 +1267,7 @@ impl IntermediateHistogramBucketEntry {
 
 /// This is the range entry for a bucket, which contains a key, count, and optionally
 /// sub_aggregations.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IntermediateRangeBucketEntry {
     /// The unique key the bucket is identified with.
     pub key: IntermediateKey,
@@ -1329,7 +1320,7 @@ impl IntermediateRangeBucketEntry {
 
 /// This is the term entry for a bucket, which contains a count, and optionally
 /// sub_aggregations.
-#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
 pub struct IntermediateTermBucketEntry {
     /// The number of documents in the bucket.
     pub doc_count: u64,
@@ -1405,7 +1396,7 @@ impl std::hash::Hash for CompositeIntermediateKey {
 }
 
 /// Composite aggregation page.
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 pub struct IntermediateCompositeBucketResult {
     pub(crate) entries: FxHashMap<Vec<CompositeIntermediateKey>, IntermediateCompositeBucketEntry>,
     pub(crate) target_size: u32,
@@ -1599,6 +1590,40 @@ mod tests {
         }
     }
 
+    fn assert_range_trees_eq(
+        actual: &IntermediateAggregationResults,
+        expected: &IntermediateAggregationResults,
+    ) {
+        assert_eq!(actual.aggs_res.len(), expected.aggs_res.len());
+        for (name, actual_result) in &actual.aggs_res {
+            let expected_result = expected.aggs_res.get(name).unwrap();
+            let (
+                IntermediateAggregationResult::Bucket(IntermediateBucketResult::Range(
+                    actual_range,
+                )),
+                IntermediateAggregationResult::Bucket(IntermediateBucketResult::Range(
+                    expected_range,
+                )),
+            ) = (actual_result, expected_result)
+            else {
+                panic!("expected range aggregation results");
+            };
+            assert_eq!(actual_range.column_type, expected_range.column_type);
+            assert_eq!(actual_range.buckets.len(), expected_range.buckets.len());
+            for (key, actual_entry) in &actual_range.buckets {
+                let expected_entry = expected_range.buckets.get(key).unwrap();
+                assert_eq!(actual_entry.key, expected_entry.key);
+                assert_eq!(actual_entry.doc_count, expected_entry.doc_count);
+                assert_eq!(actual_entry.from, expected_entry.from);
+                assert_eq!(actual_entry.to, expected_entry.to);
+                assert_range_trees_eq(
+                    &actual_entry.sub_aggregation_res,
+                    &expected_entry.sub_aggregation_res,
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_merge_fruits_tree_1() {
         let mut tree_left = get_intermediate_tree_with_ranges(&[
@@ -1617,7 +1642,7 @@ mod tests {
             ("blue".to_string(), 55, "1900".to_string(), 80),
         ]);
 
-        assert_eq!(tree_left, tree_expected);
+        assert_range_trees_eq(&tree_left, &tree_expected);
     }
 
     #[test]
@@ -1639,7 +1664,7 @@ mod tests {
             ("green".to_string(), 25, "1900".to_string(), 50),
         ]);
 
-        assert_eq!(tree_left, tree_expected);
+        assert_range_trees_eq(&tree_left, &tree_expected);
     }
 
     #[test]
@@ -1873,6 +1898,6 @@ mod tests {
             .merge_fruits(IntermediateAggregationResults::default())
             .unwrap();
 
-        assert_eq!(tree_left, orig);
+        assert_range_trees_eq(&tree_left, &orig);
     }
 }

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -787,10 +787,7 @@ impl IntermediateBucketResult {
                     buckets: term_res_right,
                 },
             ) => {
-                merge_maps(&mut term_res_left.entries, term_res_right.entries)?;
-                term_res_left.sum_other_doc_count += term_res_right.sum_other_doc_count;
-                term_res_left.doc_count_error_upper_bound +=
-                    term_res_right.doc_count_error_upper_bound;
+                term_res_left.merge(term_res_right)?;
             }
 
             (
@@ -888,17 +885,71 @@ pub struct IntermediateRangeBucketResult {
     pub(crate) column_type: Option<ColumnType>,
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 /// Term aggregation including error counts
 pub struct IntermediateTermBucketResult {
-    pub(crate) entries: FxHashMap<IntermediateKey, IntermediateTermBucketEntry>,
+    /// Bucket entries as a flat `Vec`, in unspecified order. The final result is sorted by the
+    /// requested order (see `into_final_result`).
+    pub(crate) entries: Vec<(IntermediateKey, IntermediateTermBucketEntry)>,
     pub(crate) sum_other_doc_count: u64,
     pub(crate) doc_count_error_upper_bound: u64,
+    /// Transient `key -> position in entries` index, populated lazily on the first merge so that
+    /// folding many segment results stays O(total entries) instead of rebuilding a dictionary on
+    /// every pairwise merge. Not serialized; rebuilt on demand.
+    #[serde(skip)]
+    pub(crate) key_to_idx_in_entries: FxHashMap<IntermediateKey, u32>,
+}
+
+// `key_to_idx_in_entries` is a transient acceleration structure and is excluded from equality.
+impl PartialEq for IntermediateTermBucketResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.entries == other.entries
+            && self.sum_other_doc_count == other.sum_other_doc_count
+            && self.doc_count_error_upper_bound == other.doc_count_error_upper_bound
+    }
 }
 
 impl IntermediateTermBucketResult {
-    /// Returns a reference to the map of bucket entries keyed by [`IntermediateKey`].
-    pub fn entries(&self) -> &FxHashMap<IntermediateKey, IntermediateTermBucketEntry> {
+    /// Merge `other` into `self` in place.
+    ///
+    /// The first merge builds `self.key_to_idx_in_entries` (`key -> position`) once; subsequent
+    /// merges reuse it, so
+    /// each entry is hashed once and the accumulator grows incrementally. This keeps both the
+    /// per-segment fold and the cross-node `merge_fruits` fold linear in the total number of
+    /// entries. Output order is first-seen: existing keys merge in place, new keys are appended.
+    fn merge(&mut self, other: IntermediateTermBucketResult) -> crate::Result<()> {
+        self.sum_other_doc_count += other.sum_other_doc_count;
+        self.doc_count_error_upper_bound += other.doc_count_error_upper_bound;
+        if other.entries.is_empty() {
+            return Ok(());
+        }
+        if self.entries.is_empty() {
+            self.entries = other.entries;
+            return Ok(());
+        }
+        if self.key_to_idx_in_entries.is_empty() {
+            self.key_to_idx_in_entries
+                .reserve(self.entries.len() + other.entries.len());
+            for (idx, (key, _)) in self.entries.iter().enumerate() {
+                self.key_to_idx_in_entries.insert(key.clone(), idx as u32);
+            }
+        }
+        for (key, bucket) in other.entries {
+            if let Some(&idx_in_entries) = self.key_to_idx_in_entries.get(&key) {
+                let entry = &mut self.entries[idx_in_entries as usize].1;
+                entry.doc_count += bucket.doc_count;
+                entry.sub_aggregation.merge_fruits(bucket.sub_aggregation)?;
+            } else {
+                self.key_to_idx_in_entries
+                    .insert(key.clone(), self.entries.len() as u32);
+                self.entries.push((key, bucket));
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the bucket entries. Order is unspecified.
+    pub fn entries(&self) -> &[(IntermediateKey, IntermediateTermBucketEntry)] {
         &self.entries
     }
 
@@ -955,10 +1006,26 @@ impl IntermediateTermBucketResult {
                 });
             }
             OrderTarget::Count => {
+                // Tie-break equal counts by key ascending so the output is deterministic
+                // regardless of the merge's (insertion-order) output.
+                let key_tie = |left: &BucketEntry, right: &BucketEntry| {
+                    left.key
+                        .partial_cmp(&right.key)
+                        .expect("expected type string, which is always sortable")
+                };
                 if req.order.order == Order::Desc {
-                    buckets.sort_unstable_by_key(|bucket| std::cmp::Reverse(bucket.doc_count()));
+                    buckets.sort_unstable_by(|left, right| {
+                        right
+                            .doc_count()
+                            .cmp(&left.doc_count())
+                            .then_with(|| key_tie(left, right))
+                    });
                 } else {
-                    buckets.sort_unstable_by_key(|bucket| bucket.doc_count());
+                    buckets.sort_unstable_by(|left, right| {
+                        left.doc_count()
+                            .cmp(&right.doc_count())
+                            .then_with(|| key_tie(left, right))
+                    });
                 }
             }
             OrderTarget::SubAggregation(name) => {
@@ -1013,17 +1080,19 @@ impl IntermediateTermBucketResult {
         mode: PruneMode,
     ) -> crate::Result<()> {
         let req_internal = TermsAggregationInternal::from_req(req);
+        // Pruning changes entry positions, invalidating the transient merge index.
+        self.key_to_idx_in_entries.clear();
         let size = if mode == PruneMode::Final {
             let min_doc_count = req_internal.min_doc_count;
-            self.entries.retain(|_, e| e.doc_count >= min_doc_count);
+            self.entries
+                .retain(|(_, entry)| entry.doc_count >= min_doc_count);
             req_internal.size as usize
         } else {
             req_internal.segment_size as usize
         };
 
         if self.entries.len() > size {
-            let mut entries: Vec<(IntermediateKey, IntermediateTermBucketEntry)> =
-                self.entries.drain().collect();
+            let mut entries = std::mem::take(&mut self.entries);
 
             match &req_internal.order.target {
                 OrderTarget::SubAggregation(sub_agg_path) => {
@@ -1087,10 +1156,10 @@ impl IntermediateTermBucketResult {
                 self.doc_count_error_upper_bound += cutoff_doc_count;
             }
             entries.truncate(size);
-            self.entries = entries.into_iter().collect();
+            self.entries = entries;
         }
 
-        for entry in self.entries.values_mut() {
+        for (_, entry) in &mut self.entries {
             entry
                 .sub_aggregation
                 .prune_intermediate_results(sub_aggregation_req, mode)?;
@@ -1533,9 +1602,8 @@ mod tests {
             );
         }
         let mut term_result = IntermediateTermBucketResult {
-            entries: buckets,
-            sum_other_doc_count: 0,
-            doc_count_error_upper_bound: 0,
+            entries: buckets.into_iter().collect(),
+            ..Default::default()
         };
 
         let req: TermsAggregation =
@@ -1548,10 +1616,12 @@ mod tests {
         assert_eq!(term_result.entries.len(), 2);
         assert!(term_result
             .entries
-            .contains_key(&IntermediateKey::Str("c".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("c".to_string())));
         assert!(term_result
             .entries
-            .contains_key(&IntermediateKey::Str("e".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("e".to_string())));
         assert_eq!(term_result.sum_other_doc_count, 10 + 5 + 1);
         // final-size cutoff doesn't contribute to error bound
         assert_eq!(term_result.doc_count_error_upper_bound, 0);
@@ -1573,9 +1643,8 @@ mod tests {
             );
         }
         let mut term_result = IntermediateTermBucketResult {
-            entries: buckets,
-            sum_other_doc_count: 0,
-            doc_count_error_upper_bound: 0,
+            entries: buckets.into_iter().collect(),
+            ..Default::default()
         };
 
         let req: TermsAggregation =
@@ -1588,7 +1657,8 @@ mod tests {
         assert_eq!(term_result.entries.len(), 4);
         assert!(!term_result
             .entries
-            .contains_key(&IntermediateKey::Str("d".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("d".to_string())));
         assert_eq!(term_result.sum_other_doc_count, 1);
         assert_eq!(term_result.doc_count_error_upper_bound, 1);
     }
@@ -1611,9 +1681,8 @@ mod tests {
             "my_terms".to_string(),
             IntermediateAggregationResult::Bucket(IntermediateBucketResult::Terms {
                 buckets: IntermediateTermBucketResult {
-                    entries: buckets,
-                    sum_other_doc_count: 0,
-                    doc_count_error_upper_bound: 0,
+                    entries: buckets.into_iter().collect(),
+                    ..Default::default()
                 },
             }),
         );
@@ -1634,7 +1703,8 @@ mod tests {
         assert_eq!(buckets.entries.len(), 1);
         assert!(buckets
             .entries
-            .contains_key(&IntermediateKey::Str("x".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("x".to_string())));
         assert_eq!(buckets.sum_other_doc_count, 60); // y(50) + z(10)
     }
 
@@ -1654,9 +1724,8 @@ mod tests {
             );
         }
         let mut term_result = IntermediateTermBucketResult {
-            entries: buckets,
-            sum_other_doc_count: 0,
-            doc_count_error_upper_bound: 0,
+            entries: buckets.into_iter().collect(),
+            ..Default::default()
         };
 
         let req: TermsAggregation =
@@ -1670,10 +1739,12 @@ mod tests {
         assert_eq!(term_result.entries.len(), 2);
         assert!(term_result
             .entries
-            .contains_key(&IntermediateKey::Str("a".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("a".to_string())));
         assert!(term_result
             .entries
-            .contains_key(&IntermediateKey::Str("b".to_string())));
+            .iter()
+            .any(|(key, _)| key == &IntermediateKey::Str("b".to_string())));
     }
 
     #[test]

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -928,6 +928,7 @@ pub struct IntermediateRangeBucketResult {
 pub struct IntermediateTermBucketResult {
     /// Bucket entries as a flat `Vec`, in unspecified order. The final result is sorted by the
     /// requested order (see `into_final_result`).
+    #[serde(with = "tuple_vec_map")]
     pub(crate) entries: Vec<(IntermediateKey, IntermediateTermBucketEntry)>,
     pub(crate) sum_other_doc_count: u64,
     pub(crate) doc_count_error_upper_bound: u64,
@@ -1518,6 +1519,46 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_deserialize_legacy_postcard_term_result() {
+        // Quickwit sends intermediate aggregation results between nodes, which may run different
+        // versions during a rollout. This fixture ensures the wire format of existing aggregations
+        // remains readable. It was generated with commit 8e7e157f1, where term entries were stored
+        // in an FxHashMap, and contains one terms bucket with a nested histogram bucket.
+        const POSTCARD_FIXTURE: &[u8] = &[
+            1, 1, 116, 0, 2, 1, 5, 0, 1, 1, 1, 104, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
+            3, 4,
+        ];
+
+        let mut result: IntermediateAggregationResults =
+            postcard::from_bytes(POSTCARD_FIXTURE).unwrap();
+        let IntermediateAggregationResult::Bucket(IntermediateBucketResult::Terms {
+            buckets,
+        }) = result.aggs_res.remove("t").unwrap()
+        else {
+            panic!("expected terms aggregation");
+        };
+        assert_eq!(buckets.sum_other_doc_count, 3);
+        assert_eq!(buckets.doc_count_error_upper_bound, 4);
+        let [(IntermediateKey::U64(0), term_entry)] = buckets.entries.as_slice() else {
+            panic!("expected one u64 term bucket");
+        };
+        assert_eq!(term_entry.doc_count, 1);
+
+        let IntermediateAggregationResult::Bucket(IntermediateBucketResult::Histogram {
+            is_date_agg,
+            buckets,
+        }) = term_entry.sub_aggregation.aggs_res.get("h").unwrap()
+        else {
+            panic!("expected nested histogram aggregation");
+        };
+        assert!(!is_date_agg);
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0].key, 0.0);
+        assert_eq!(buckets[0].doc_count, 2);
+        assert!(buckets[0].sub_aggregation.aggs_res.is_empty());
+    }
 
     fn get_sub_test_tree(data: &[(String, u64)]) -> IntermediateAggregationResults {
         let mut map = HashMap::new();

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -1527,15 +1527,13 @@ mod tests {
         // remains readable. It was generated with commit 8e7e157f1, where term entries were stored
         // in an FxHashMap, and contains one terms bucket with a nested histogram bucket.
         const POSTCARD_FIXTURE: &[u8] = &[
-            1, 1, 116, 0, 2, 1, 5, 0, 1, 1, 1, 104, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0,
-            3, 4,
+            1, 1, 116, 0, 2, 1, 5, 0, 1, 1, 1, 104, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 3, 4,
         ];
 
         let mut result: IntermediateAggregationResults =
             postcard::from_bytes(POSTCARD_FIXTURE).unwrap();
-        let IntermediateAggregationResult::Bucket(IntermediateBucketResult::Terms {
-            buckets,
-        }) = result.aggs_res.remove("t").unwrap()
+        let IntermediateAggregationResult::Bucket(IntermediateBucketResult::Terms { buckets }) =
+            result.aggs_res.remove("t").unwrap()
         else {
             panic!("expected terms aggregation");
         };

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -1155,8 +1155,9 @@ impl IntermediateTermBucketResult {
                     }
                     entries = keyed.into_iter().map(|(_, entry)| entry).collect();
                 }
-                OrderTarget::Count if mode == PruneMode::Final => {
-                    // Match the final result ordering: equal counts are ordered by key ascending.
+                OrderTarget::Count => {
+                    // Match the final result ordering at every pruning level: equal counts are
+                    // ordered by key ascending, making the selected bucket set deterministic.
                     let mut keyed: Vec<(Key, (IntermediateKey, IntermediateTermBucketEntry))> =
                         entries
                             .into_iter()
@@ -1183,15 +1184,6 @@ impl IntermediateTermBucketResult {
                         );
                     }
                     entries = keyed.into_iter().map(|(_, entry)| entry).collect();
-                }
-                OrderTarget::Count => {
-                    if req_internal.order.order == Order::Desc {
-                        entries.select_nth_unstable_by_key(size, |(_, e)| {
-                            std::cmp::Reverse(e.doc_count)
-                        });
-                    } else {
-                        entries.select_nth_unstable_by_key(size, |(_, e)| e.doc_count);
-                    }
                 }
             }
             let cutoff_doc_count = entries[size].1.doc_count;
@@ -1709,41 +1701,44 @@ mod tests {
     }
 
     #[test]
-    fn test_prune_intermediate_results_final_count_ties_by_key() {
+    fn test_prune_intermediate_results_count_ties_by_key() {
         use crate::aggregation::bucket::TermsAggregation;
 
-        for order in ["asc", "desc"] {
-            let entries = ["z", "y", "a"]
-                .into_iter()
-                .map(|key| {
-                    (
-                        IntermediateKey::Str(key.to_string()),
-                        IntermediateTermBucketEntry {
-                            doc_count: 1,
-                            sub_aggregation: Default::default(),
-                        },
-                    )
-                })
-                .collect();
-            let mut term_result = IntermediateTermBucketResult {
-                entries,
-                ..Default::default()
-            };
-            let req: TermsAggregation = serde_json::from_value(serde_json::json!({
-                "field": "myfield",
-                "size": 1,
-                "order": { "_count": order },
-            }))
-            .unwrap();
-
-            term_result
-                .prune_intermediate_results(&req, &Default::default(), PruneMode::Final)
+        for mode in [PruneMode::Final, PruneMode::Intermediate] {
+            for order in ["asc", "desc"] {
+                let entries = ["z", "y", "a"]
+                    .into_iter()
+                    .map(|key| {
+                        (
+                            IntermediateKey::Str(key.to_string()),
+                            IntermediateTermBucketEntry {
+                                doc_count: 1,
+                                sub_aggregation: Default::default(),
+                            },
+                        )
+                    })
+                    .collect();
+                let mut term_result = IntermediateTermBucketResult {
+                    entries,
+                    ..Default::default()
+                };
+                let req: TermsAggregation = serde_json::from_value(serde_json::json!({
+                    "field": "myfield",
+                    "size": 1,
+                    "segment_size": 1,
+                    "order": { "_count": order },
+                }))
                 .unwrap();
 
-            assert_eq!(
-                term_result.entries[0].0,
-                IntermediateKey::Str("a".to_string())
-            );
+                term_result
+                    .prune_intermediate_results(&req, &Default::default(), mode)
+                    .unwrap();
+
+                assert_eq!(
+                    term_result.entries[0].0,
+                    IntermediateKey::Str("a".to_string())
+                );
+            }
         }
     }
 

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -998,21 +998,16 @@ impl IntermediateTermBucketResult {
             OrderTarget::Key => {
                 buckets.sort_by(|left, right| {
                     if req.order.order == Order::Asc {
-                        left.key.partial_cmp(&right.key)
+                        left.key.cmp(&right.key)
                     } else {
-                        right.key.partial_cmp(&left.key)
+                        right.key.cmp(&left.key)
                     }
-                    .expect("expected type string, which is always sortable")
                 });
             }
             OrderTarget::Count => {
                 // Tie-break equal counts by key ascending so the output is deterministic
                 // regardless of the merge's (insertion-order) output.
-                let key_tie = |left: &BucketEntry, right: &BucketEntry| {
-                    left.key
-                        .partial_cmp(&right.key)
-                        .expect("expected type string, which is always sortable")
-                };
+                let key_tie = |left: &BucketEntry, right: &BucketEntry| left.key.cmp(&right.key);
                 if req.order.order == Order::Desc {
                     buckets.sort_unstable_by(|left, right| {
                         right
@@ -1125,15 +1120,9 @@ impl IntermediateTermBucketResult {
                             .map(|entry| (entry.0.clone().into(), entry))
                             .collect();
                     if req_internal.order.order == Order::Desc {
-                        keyed.select_nth_unstable_by(size, |(k1, _), (k2, _)| {
-                            k2.partial_cmp(k1)
-                                .expect("expected type string, which is always sortable")
-                        });
+                        keyed.select_nth_unstable_by(size, |(k1, _), (k2, _)| k2.cmp(k1));
                     } else {
-                        keyed.select_nth_unstable_by(size, |(k1, _), (k2, _)| {
-                            k1.partial_cmp(k2)
-                                .expect("expected type string, which is always sortable")
-                        });
+                        keyed.select_nth_unstable_by(size, |(k1, _), (k2, _)| k1.cmp(k2));
                     }
                     entries = keyed.into_iter().map(|(_, entry)| entry).collect();
                 }

--- a/src/aggregation/intermediate_agg_result.rs
+++ b/src/aggregation/intermediate_agg_result.rs
@@ -51,7 +51,7 @@ pub struct IntermediateAggregationResults {
     pub(crate) aggs_res: FxHashMap<String, IntermediateAggregationResult>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// The key to identify a bucket.
 /// This might seem redundant with `Key`, but the point is to have a different
 /// Serialize implementation.
@@ -70,16 +70,56 @@ pub enum IntermediateKey {
     U64(u64),
 }
 
-impl From<NumericalValue> for IntermediateKey {
-    fn from(value: NumericalValue) -> Self {
-        match value {
-            NumericalValue::I64(i64_val) => IntermediateKey::I64(i64_val),
-            NumericalValue::U64(u64_val) => IntermediateKey::U64(u64_val),
-            NumericalValue::F64(f64_val) => IntermediateKey::F64(f64_val),
+impl IntermediateKey {
+    fn variant_ord(&self) -> u8 {
+        match self {
+            Self::IpAddr(_) => 0,
+            Self::Bool(_) => 1,
+            Self::Str(_) => 2,
+            Self::F64(_) => 3,
+            Self::I64(_) => 4,
+            Self::U64(_) => 5,
         }
     }
 }
 
+impl Ord for IntermediateKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::IpAddr(left), Self::IpAddr(right)) => left.cmp(right),
+            (Self::Bool(left), Self::Bool(right)) => left.cmp(right),
+            (Self::Str(left), Self::Str(right)) => left.cmp(right),
+            (Self::F64(left), Self::F64(right)) => left.total_cmp(right),
+            (Self::I64(left), Self::I64(right)) => left.cmp(right),
+            (Self::U64(left), Self::U64(right)) => left.cmp(right),
+            (left, right) => left.variant_ord().cmp(&right.variant_ord()),
+        }
+    }
+}
+
+impl PartialOrd for IntermediateKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for IntermediateKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for IntermediateKey {}
+
+impl From<NumericalValue> for IntermediateKey {
+    fn from(value: NumericalValue) -> Self {
+        match value {
+            NumericalValue::U64(value) => Self::U64(value),
+            NumericalValue::I64(value) => Self::I64(value),
+            NumericalValue::F64(value) => Self::F64(value),
+        }
+    }
+}
 impl From<Key> for IntermediateKey {
     fn from(value: Key) -> Self {
         match value {
@@ -109,8 +149,6 @@ impl From<IntermediateKey> for Key {
         }
     }
 }
-
-impl Eq for IntermediateKey {}
 
 impl std::fmt::Display for IntermediateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1126,6 +1164,35 @@ impl IntermediateTermBucketResult {
                     }
                     entries = keyed.into_iter().map(|(_, entry)| entry).collect();
                 }
+                OrderTarget::Count if mode == PruneMode::Final => {
+                    // Match the final result ordering: equal counts are ordered by key ascending.
+                    let mut keyed: Vec<(Key, (IntermediateKey, IntermediateTermBucketEntry))> =
+                        entries
+                            .into_iter()
+                            .map(|entry| (entry.0.clone().into(), entry))
+                            .collect();
+                    if req_internal.order.order == Order::Desc {
+                        keyed.select_nth_unstable_by(
+                            size,
+                            |(left_key, (_, left)), (right_key, (_, right))| {
+                                right
+                                    .doc_count
+                                    .cmp(&left.doc_count)
+                                    .then_with(|| left_key.cmp(right_key))
+                            },
+                        );
+                    } else {
+                        keyed.select_nth_unstable_by(
+                            size,
+                            |(left_key, (_, left)), (right_key, (_, right))| {
+                                left.doc_count
+                                    .cmp(&right.doc_count)
+                                    .then_with(|| left_key.cmp(right_key))
+                            },
+                        );
+                    }
+                    entries = keyed.into_iter().map(|(_, entry)| entry).collect();
+                }
                 OrderTarget::Count => {
                     if req_internal.order.order == Order::Desc {
                         entries.select_nth_unstable_by_key(size, |(_, e)| {
@@ -1614,6 +1681,45 @@ mod tests {
         assert_eq!(term_result.sum_other_doc_count, 10 + 5 + 1);
         // final-size cutoff doesn't contribute to error bound
         assert_eq!(term_result.doc_count_error_upper_bound, 0);
+    }
+
+    #[test]
+    fn test_prune_intermediate_results_final_count_ties_by_key() {
+        use crate::aggregation::bucket::TermsAggregation;
+
+        for order in ["asc", "desc"] {
+            let entries = ["z", "y", "a"]
+                .into_iter()
+                .map(|key| {
+                    (
+                        IntermediateKey::Str(key.to_string()),
+                        IntermediateTermBucketEntry {
+                            doc_count: 1,
+                            sub_aggregation: Default::default(),
+                        },
+                    )
+                })
+                .collect();
+            let mut term_result = IntermediateTermBucketResult {
+                entries,
+                ..Default::default()
+            };
+            let req: TermsAggregation = serde_json::from_value(serde_json::json!({
+                "field": "myfield",
+                "size": 1,
+                "order": { "_count": order },
+            }))
+            .unwrap();
+
+            term_result
+                .prune_intermediate_results(&req, &Default::default(), PruneMode::Final)
+                .unwrap();
+
+            assert_eq!(
+                term_result.entries[0].0,
+                IntermediateKey::Str("a".to_string())
+            );
+        }
     }
 
     #[test]

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -142,6 +142,7 @@ pub mod intermediate_agg_result;
 pub mod metric;
 
 mod segment_agg_result;
+use std::cmp::Ordering;
 use std::fmt::Display;
 
 pub(crate) use block_accessor::ColumnBlockAccessor;
@@ -298,7 +299,7 @@ where D: Deserializer<'de> {
 /// The serialized key is used in a `HashMap`.
 pub type SerializedKey = String;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// The key to identify a bucket.
 ///
 /// The order is important, with serde untagged, that we try to deserialize into i64 first.
@@ -314,6 +315,35 @@ pub enum Key {
     F64(f64),
 }
 impl Eq for Key {}
+
+impl Ord for Key {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Str(left), Self::Str(right)) => left.cmp(right),
+            (Self::I64(left), Self::I64(right)) => left.cmp(right),
+            (Self::U64(left), Self::U64(right)) => left.cmp(right),
+            (Self::F64(left), Self::F64(right)) => left.total_cmp(right),
+            // Keep the variant order from the previous derived `PartialOrd` implementation.
+            (left, right) => key_variant_ord(left).cmp(&key_variant_ord(right)),
+        }
+    }
+}
+
+impl PartialOrd for Key {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn key_variant_ord(key: &Key) -> u8 {
+    match key {
+        Key::Str(_) => 0,
+        Key::I64(_) => 1,
+        Key::U64(_) => 2,
+        Key::F64(_) => 3,
+    }
+}
+
 impl std::hash::Hash for Key {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         core::mem::discriminant(self).hash(state);
@@ -406,6 +436,7 @@ pub(crate) fn f64_to_fastfield_u64(val: f64, field_type: &ColumnType) -> Option<
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::net::Ipv6Addr;
 
     use columnar::DateTime;
@@ -419,6 +450,20 @@ mod tests {
     use crate::schema::{IndexRecordOption, Schema, TextFieldIndexing, FAST, STRING};
     use crate::tokenizer::RAW_TOKENIZER_NAME;
     use crate::{Index, IndexWriter, Term};
+
+    #[test]
+    fn key_order_is_total_and_consistent_with_equality() {
+        let negative_zero = Key::F64(-0.0);
+        let positive_zero = Key::F64(0.0);
+        assert_ne!(negative_zero, positive_zero);
+        assert_eq!(negative_zero.cmp(&positive_zero), Ordering::Less);
+
+        let nan = Key::F64(f64::from_bits(0x7ff8_0000_0000_0001));
+        assert_eq!(nan.cmp(&nan), Ordering::Equal);
+
+        let keys = BTreeSet::from([negative_zero, positive_zero, nan]);
+        assert_eq!(keys.len(), 3);
+    }
 
     pub fn get_test_index_with_num_docs(
         merge_segments: bool,


### PR DESCRIPTION
   ## Summary                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                               
   Speed up terms aggregation result merging across by replacing repeated hash-map reconstruction with a flat bucket vector and a key-to-position index.                                                                       
                                                                                                                                                                                                                                                               
   This targets queries over indexes with many segments, where intermediate term buckets are folded repeatedly and the previous merge path rehashed the accumulated result on every merge. 

   ## Changes                                                                                                                                                                                                                                                  
   - Store intermediate term buckets in a flat `Vec` rather than an `FxHashMap`.                                                                                                                                                                               
   - Build a transient key-to-position map on the first merge and reuse it while folding subsequent segment results.                                                                                                                                                                                                                                                                                                                                                                                                                        
   - Add deterministic key-based tie-breaking when term buckets have equal document counts.                                                                                                                                                                    
   - Extend `agg_bench` with a 100-segment index 
   - Give aggregation keys a total order, using `f64::total_cmp` so ordering is consistent with bitwise equality for NaNs and signed zero.

   ## Benchmark             
```
100_segments
terms_7             Memory: 871.4 KB (-1.20%)    Avg: 13.9813ms (-11.11%)    Median: 13.8848ms (-10.01%)    [13.4502ms .. 16.5813ms]    
terms_zipfs_1000    Memory: 7.0 MB (-15.73%)     Avg: 18.7053ms (-11.35%)    Median: 18.5579ms (-10.23%)    [18.0121ms .. 20.3877ms]    
terms_150_000       Memory: 13.6 MB (-14.20%)    Avg: 40.1980ms (-24.13%)    Median: 40.1449ms (-24.45%)    [39.2021ms .. 41.7115ms]    
terms_all_unique    Memory: 31.1 MB (+30.08%)    Avg: 40.9190ms (-33.76%)    Median: 40.9192ms (-34.39%)    [40.3646ms .. 41.5972ms]    
```


## Alternatives considered
An alternative would be k-merge on sorted Vecs. Results are merged incrementally in a distributed scenario, which may make this alternative more expensive.

## Profile

<img width="1610" height="703" alt="Screenshot 2026-08-13 at 08 15 34" src="https://github.com/user-attachments/assets/6c13568c-b26b-4642-aa6a-aef710aaa56f" />
