### PR TITLE
Add BlockFor fast field codec + SIMD batch decode (ALP included, unwired)

### DIFF
--- a/bitpacker/Cargo.toml
+++ b/bitpacker/Cargo.toml
@@ -15,7 +15,6 @@ homepage = "https://github.com/quickwit-oss/tantivy"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitpacking = { version = "0.9.2", default-features = false, features = ["bitpacker1x"] }
 
 [dev-dependencies]
 binggan = "0.17.0"

--- a/bitpacker/src/bitpacker.rs
+++ b/bitpacker/src/bitpacker.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::ops::{Range, RangeInclusive};
 
-use bitpacking::{BitPacker as ExternalBitPackerTrait, BitPacker1x};
+use crate::block_decode::{BLOCK_LEN, Lane, decode_block_lanes};
 
 pub struct BitPacker {
     mini_buffer: u64,
@@ -122,6 +122,10 @@ impl BitUnpacker {
         val_shifted & self.mask
     }
 
+    pub fn get_batch(&self, start_idx: u32, data: &[u8], output: &mut [u64]) {
+        self.get_batch_lanes(start_idx, data, output);
+    }
+
     // Decodes the range of bitpacked `u32` values with idx
     // in [start_idx, start_idx + output.len()).
     //
@@ -133,64 +137,46 @@ impl BitUnpacker {
             self.bit_width() <= 32,
             "Bitwidth must be <= 32 to use this method."
         );
+        self.get_batch_lanes(start_idx, data, output);
+    }
 
-        let end_idx: u32 = start_idx + output.len() as u32;
-
-        // We use `usize` here to avoid overflow issues.
-        let end_bit_read = (end_idx as usize) * self.num_bits;
-        let end_byte_read = end_bit_read.div_ceil(8);
+    /// Decodes `[start_idx, start_idx + output.len())` into `output`, routing
+    /// whole aligned blocks through [`crate::block_decode::decode_block`] and
+    /// the two edges through [`Self::get`].
+    ///
+    /// A block only starts byte-aligned -- which the kernels require -- when
+    /// its first index is a multiple of 8, since 8 values occupy exactly
+    /// `num_bits` bytes. So the block loop is preceded by an entrance ramp of
+    /// up to 7 values, and followed by an exit ramp of up to `BLOCK_LEN - 1`.
+    fn get_batch_lanes<L: Lane>(&self, start_idx: u32, data: &[u8], output: &mut [L]) {
+        // `usize` throughout to avoid overflow issues.
+        let end_idx = start_idx as usize + output.len();
         assert!(
-            end_byte_read <= data.len(),
+            (end_idx * self.num_bits).div_ceil(8) <= data.len(),
             "Requested index is out of bounds."
         );
 
-        // Simple slow implementation of get_batch_u32s, to deal with our ramps.
-        let get_batch_ramp = |start_idx: u32, output: &mut [u32]| {
-            for (out, idx) in output.iter_mut().zip(start_idx..) {
-                *out = self.get(idx, data) as u32;
-            }
+        let ramp = ((8 - start_idx % 8) % 8) as usize;
+        let mut cursor = if ramp + BLOCK_LEN <= output.len() {
+            ramp
+        } else {
+            output.len()
         };
-
-        // We use an unrolled routine to decode 32 values at once.
-        // We therefore decompose our range of values to decode into three ranges:
-        // - Entrance ramp: [start_idx, fast_track_start) (up to 31 values)
-        // - Highway: [fast_track_start, fast_track_end) (a length multiple of 32s)
-        // - Exit ramp: [fast_track_end, start_idx + output.len()) (up to 31 values)
-
-        // We want the start of the fast track to start align with bytes.
-        // A sufficient condition is to start with an idx that is a multiple of 8,
-        // so highway start is the closest multiple of 8 that is >= start_idx.
-        let entrance_ramp_len: u32 = 8 - (start_idx % 8) % 8;
-
-        let highway_start: u32 = start_idx + entrance_ramp_len;
-
-        if highway_start + (BitPacker1x::BLOCK_LEN as u32) > end_idx {
-            // We don't have enough values to have even a single block of highway.
-            // Let's just supply the values the simple way.
-            get_batch_ramp(start_idx, output);
-            return;
+        for (i, out) in output[..cursor].iter_mut().enumerate() {
+            *out = L::from_u64(self.get(start_idx + i as u32, data));
         }
-
-        let num_blocks: usize = (end_idx - highway_start) as usize / BitPacker1x::BLOCK_LEN;
-
-        // Entrance ramp
-        get_batch_ramp(start_idx, &mut output[..entrance_ramp_len as usize]);
-
-        // Highway
-        let mut offset = (highway_start as usize * self.num_bits) / 8;
-        let mut output_cursor = (highway_start - start_idx) as usize;
-        for _ in 0..num_blocks {
-            offset += BitPacker1x.decompress(
-                &data[offset..],
-                &mut output[output_cursor..],
-                self.num_bits as u8,
-            );
-            output_cursor += 32;
+        while cursor + BLOCK_LEN <= output.len() {
+            let block_start_bytes = (start_idx as usize + cursor) * self.num_bits / 8;
+            let block: &mut [L; BLOCK_LEN] = (&mut output[cursor..cursor + BLOCK_LEN])
+                .try_into()
+                .unwrap();
+            decode_block_lanes(self.num_bits as u8, &data[block_start_bytes..], block);
+            cursor += BLOCK_LEN;
         }
-
-        // Exit ramp
-        let highway_end: u32 = highway_start + (num_blocks * BitPacker1x::BLOCK_LEN) as u32;
-        get_batch_ramp(highway_end, &mut output[output_cursor..]);
+        for (i, out) in output[cursor..].iter_mut().enumerate() {
+            let idx = start_idx + (cursor + i) as u32;
+            *out = L::from_u64(self.get(idx, data));
+        }
     }
 
     pub fn get_ids_for_value_range(
@@ -348,6 +334,11 @@ mod test {
         bitunpacker.get_batch_u32s(8 * 4 - 2, &[0u8, 0u8, 0u8, 0u8], &mut output[..]);
     }
 
+    /// Lengths that straddle the block grid: none, one and several whole
+    /// blocks, plus both ramps.
+    const BATCH_LENS: [usize; 12] = [0, 1, 2, 32, 33, 64, 127, 128, 129, 135, 256, 300];
+    const NUM_VALS: u64 = 600;
+
     proptest::proptest! {
         #[test]
         fn test_get_batch_u32s_proptest(num_bits in 0u8..=32u8) {
@@ -359,19 +350,50 @@ mod test {
                 };
             let mut buffer: Vec<u8> = Vec::new();
             let mut bitpacker = BitPacker::new();
-            for val in 0..100 {
+            for val in 0..NUM_VALS {
                 bitpacker.write(val & mask as u64, num_bits, &mut buffer).unwrap();
             }
             bitpacker.flush(&mut buffer).unwrap();
             let bitunpacker = BitUnpacker::new(num_bits);
             let mut output: Vec<u32> = Vec::new();
-            for len in [0, 1, 2, 32, 33, 34, 64] {
+            for len in BATCH_LENS {
                 for start_idx in 0u32..32u32 {
                     output.resize(len, 0);
                     bitunpacker.get_batch_u32s(start_idx, &buffer, &mut output);
                     for (i, output_byte) in output.iter().enumerate() {
                         let expected = (start_idx + i as u32) & mask;
                         assert_eq!(*output_byte, expected);
+                    }
+                }
+            }
+        }
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn test_get_batch_proptest((num_bits, _vals) in vals_strategy()) {
+            let mask = if num_bits == 64 { u64::MAX } else { (1u64 << num_bits) - 1 };
+            // Values fill the whole width, so a kernel dropping high bits
+            // cannot pass.
+            let vals: Vec<u64> = (0..NUM_VALS)
+                .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15) & mask)
+                .collect();
+            let mut buffer: Vec<u8> = Vec::new();
+            let mut bitpacker = BitPacker::new();
+            for &val in &vals {
+                bitpacker.write(val, num_bits, &mut buffer).unwrap();
+            }
+            bitpacker.flush(&mut buffer).unwrap();
+            let bitunpacker = BitUnpacker::new(num_bits);
+            let mut output: Vec<u64> = Vec::new();
+            for len in BATCH_LENS {
+                for start_idx in 0u32..32u32 {
+                    output.resize(len, 0);
+                    bitunpacker.get_batch(start_idx, &buffer, &mut output);
+                    for (i, got) in output.iter().enumerate() {
+                        let idx = start_idx + i as u32;
+                        assert_eq!(*got, vals[idx as usize], "num_bits {num_bits} len {len} idx {idx}");
+                        assert_eq!(*got, bitunpacker.get(idx, &buffer));
                     }
                 }
             }

--- a/bitpacker/src/bitpacker.rs
+++ b/bitpacker/src/bitpacker.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::ops::{Range, RangeInclusive};
 
-use crate::block_decode::{BLOCK_LEN, Lane, decode_block_lanes};
+use crate::block_decode::{decode_range, decode_value};
 
 pub struct BitPacker {
     mini_buffer: u64,
@@ -94,36 +94,13 @@ impl BitUnpacker {
 
     #[inline]
     pub fn get(&self, idx: u32, data: &[u8]) -> u64 {
-        let addr_in_bits = idx as usize * self.num_bits;
-        let addr = addr_in_bits >> 3;
-        if addr + 8 > data.len() {
-            if self.num_bits == 0 {
-                return 0;
-            }
-            let bit_shift = addr_in_bits & 7;
-            return self.get_slow_path(addr, bit_shift as u32, data);
-        }
-        let bit_shift = addr_in_bits & 7;
-        let bytes: [u8; 8] = (&data[addr..addr + 8]).try_into().unwrap();
-        let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
-        let val_shifted = val_unshifted_unmasked >> bit_shift;
-        val_shifted & self.mask
+        decode_value(self.num_bits, self.mask, idx as usize, data)
     }
 
-    #[inline(never)]
-    fn get_slow_path(&self, addr: usize, bit_shift: u32, data: &[u8]) -> u64 {
-        let mut bytes: [u8; 8] = [0u8; 8];
-        let available_bytes = data.len() - addr;
-        // This function is meant to only be called if we did not have 8 bytes to load.
-        debug_assert!(available_bytes < 8);
-        bytes[..available_bytes].copy_from_slice(&data[addr..]);
-        let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
-        let val_shifted = val_unshifted_unmasked >> bit_shift;
-        val_shifted & self.mask
-    }
-
+    /// Decodes `[start_idx, start_idx + output.len())` into `output`. See
+    /// [`crate::block_decode::decode_range`].
     pub fn get_batch(&self, start_idx: u32, data: &[u8], output: &mut [u64]) {
-        self.get_batch_lanes(start_idx, data, output);
+        decode_range(self.bit_width(), start_idx as usize, data, output);
     }
 
     // Decodes the range of bitpacked `u32` values with idx
@@ -137,46 +114,7 @@ impl BitUnpacker {
             self.bit_width() <= 32,
             "Bitwidth must be <= 32 to use this method."
         );
-        self.get_batch_lanes(start_idx, data, output);
-    }
-
-    /// Decodes `[start_idx, start_idx + output.len())` into `output`, routing
-    /// whole aligned blocks through [`crate::block_decode::decode_block`] and
-    /// the two edges through [`Self::get`].
-    ///
-    /// A block only starts byte-aligned -- which the kernels require -- when
-    /// its first index is a multiple of 8, since 8 values occupy exactly
-    /// `num_bits` bytes. So the block loop is preceded by an entrance ramp of
-    /// up to 7 values, and followed by an exit ramp of up to `BLOCK_LEN - 1`.
-    fn get_batch_lanes<L: Lane>(&self, start_idx: u32, data: &[u8], output: &mut [L]) {
-        // `usize` throughout to avoid overflow issues.
-        let end_idx = start_idx as usize + output.len();
-        assert!(
-            (end_idx * self.num_bits).div_ceil(8) <= data.len(),
-            "Requested index is out of bounds."
-        );
-
-        let ramp = ((8 - start_idx % 8) % 8) as usize;
-        let mut cursor = if ramp + BLOCK_LEN <= output.len() {
-            ramp
-        } else {
-            output.len()
-        };
-        for (i, out) in output[..cursor].iter_mut().enumerate() {
-            *out = L::from_u64(self.get(start_idx + i as u32, data));
-        }
-        while cursor + BLOCK_LEN <= output.len() {
-            let block_start_bytes = (start_idx as usize + cursor) * self.num_bits / 8;
-            let block: &mut [L; BLOCK_LEN] = (&mut output[cursor..cursor + BLOCK_LEN])
-                .try_into()
-                .unwrap();
-            decode_block_lanes(self.num_bits as u8, &data[block_start_bytes..], block);
-            cursor += BLOCK_LEN;
-        }
-        for (i, out) in output[cursor..].iter_mut().enumerate() {
-            let idx = start_idx + (cursor + i) as u32;
-            *out = L::from_u64(self.get(idx, data));
-        }
+        decode_range(self.bit_width(), start_idx as usize, data, output);
     }
 
     pub fn get_ids_for_value_range(

--- a/bitpacker/src/block_decode/avx2.rs
+++ b/bitpacker/src/block_decode/avx2.rs
@@ -1,0 +1,151 @@
+use std::arch::x86_64::*;
+
+use super::{BLOCK_LEN, Lane};
+
+/// AVX2 unpack for bit widths 1..=25, the direct counterpart of the NEON
+/// kernel in `neon.rs`.
+///
+/// 8 consecutive values occupy exactly `w` bytes and always start
+/// byte-aligned, so the (byte offset, bit shift) pattern of the 8 values is a
+/// constant per width. `vpshufb` shuffles within each 128-bit half
+/// independently, so one 256-bit register does both halves of a group at once:
+/// the low half gathers values 0..4 from `ptr`, the high half gathers values
+/// 4..8 from `ptr + hi_base`. Then `vpsrlvd` applies the per-lane shift and
+/// `vpand` the width mask.
+///
+/// Constraint: bit_shift (<=7) + w <= 32 => w <= 25.
+///
+/// # Safety
+/// AVX2 must be available, and `data.len() >= 16 * w + 16` must hold (we read
+/// 16 bytes at `15 * w + (4 * w) / 8`, which is `< 16 * w + 16`).
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn decode_block_avx2<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+    debug_assert!((1..=25).contains(&w));
+    debug_assert!(data.len() >= 16 * w + 16);
+    let hi_base = (4 * w) / 8;
+    let mut idx = [0i8; 32];
+    let mut sh = [0i32; 8];
+    for j in 0..4 {
+        let bit_lo = j * w;
+        let bit_hi = (4 + j) * w;
+        for k in 0..4 {
+            idx[j * 4 + k] = (bit_lo / 8 + k) as i8;
+            idx[16 + j * 4 + k] = (bit_hi / 8 - hi_base + k) as i8;
+        }
+        sh[j] = (bit_lo % 8) as i32;
+        sh[4 + j] = (bit_hi % 8) as i32;
+    }
+    unsafe {
+        let idx_v = _mm256_loadu_si256(idx.as_ptr() as *const __m256i);
+        let sh_v = _mm256_loadu_si256(sh.as_ptr() as *const __m256i);
+        let mask = _mm256_set1_epi32(((1u64 << w) - 1) as i32);
+        let mut ptr = data.as_ptr();
+        let mut out_ptr = out.as_mut_ptr();
+        for _ in 0..BLOCK_LEN / 8 {
+            let bytes_lo = _mm_loadu_si128(ptr as *const __m128i);
+            let bytes_hi = _mm_loadu_si128(ptr.add(hi_base) as *const __m128i);
+            let bytes = _mm256_set_m128i(bytes_hi, bytes_lo);
+            let vals = _mm256_and_si256(
+                _mm256_srlv_epi32(_mm256_shuffle_epi8(bytes, idx_v), sh_v),
+                mask,
+            );
+            if L::IS_U64 {
+                let dst = out_ptr as *mut __m256i;
+                _mm256_storeu_si256(dst, _mm256_cvtepu32_epi64(_mm256_castsi256_si128(vals)));
+                _mm256_storeu_si256(
+                    dst.add(1),
+                    _mm256_cvtepu32_epi64(_mm256_extracti128_si256::<1>(vals)),
+                );
+            } else {
+                _mm256_storeu_si256(out_ptr as *mut __m256i, vals);
+            }
+            ptr = ptr.add(w);
+            out_ptr = out_ptr.add(8);
+        }
+    }
+}
+
+/// AVX2 unpack for bit widths 26..=56, the counterpart of
+/// `neon::decode_block_neon_wide`.
+///
+/// Same shape as [`decode_block_avx2`] with the lanes doubled: 4 `u64` lanes
+/// per register, so a group of 8 values is two iterations instead of one.
+/// `vpshufb` shuffles within each 128-bit half independently, and a half holds
+/// 2 values whose 8-byte spans both start within 16 bytes of the lower one, so
+/// each half still gathers from a single `vmovdqu`.
+///
+/// Constraint: bit_shift (<=7) + w <= 64 => w <= 57.
+///
+/// # Safety
+/// AVX2 must be available, and `data.len() >= 16 * w + 16` must hold: the last
+/// group starts at `15 * w` and its last pair loads 16 bytes at `+ 6 * w / 8`,
+/// which is `< 16 * w + 16`.
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn decode_block_avx2_wide<L: Lane>(
+    w: usize,
+    data: &[u8],
+    out: &mut [L; BLOCK_LEN],
+) {
+    debug_assert!((26..=57).contains(&w));
+    debug_assert!(data.len() >= 16 * w + 16);
+    // Per half-group of 4 values: the byte the low half loads from, the byte
+    // the high half loads from, the 32 shuffle indices and the 4 shifts.
+    let mut lo_base = [0usize; 2];
+    let mut hi_base = [0usize; 2];
+    let mut idx = [[0i8; 32]; 2];
+    let mut sh = [[0i64; 4]; 2];
+    for q in 0..2 {
+        for half in 0..2 {
+            let v = 4 * q + 2 * half;
+            let bit_lo = v * w;
+            let bit_hi = (v + 1) * w;
+            let base = bit_lo / 8;
+            if half == 0 {
+                lo_base[q] = base;
+            } else {
+                hi_base[q] = base;
+            }
+            let hi_delta = bit_hi / 8 - base;
+            for k in 0..8 {
+                idx[q][16 * half + k] = k as i8;
+                idx[q][16 * half + 8 + k] = (hi_delta + k) as i8;
+            }
+            sh[q][2 * half] = (bit_lo % 8) as i64;
+            sh[q][2 * half + 1] = (bit_hi % 8) as i64;
+        }
+    }
+    unsafe {
+        let mask = _mm256_set1_epi64x(((1u64 << w) - 1) as i64);
+        let mut ptr = data.as_ptr();
+        let mut out_ptr = out.as_mut_ptr();
+        for _ in 0..BLOCK_LEN / 8 {
+            for q in 0..2 {
+                let idx_v = _mm256_loadu_si256(idx[q].as_ptr() as *const __m256i);
+                let sh_v = _mm256_loadu_si256(sh[q].as_ptr() as *const __m256i);
+                let bytes_lo = _mm_loadu_si128(ptr.add(lo_base[q]) as *const __m128i);
+                let bytes_hi = _mm_loadu_si128(ptr.add(hi_base[q]) as *const __m128i);
+                let bytes = _mm256_set_m128i(bytes_hi, bytes_lo);
+                let vals = _mm256_and_si256(
+                    _mm256_srlv_epi64(_mm256_shuffle_epi8(bytes, idx_v), sh_v),
+                    mask,
+                );
+                if L::IS_U64 {
+                    _mm256_storeu_si256(out_ptr.add(4 * q) as *mut __m256i, vals);
+                } else {
+                    // Narrow the 4 `u64` lanes to 4 `u32`: gather the low
+                    // dword of each into the low half, then store that half.
+                    let packed = _mm256_permutevar8x32_epi32(
+                        vals,
+                        _mm256_setr_epi32(0, 2, 4, 6, 0, 0, 0, 0),
+                    );
+                    _mm_storeu_si128(
+                        out_ptr.add(4 * q) as *mut __m128i,
+                        _mm256_castsi256_si128(packed),
+                    );
+                }
+            }
+            ptr = ptr.add(w);
+            out_ptr = out_ptr.add(8);
+        }
+    }
+}

--- a/bitpacker/src/block_decode/avx2.rs
+++ b/bitpacker/src/block_decode/avx2.rs
@@ -1,9 +1,8 @@
 use std::arch::x86_64::*;
 
-use super::{BLOCK_LEN, Lane};
+use super::Lane;
 
-/// AVX2 unpack for bit widths 1..=25, the direct counterpart of the NEON
-/// kernel in `neon.rs`.
+/// AVX2 unpack for bit widths 1..=25
 ///
 /// 8 consecutive values occupy exactly `w` bytes and always start
 /// byte-aligned, so the (byte offset, bit shift) pattern of the 8 values is a
@@ -12,16 +11,11 @@ use super::{BLOCK_LEN, Lane};
 /// the low half gathers values 0..4 from `ptr`, the high half gathers values
 /// 4..8 from `ptr + hi_base`. Then `vpsrlvd` applies the per-lane shift and
 /// `vpand` the width mask.
-///
-/// Constraint: bit_shift (<=7) + w <= 32 => w <= 25.
-///
-/// # Safety
-/// AVX2 must be available, and `data.len() >= 16 * w + 16` must hold (we read
-/// 16 bytes at `15 * w + (4 * w) / 8`, which is `< 16 * w + 16`).
 #[target_feature(enable = "avx2")]
-pub(super) unsafe fn decode_block_avx2<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+pub(super) unsafe fn decode_block_avx2<L: Lane>(w: usize, data: &[u8], out: &mut [L]) {
     debug_assert!((1..=25).contains(&w));
-    debug_assert!(data.len() >= 16 * w + 16);
+    debug_assert!(out.len() % 8 == 0);
+    debug_assert!(data.len() >= out.len() / 8 * w + 16);
     let hi_base = (4 * w) / 8;
     let mut idx = [0i8; 32];
     let mut sh = [0i32; 8];
@@ -39,9 +33,10 @@ pub(super) unsafe fn decode_block_avx2<L: Lane>(w: usize, data: &[u8], out: &mut
         let idx_v = _mm256_loadu_si256(idx.as_ptr() as *const __m256i);
         let sh_v = _mm256_loadu_si256(sh.as_ptr() as *const __m256i);
         let mask = _mm256_set1_epi32(((1u64 << w) - 1) as i32);
+        let num_groups = out.len() / 8;
         let mut ptr = data.as_ptr();
         let mut out_ptr = out.as_mut_ptr();
-        for _ in 0..BLOCK_LEN / 8 {
+        for _ in 0..num_groups {
             let bytes_lo = _mm_loadu_si128(ptr as *const __m128i);
             let bytes_hi = _mm_loadu_si128(ptr.add(hi_base) as *const __m128i);
             let bytes = _mm256_set_m128i(bytes_hi, bytes_lo);
@@ -67,29 +62,11 @@ pub(super) unsafe fn decode_block_avx2<L: Lane>(w: usize, data: &[u8], out: &mut
 
 /// AVX2 unpack for bit widths 26..=56, the counterpart of
 /// `neon::decode_block_neon_wide`.
-///
-/// Same shape as [`decode_block_avx2`] with the lanes doubled: 4 `u64` lanes
-/// per register, so a group of 8 values is two iterations instead of one.
-/// `vpshufb` shuffles within each 128-bit half independently, and a half holds
-/// 2 values whose 8-byte spans both start within 16 bytes of the lower one, so
-/// each half still gathers from a single `vmovdqu`.
-///
-/// Constraint: bit_shift (<=7) + w <= 64 => w <= 57.
-///
-/// # Safety
-/// AVX2 must be available, and `data.len() >= 16 * w + 16` must hold: the last
-/// group starts at `15 * w` and its last pair loads 16 bytes at `+ 6 * w / 8`,
-/// which is `< 16 * w + 16`.
 #[target_feature(enable = "avx2")]
-pub(super) unsafe fn decode_block_avx2_wide<L: Lane>(
-    w: usize,
-    data: &[u8],
-    out: &mut [L; BLOCK_LEN],
-) {
+pub(super) unsafe fn decode_block_avx2_wide<L: Lane>(w: usize, data: &[u8], out: &mut [L]) {
     debug_assert!((26..=57).contains(&w));
-    debug_assert!(data.len() >= 16 * w + 16);
-    // Per half-group of 4 values: the byte the low half loads from, the byte
-    // the high half loads from, the 32 shuffle indices and the 4 shifts.
+    debug_assert!(out.len() % 8 == 0);
+    debug_assert!(data.len() >= out.len() / 8 * w + 16);
     let mut lo_base = [0usize; 2];
     let mut hi_base = [0usize; 2];
     let mut idx = [[0i8; 32]; 2];
@@ -116,9 +93,10 @@ pub(super) unsafe fn decode_block_avx2_wide<L: Lane>(
     }
     unsafe {
         let mask = _mm256_set1_epi64x(((1u64 << w) - 1) as i64);
+        let num_groups = out.len() / 8;
         let mut ptr = data.as_ptr();
         let mut out_ptr = out.as_mut_ptr();
-        for _ in 0..BLOCK_LEN / 8 {
+        for _ in 0..num_groups {
             for q in 0..2 {
                 let idx_v = _mm256_loadu_si256(idx[q].as_ptr() as *const __m256i);
                 let sh_v = _mm256_loadu_si256(sh[q].as_ptr() as *const __m256i);
@@ -132,8 +110,6 @@ pub(super) unsafe fn decode_block_avx2_wide<L: Lane>(
                 if L::IS_U64 {
                     _mm256_storeu_si256(out_ptr.add(4 * q) as *mut __m256i, vals);
                 } else {
-                    // Narrow the 4 `u64` lanes to 4 `u32`: gather the low
-                    // dword of each into the low half, then store that half.
                     let packed = _mm256_permutevar8x32_epi32(
                         vals,
                         _mm256_setr_epi32(0, 2, 4, 6, 0, 0, 0, 0),

--- a/bitpacker/src/block_decode/mod.rs
+++ b/bitpacker/src/block_decode/mod.rs
@@ -7,16 +7,12 @@
 //!
 //! Bit widths crate-wide are `0..=56` or exactly `64` (see
 //! [`crate::compute_num_bits`]); the kernels rely on that.
-
 #[cfg(target_arch = "x86_64")]
 mod avx2;
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 mod neon;
 
 pub const BLOCK_LEN: usize = 128;
-
-/// Whether the SIMD path is enabled
-/// and `TANTIVY_BITPACKER_SCALAR=1` doesn't force the scalar path
 pub fn simd_enabled() -> bool {
     static SIMD: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *SIMD.get_or_init(|| {
@@ -30,10 +26,10 @@ pub fn simd_enabled() -> bool {
     })
 }
 
-/// Whether [`decode_block`] reaches a SIMD kernel for this width.
+/// Whether [`decode_groups`] reaches a SIMD kernel for this width.
 ///
 /// Every packed width `1..=56` does where the target and CPU have kernels;
-/// 0 and 64 are served by [`decode_block`] itself.
+/// 0 and 64 are served by [`decode_groups`] itself.
 #[inline(always)]
 pub fn simd_kernel_applies(bit_width: u8) -> bool {
     (1..=56).contains(&bit_width) && simd_enabled()
@@ -54,10 +50,6 @@ mod sealed {
 }
 
 /// Output lane of the block kernels. Sealed; implemented for `u32` and `u64`
-/// only.
-///
-/// `u32` exists for [`crate::BitUnpacker::get_ids_for_value_range`], whose
-/// filter operates on `u32`.
 pub trait Lane: Copy + sealed::Sealed {
     /// Lets the kernels pick their store shape with a branch that folds away
     /// at monomorphization.
@@ -116,76 +108,63 @@ pub(crate) fn decode_value(num_bits: usize, mask: u64, idx: usize, data: &[u8]) 
 fn decode_value_slow_path(mask: u64, addr: usize, bit_shift: u32, data: &[u8]) -> u64 {
     let mut bytes: [u8; 8] = [0u8; 8];
     let available_bytes = data.len() - addr;
-    // This function is meant to only be called if we did not have 8 bytes to load.
     debug_assert!(available_bytes < 8);
     bytes[..available_bytes].copy_from_slice(&data[addr..]);
     let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
     (val_unshifted_unmasked >> bit_shift) & mask
 }
 
-/// Decodes the packed slots `[start_idx, start_idx + output.len())` into
-/// `output`, routing whole aligned blocks through [`decode_block`] and the two
-/// edges through [`decode_value`].
-///
-/// A block only starts byte-aligned -- which the kernels require -- when its
-/// first index is a multiple of 8, since 8 values occupy exactly `bit_width`
-/// bytes. So the block loop is preceded by an entrance ramp of up to 7 values,
-/// and followed by an exit ramp of up to `BLOCK_LEN - 1`.
-///
-/// # Panics
-///
-/// Panics if the requested range needs bytes past the end of `data`.
 #[inline(always)]
 pub fn decode_range<L: Lane>(bit_width: u8, start_idx: usize, data: &[u8], output: &mut [L]) {
     let num_bits = bit_width as usize;
-    // `usize` throughout to avoid overflow issues.
     let end_idx = start_idx + output.len();
     assert!(
         (end_idx * num_bits).div_ceil(8) <= data.len(),
         "Requested index is out of bounds."
     );
-    let mask: u64 = if bit_width == 64 {
+
+    let mask = if bit_width == 64 {
         !0u64
     } else {
         (1u64 << num_bits) - 1u64
     };
 
-    let ramp = (8 - start_idx % 8) % 8;
-    let mut cursor = if ramp + BLOCK_LEN <= output.len() {
-        ramp
-    } else {
-        output.len()
-    };
-    for (i, out) in output[..cursor].iter_mut().enumerate() {
+    let ramp = ((8 - start_idx % 8) % 8).min(output.len());
+    let groups = (output.len() - ramp) / 8;
+    if groups < MIN_KERNEL_GROUPS {
+        for (i, out) in output.iter_mut().enumerate() {
+            *out = L::from_u64(decode_value(num_bits, mask, start_idx + i, data));
+        }
+        return;
+    }
+
+    for (i, out) in output[..ramp].iter_mut().enumerate() {
         *out = L::from_u64(decode_value(num_bits, mask, start_idx + i, data));
     }
-    while cursor + BLOCK_LEN <= output.len() {
-        let block_start_bytes = (start_idx + cursor) * num_bits / 8;
-        let block: &mut [L; BLOCK_LEN] = (&mut output[cursor..cursor + BLOCK_LEN])
-            .try_into()
-            .unwrap();
-        decode_block(bit_width, &data[block_start_bytes..], block);
-        cursor += BLOCK_LEN;
-    }
-    for (i, out) in output[cursor..].iter_mut().enumerate() {
-        *out = L::from_u64(decode_value(num_bits, mask, start_idx + cursor + i, data));
+    let mid_start_bytes = (start_idx + ramp) * num_bits / 8;
+    let done = ramp + groups * 8;
+    decode_groups(bit_width, &data[mid_start_bytes..], &mut output[ramp..done]);
+    for (i, out) in output[done..].iter_mut().enumerate() {
+        *out = L::from_u64(decode_value(num_bits, mask, start_idx + done + i, data));
     }
 }
 
-/// Decodes the 128 packed `bit_width`-bit slots starting at `data[0]` into `out`.
-///
-/// `data` is the slice starting at the block and running to the end of the
-/// data stream: the kernels read a few bytes past the block's own end, so
-/// short slices fall back to a bounds-checked scalar path.
+const MIN_KERNEL_GROUPS: usize = 2;
+
 #[inline(always)]
-pub fn decode_block<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+fn decode_groups<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L]) {
+    debug_assert_eq!(out.len() % 8, 0);
+    if out.is_empty() {
+        return;
+    };
     let w = bit_width as usize;
     if w == 0 {
         out.fill(L::from_u64(0));
         return;
     }
+
     if w == 64 {
-        let block = data.get(..BLOCK_LEN * 8).unwrap_or(data);
+        let block = data.get(..out.len() * 8).unwrap_or(data);
         for (i, o) in out.iter_mut().enumerate() {
             let bytes = block[i * 8..i * 8 + 8].try_into().unwrap();
             *o = L::from_u64(u64::from_le_bytes(bytes));
@@ -197,7 +176,7 @@ pub fn decode_block<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN
         all(target_arch = "aarch64", target_endian = "little"),
         target_arch = "x86_64"
     ))]
-    if simd_kernel_applies(bit_width) && data.len() >= 16 * w + 16 {
+    if simd_kernel_applies(bit_width) && data.len() >= out.len() / 8 * w + 16 {
         #[cfg(target_arch = "x86_64")]
         use avx2::{decode_block_avx2 as narrow_kernel, decode_block_avx2_wide as wide_kernel};
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
@@ -210,13 +189,13 @@ pub fn decode_block<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN
         }
         return;
     }
-    decode_block_scalar(w, data, out);
+    decode_groups_scalar(w, data, out);
 }
 
-fn decode_block_scalar<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+fn decode_groups_scalar<L: Lane>(w: usize, data: &[u8], out: &mut [L]) {
     debug_assert!((1..=56).contains(&w));
     let mask = (1u64 << w) - 1;
-    let needed = (BLOCK_LEN - 1) * w / 8 + 8;
+    let needed = (out.len() - 1) * w / 8 + 8;
     if needed <= data.len() {
         let block = &data[..needed];
         for (group, chunk) in out.chunks_exact_mut(8).enumerate() {
@@ -270,27 +249,24 @@ mod tests {
     fn check_width(bit_width: u8, pad: usize) {
         let (vals, data) = pack_block(bit_width, pad);
         let mut out = [0u64; BLOCK_LEN];
-        decode_block(bit_width, &data, &mut out);
+        decode_groups(bit_width, &data, &mut out);
         assert_eq!(&out[..], &vals[..], "width {bit_width} pad {pad}");
         if bit_width <= 32 {
             let mut out32 = [0u32; BLOCK_LEN];
-            decode_block(bit_width, &data, &mut out32);
+            decode_groups(bit_width, &data, &mut out32);
             let expected: Vec<u32> = vals.iter().map(|&v| v as u32).collect();
             assert_eq!(&out32[..], &expected[..], "width {bit_width} pad {pad} u32");
         }
     }
 
     #[test]
-    fn test_decode_block_all_widths() {
+    fn test_decode_groups_all_widths() {
         for bit_width in (0..=56u8).chain(std::iter::once(64u8)) {
             check_width(bit_width, 0);
             check_width(bit_width, 16);
         }
     }
 
-    /// `decode_range` must agree with per-value extraction for every width,
-    /// across start offsets that exercise the entrance ramp (unaligned and
-    /// 8-aligned starts), the kernel loop, and the exit ramp.
     #[test]
     fn test_decode_range_all_widths_and_offsets() {
         let num_vals = 3 * BLOCK_LEN + 17;
@@ -312,8 +288,12 @@ mod tests {
             }
             packer.close(&mut data).unwrap();
 
-            for &start in &[0usize, 1, 5, 7, 8, 64, 127, 128, 129, 255, 256, 400] {
-                for &len in &[0usize, 1, 7, 8, 100, 128, 129, 256, num_vals - start] {
+            // Every start phase modulo 8 crossed with every length up to just
+            // past a block: the aligned middle runs on groups of 8, so the
+            // entrance ramp, group count and exit ramp all have to line up for
+            // lengths that are not multiples of 8 and never reach 128.
+            for start in (0usize..24).chain([64, 127, 128, 129, 255, 256, 400]) {
+                for len in (0usize..136).chain([256, num_vals - start]) {
                     if start + len > num_vals {
                         continue;
                     }
@@ -358,20 +338,20 @@ mod tests {
             let (vals, data) = pack_block(bit_width, 16);
             let mut out = [0u64; BLOCK_LEN];
 
-            decode_block(bit_width, &data, &mut out);
+            decode_groups(bit_width, &data, &mut out);
             assert_eq!(&out[..], &vals[..], "width {bit_width}");
 
             let mut best = [f64::MAX; 2];
             for _ in 0..3 {
                 let t0 = Instant::now();
                 for _ in 0..REPS {
-                    decode_block(bit_width, &data, &mut out);
+                    decode_groups(bit_width, &data, &mut out);
                     black_box(out[0]);
                 }
                 best[0] = best[0].min(t0.elapsed().as_nanos() as f64 / REPS as f64);
                 let t0 = Instant::now();
                 for _ in 0..REPS {
-                    decode_block_scalar(bit_width as usize, &data, &mut out);
+                    decode_groups_scalar(bit_width as usize, &data, &mut out);
                     black_box(out[0]);
                 }
                 best[1] = best[1].min(t0.elapsed().as_nanos() as f64 / REPS as f64);
@@ -407,14 +387,14 @@ mod tests {
                 "width {bit_width} has no kernel"
             );
         }
-        // 0 and 64 are served by `decode_block` itself.
+        // 0 and 64 are served by `decode_groups` itself.
         assert!(!simd_kernel_applies(0) && !simd_kernel_applies(64));
         // The narrow kernel's own limit: `bit_shift (<= 7) + w <= 32`.
         assert!(narrow_kernel_applies(25) && !narrow_kernel_applies(26));
     }
 
     #[test]
-    fn test_decode_block_scalar_matches_kernel() {
+    fn test_decode_groups_scalar_matches_kernel() {
         assert!(
             !simd_enabled() || simd_kernel_applies(8),
             "a kernel is available but the width gate rejects it"
@@ -423,16 +403,16 @@ mod tests {
             let (_, data) = pack_block(bit_width, 16);
 
             let mut kernel = [0u64; BLOCK_LEN];
-            decode_block(bit_width, &data, &mut kernel);
+            decode_groups(bit_width, &data, &mut kernel);
             let mut scalar = [0u64; BLOCK_LEN];
-            decode_block_scalar(bit_width as usize, &data, &mut scalar);
+            decode_groups_scalar(bit_width as usize, &data, &mut scalar);
             assert_eq!(&kernel[..], &scalar[..], "u64 width {bit_width}");
 
             // The u32 lane takes a different store path in both kernels.
             let mut kernel32 = [0u32; BLOCK_LEN];
-            decode_block(bit_width, &data, &mut kernel32);
+            decode_groups(bit_width, &data, &mut kernel32);
             let mut scalar32 = [0u32; BLOCK_LEN];
-            decode_block_scalar(bit_width as usize, &data, &mut scalar32);
+            decode_groups_scalar(bit_width as usize, &data, &mut scalar32);
             assert_eq!(&kernel32[..], &scalar32[..], "u32 width {bit_width}");
         }
     }

--- a/bitpacker/src/block_decode/mod.rs
+++ b/bitpacker/src/block_decode/mod.rs
@@ -1,0 +1,362 @@
+//! Batch unpack kernels for fixed-width bitpacked values, 128 values at a time.
+//!
+//! 8 consecutive values occupy exactly `bit_width` bytes, so a group of 128
+//! values is `16 * bit_width` bytes and always starts byte aligned. That makes
+//! the (byte offset, bit shift) pattern of a group constant per width, which
+//! is what lets the kernels shuffle 8 values at a time.
+//!
+//! Bit widths crate-wide are `0..=56` or exactly `64` (see
+//! [`crate::compute_num_bits`]); the kernels rely on that.
+
+#[cfg(target_arch = "x86_64")]
+mod avx2;
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+mod neon;
+
+use crate::BitUnpacker;
+
+/// Number of values decoded per [`decode_block`] call.
+pub const BLOCK_LEN: usize = 128;
+
+/// Whether a SIMD kernel is compiled in *and* supported by this CPU.
+///
+/// The `target_endian` guard exists because the kernels' shuffle tables
+/// assume the little-endian u8 -> u32 lane mapping.
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+fn kernel_available() -> bool {
+    true
+}
+#[cfg(target_arch = "x86_64")]
+fn kernel_available() -> bool {
+    std::arch::is_x86_feature_detected!("avx2")
+}
+#[cfg(not(any(
+    all(target_arch = "aarch64", target_endian = "little"),
+    target_arch = "x86_64"
+)))]
+fn kernel_available() -> bool {
+    false
+}
+
+/// Returns whether the SIMD block-decode path is enabled.
+///
+/// `TANTIVY_BITPACKER_SCALAR=1` forces the scalar path.
+pub fn simd_enabled() -> bool {
+    static SIMD: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *SIMD.get_or_init(|| {
+        kernel_available() && std::env::var_os("TANTIVY_BITPACKER_SCALAR").is_none()
+    })
+}
+
+/// Whether [`decode_block`] reaches a SIMD kernel for this width.
+///
+/// Every packed width `1..=56` does where the target and CPU have kernels;
+/// 0 and 64 are served by [`decode_block_lanes`] itself.
+#[inline]
+pub fn simd_kernel_applies(bit_width: u8) -> bool {
+    (1..=56).contains(&bit_width) && simd_enabled()
+}
+
+/// Whether the *narrow* (`u32` lane) kernel takes this width: it needs
+/// `bit_shift (<= 7) + bit_width <= 32`. Above that the wide (`u64` lane)
+/// kernel takes over.
+#[inline]
+fn narrow_kernel_applies(bit_width: u8) -> bool {
+    (1..=25).contains(&bit_width)
+}
+
+/// Output lane of the block kernels. Implemented for `u32` and `u64` only.
+///
+/// `u32` exists for [`crate::BitUnpacker::get_ids_for_value_range`], whose
+/// filter operates on `u32`.
+pub(crate) trait Lane: Copy {
+    /// Lets the AVX2 kernel pick its store shape with a branch that folds away
+    /// at monomorphization.
+    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
+    const IS_U64: bool;
+
+    fn from_u64(val: u64) -> Self;
+
+    /// Stores 4 unpacked values held in `u32` lanes at `out`.
+    ///
+    /// # Safety
+    /// `out` must be writable for 4 elements.
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    unsafe fn store_u32x4(out: *mut Self, vals: std::arch::aarch64::uint32x4_t);
+
+    /// Stores 2 unpacked values held in `u64` lanes at `out`.
+    ///
+    /// # Safety
+    /// `out` must be writable for 2 elements, and every lane must fit `Self`
+    /// (the `u32` lane is only ever used at widths `<= 32`).
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    unsafe fn store_u64x2(out: *mut Self, vals: std::arch::aarch64::uint64x2_t);
+}
+
+impl Lane for u32 {
+    const IS_U64: bool = false;
+
+    #[inline(always)]
+    fn from_u64(val: u64) -> u32 {
+        val as u32
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[inline(always)]
+    unsafe fn store_u32x4(out: *mut u32, vals: std::arch::aarch64::uint32x4_t) {
+        unsafe { std::arch::aarch64::vst1q_u32(out, vals) }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[inline(always)]
+    unsafe fn store_u64x2(out: *mut u32, vals: std::arch::aarch64::uint64x2_t) {
+        use std::arch::aarch64::*;
+        unsafe { vst1_u32(out, vmovn_u64(vals)) }
+    }
+}
+
+impl Lane for u64 {
+    const IS_U64: bool = true;
+
+    #[inline(always)]
+    fn from_u64(val: u64) -> u64 {
+        val
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[inline(always)]
+    unsafe fn store_u32x4(out: *mut u64, vals: std::arch::aarch64::uint32x4_t) {
+        use std::arch::aarch64::*;
+        unsafe {
+            vst1q_u64(out, vmovl_u32(vget_low_u32(vals)));
+            vst1q_u64(out.add(2), vmovl_high_u32(vals));
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[inline(always)]
+    unsafe fn store_u64x2(out: *mut u64, vals: std::arch::aarch64::uint64x2_t) {
+        unsafe { std::arch::aarch64::vst1q_u64(out, vals) }
+    }
+}
+
+/// Decodes the 128 packed `bit_width`-bit slots starting at `data[0]` into `out`.
+///
+/// `data` is the slice starting at the block and running to the end of the
+/// data stream: the kernels read a few bytes past the block's own end, so
+/// short slices fall back to a bounds-checked scalar path.
+#[inline]
+pub fn decode_block(bit_width: u8, data: &[u8], out: &mut [u64; BLOCK_LEN]) {
+    decode_block_lanes(bit_width, data, out);
+}
+
+pub(crate) fn decode_block_lanes<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+    let w = bit_width as usize;
+    if w == 0 {
+        out.fill(L::from_u64(0));
+        return;
+    }
+    if w == 64 {
+        let block = data.get(..BLOCK_LEN * 8).unwrap_or(data);
+        for (i, o) in out.iter_mut().enumerate() {
+            let bytes = block[i * 8..i * 8 + 8].try_into().unwrap();
+            *o = L::from_u64(u64::from_le_bytes(bytes));
+        }
+        return;
+    }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    if simd_kernel_applies(bit_width) && data.len() >= 16 * w + 16 {
+        if narrow_kernel_applies(bit_width) {
+            unsafe { neon::decode_block_neon(w, data, out) };
+        } else {
+            unsafe { neon::decode_block_neon_wide(w, data, out) };
+        }
+        return;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if simd_kernel_applies(bit_width) && data.len() >= 16 * w + 16 {
+        if narrow_kernel_applies(bit_width) {
+            unsafe { avx2::decode_block_avx2(w, data, out) };
+        } else {
+            unsafe { avx2::decode_block_avx2_wide(w, data, out) };
+        }
+        return;
+    }
+    decode_block_scalar(w, data, out);
+}
+
+fn decode_block_scalar<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+    debug_assert!((1..=56).contains(&w));
+    let mask = (1u64 << w) - 1;
+    let needed = (BLOCK_LEN - 1) * w / 8 + 8;
+    if needed <= data.len() {
+        let block = &data[..needed];
+        for (group, chunk) in out.chunks_exact_mut(8).enumerate() {
+            let base = group * w;
+            for (j, o) in chunk.iter_mut().enumerate() {
+                let bit = j * w;
+                let byte = base + bit / 8;
+                let bytes = block[byte..byte + 8].try_into().unwrap();
+                *o = L::from_u64((u64::from_le_bytes(bytes) >> (bit % 8)) & mask);
+            }
+        }
+    } else {
+        let unpacker = BitUnpacker::new(w as u8);
+        for (i, o) in out.iter_mut().enumerate() {
+            *o = L::from_u64(unpacker.get(i as u32, data));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BitPacker;
+
+    fn pack_block(bit_width: u8, pad: usize) -> (Vec<u64>, Vec<u8>) {
+        let max_val = if bit_width == 64 {
+            u64::MAX
+        } else if bit_width == 0 {
+            0
+        } else {
+            (1u64 << bit_width) - 1
+        };
+        let vals: Vec<u64> = (0..BLOCK_LEN as u64)
+            .map(|i| {
+                if max_val == 0 {
+                    0
+                } else {
+                    i.wrapping_mul(0x9E3779B97F4A7C15) % max_val.saturating_add(1)
+                }
+            })
+            .collect();
+        let mut data = Vec::new();
+        let mut packer = BitPacker::new();
+        for &val in &vals {
+            packer.write(val, bit_width, &mut data).unwrap();
+        }
+        packer.close(&mut data).unwrap();
+        data.resize(data.len() + pad, 0u8);
+        (vals, data)
+    }
+
+    fn check_width(bit_width: u8, pad: usize) {
+        let (vals, data) = pack_block(bit_width, pad);
+        let mut out = [0u64; BLOCK_LEN];
+        decode_block(bit_width, &data, &mut out);
+        assert_eq!(&out[..], &vals[..], "width {bit_width} pad {pad}");
+        if bit_width <= 32 {
+            let mut out32 = [0u32; BLOCK_LEN];
+            decode_block_lanes(bit_width, &data, &mut out32);
+            let expected: Vec<u32> = vals.iter().map(|&v| v as u32).collect();
+            assert_eq!(&out32[..], &expected[..], "width {bit_width} pad {pad} u32");
+        }
+    }
+
+    #[test]
+    fn test_decode_block_all_widths() {
+        for bit_width in (0..=56u8).chain(std::iter::once(64u8)) {
+            check_width(bit_width, 0);
+            check_width(bit_width, 16);
+        }
+    }
+
+    /// Sweeps both kernels against the scalar path, per width, in one process.
+    ///
+    /// ```text
+    /// cargo test --release -p tantivy-bitpacker --lib kernel_sweep \
+    ///     -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore]
+    fn kernel_sweep() {
+        use std::hint::black_box;
+        use std::time::Instant;
+
+        const REPS: usize = 20_000;
+        assert!(simd_enabled(), "no kernel compiled in or CPU lacks it");
+        println!("{:>5} {:>10} {:>10} {:>8}  kernel", "width", "simd_ns", "scalar_ns", "ratio");
+        for bit_width in 1..=56u8 {
+            let (vals, data) = pack_block(bit_width, 16);
+            let mut out = [0u64; BLOCK_LEN];
+
+            decode_block(bit_width, &data, &mut out);
+            assert_eq!(&out[..], &vals[..], "width {bit_width}");
+
+            let mut best = [f64::MAX; 2];
+            for _ in 0..3 {
+                let t0 = Instant::now();
+                for _ in 0..REPS {
+                    decode_block(bit_width, &data, &mut out);
+                    black_box(out[0]);
+                }
+                best[0] = best[0].min(t0.elapsed().as_nanos() as f64 / REPS as f64);
+                let t0 = Instant::now();
+                for _ in 0..REPS {
+                    decode_block_scalar(bit_width as usize, &data, &mut out);
+                    black_box(out[0]);
+                }
+                best[1] = best[1].min(t0.elapsed().as_nanos() as f64 / REPS as f64);
+            }
+            let which = if narrow_kernel_applies(bit_width) {
+                "narrow"
+            } else {
+                "wide"
+            };
+            println!(
+                "{bit_width:>5} {:>10.1} {:>10.1} {:>8.2}  {which}",
+                best[0],
+                best[1],
+                best[1] / best[0]
+            );
+        }
+    }
+
+    /// No packed width may fall through to the scalar unpacker: nothing else
+    /// states that the wide kernel picks up exactly where the narrow one
+    /// stops, and a gap is invisible to value tests.
+    #[test]
+    fn test_no_packed_width_falls_through_to_scalar() {
+        if !simd_enabled() {
+            for bit_width in 0..=64u8 {
+                assert!(!simd_kernel_applies(bit_width));
+            }
+            return;
+        }
+        for bit_width in 1..=56u8 {
+            assert!(
+                simd_kernel_applies(bit_width),
+                "width {bit_width} has no kernel"
+            );
+        }
+        // 0 and 64 are served by `decode_block_lanes` itself.
+        assert!(!simd_kernel_applies(0) && !simd_kernel_applies(64));
+        // The narrow kernel's own limit: `bit_shift (<= 7) + w <= 32`.
+        assert!(narrow_kernel_applies(25) && !narrow_kernel_applies(26));
+    }
+
+    #[test]
+    fn test_decode_block_scalar_matches_kernel() {
+        assert!(
+            !simd_enabled() || simd_kernel_applies(8),
+            "a kernel is available but the width gate rejects it"
+        );
+        for bit_width in 1..=56u8 {
+            let (_, data) = pack_block(bit_width, 16);
+
+            let mut kernel = [0u64; BLOCK_LEN];
+            decode_block(bit_width, &data, &mut kernel);
+            let mut scalar = [0u64; BLOCK_LEN];
+            decode_block_scalar(bit_width as usize, &data, &mut scalar);
+            assert_eq!(&kernel[..], &scalar[..], "u64 width {bit_width}");
+
+            // The u32 lane takes a different store path in both kernels.
+            let mut kernel32 = [0u32; BLOCK_LEN];
+            decode_block_lanes(bit_width, &data, &mut kernel32);
+            let mut scalar32 = [0u32; BLOCK_LEN];
+            decode_block_scalar(bit_width as usize, &data, &mut scalar32);
+            assert_eq!(&kernel32[..], &scalar32[..], "u32 width {bit_width}");
+        }
+    }
+}

--- a/bitpacker/src/block_decode/mod.rs
+++ b/bitpacker/src/block_decode/mod.rs
@@ -13,46 +13,28 @@ mod avx2;
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 mod neon;
 
-use crate::BitUnpacker;
-
-/// Number of values decoded per [`decode_block`] call.
 pub const BLOCK_LEN: usize = 128;
 
-/// Whether a SIMD kernel is compiled in *and* supported by this CPU.
-///
-/// The `target_endian` guard exists because the kernels' shuffle tables
-/// assume the little-endian u8 -> u32 lane mapping.
-#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-fn kernel_available() -> bool {
-    true
-}
-#[cfg(target_arch = "x86_64")]
-fn kernel_available() -> bool {
-    std::arch::is_x86_feature_detected!("avx2")
-}
-#[cfg(not(any(
-    all(target_arch = "aarch64", target_endian = "little"),
-    target_arch = "x86_64"
-)))]
-fn kernel_available() -> bool {
-    false
-}
-
-/// Returns whether the SIMD block-decode path is enabled.
-///
-/// `TANTIVY_BITPACKER_SCALAR=1` forces the scalar path.
+/// Whether the SIMD path is enabled
+/// and `TANTIVY_BITPACKER_SCALAR=1` doesn't force the scalar path
 pub fn simd_enabled() -> bool {
     static SIMD: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *SIMD.get_or_init(|| {
-        kernel_available() && std::env::var_os("TANTIVY_BITPACKER_SCALAR").is_none()
+        if std::env::var_os("TANTIVY_BITPACKER_SCALAR").is_some() {
+            return false;
+        }
+        #[cfg(target_arch = "x86_64")]
+        return std::arch::is_x86_feature_detected!("avx2");
+        #[cfg(not(target_arch = "x86_64"))]
+        cfg!(all(target_arch = "aarch64", target_endian = "little"))
     })
 }
 
 /// Whether [`decode_block`] reaches a SIMD kernel for this width.
 ///
 /// Every packed width `1..=56` does where the target and CPU have kernels;
-/// 0 and 64 are served by [`decode_block_lanes`] itself.
-#[inline]
+/// 0 and 64 are served by [`decode_block`] itself.
+#[inline(always)]
 pub fn simd_kernel_applies(bit_width: u8) -> bool {
     (1..=56).contains(&bit_width) && simd_enabled()
 }
@@ -60,37 +42,35 @@ pub fn simd_kernel_applies(bit_width: u8) -> bool {
 /// Whether the *narrow* (`u32` lane) kernel takes this width: it needs
 /// `bit_shift (<= 7) + bit_width <= 32`. Above that the wide (`u64` lane)
 /// kernel takes over.
-#[inline]
+#[inline(always)]
 fn narrow_kernel_applies(bit_width: u8) -> bool {
     (1..=25).contains(&bit_width)
 }
 
-/// Output lane of the block kernels. Implemented for `u32` and `u64` only.
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for u32 {}
+    impl Sealed for u64 {}
+}
+
+/// Output lane of the block kernels. Sealed; implemented for `u32` and `u64`
+/// only.
 ///
 /// `u32` exists for [`crate::BitUnpacker::get_ids_for_value_range`], whose
 /// filter operates on `u32`.
-pub(crate) trait Lane: Copy {
-    /// Lets the AVX2 kernel pick its store shape with a branch that folds away
+pub trait Lane: Copy + sealed::Sealed {
+    /// Lets the kernels pick their store shape with a branch that folds away
     /// at monomorphization.
-    #[cfg_attr(not(target_arch = "x86_64"), allow(dead_code))]
+    #[cfg_attr(
+        not(any(
+            target_arch = "x86_64",
+            all(target_arch = "aarch64", target_endian = "little")
+        )),
+        allow(dead_code)
+    )]
     const IS_U64: bool;
 
     fn from_u64(val: u64) -> Self;
-
-    /// Stores 4 unpacked values held in `u32` lanes at `out`.
-    ///
-    /// # Safety
-    /// `out` must be writable for 4 elements.
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    unsafe fn store_u32x4(out: *mut Self, vals: std::arch::aarch64::uint32x4_t);
-
-    /// Stores 2 unpacked values held in `u64` lanes at `out`.
-    ///
-    /// # Safety
-    /// `out` must be writable for 2 elements, and every lane must fit `Self`
-    /// (the `u32` lane is only ever used at widths `<= 32`).
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    unsafe fn store_u64x2(out: *mut Self, vals: std::arch::aarch64::uint64x2_t);
 }
 
 impl Lane for u32 {
@@ -99,19 +79,6 @@ impl Lane for u32 {
     #[inline(always)]
     fn from_u64(val: u64) -> u32 {
         val as u32
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[inline(always)]
-    unsafe fn store_u32x4(out: *mut u32, vals: std::arch::aarch64::uint32x4_t) {
-        unsafe { std::arch::aarch64::vst1q_u32(out, vals) }
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[inline(always)]
-    unsafe fn store_u64x2(out: *mut u32, vals: std::arch::aarch64::uint64x2_t) {
-        use std::arch::aarch64::*;
-        unsafe { vst1_u32(out, vmovn_u64(vals)) }
     }
 }
 
@@ -122,21 +89,86 @@ impl Lane for u64 {
     fn from_u64(val: u64) -> u64 {
         val
     }
+}
 
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[inline(always)]
-    unsafe fn store_u32x4(out: *mut u64, vals: std::arch::aarch64::uint32x4_t) {
-        use std::arch::aarch64::*;
-        unsafe {
-            vst1q_u64(out, vmovl_u32(vget_low_u32(vals)));
-            vst1q_u64(out.add(2), vmovl_high_u32(vals));
+/// Extracts the single packed `num_bits`-bit slot `idx` via an unaligned
+/// 8-byte load, shift and mask. Works at any index; no block alignment needed.
+///
+/// `mask` must be `BitUnpacker`'s value mask for `num_bits` (all ones for 64),
+/// passed in precomputed so per-value callers pay nothing extra.
+#[inline(always)]
+pub(crate) fn decode_value(num_bits: usize, mask: u64, idx: usize, data: &[u8]) -> u64 {
+    let addr_in_bits = idx * num_bits;
+    let addr = addr_in_bits >> 3;
+    let bit_shift = addr_in_bits & 7;
+    if addr + 8 > data.len() {
+        if num_bits == 0 {
+            return 0;
         }
+        return decode_value_slow_path(mask, addr, bit_shift as u32, data);
     }
+    let bytes: [u8; 8] = (&data[addr..addr + 8]).try_into().unwrap();
+    let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
+    (val_unshifted_unmasked >> bit_shift) & mask
+}
 
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[inline(always)]
-    unsafe fn store_u64x2(out: *mut u64, vals: std::arch::aarch64::uint64x2_t) {
-        unsafe { std::arch::aarch64::vst1q_u64(out, vals) }
+#[inline(never)]
+fn decode_value_slow_path(mask: u64, addr: usize, bit_shift: u32, data: &[u8]) -> u64 {
+    let mut bytes: [u8; 8] = [0u8; 8];
+    let available_bytes = data.len() - addr;
+    // This function is meant to only be called if we did not have 8 bytes to load.
+    debug_assert!(available_bytes < 8);
+    bytes[..available_bytes].copy_from_slice(&data[addr..]);
+    let val_unshifted_unmasked: u64 = u64::from_le_bytes(bytes);
+    (val_unshifted_unmasked >> bit_shift) & mask
+}
+
+/// Decodes the packed slots `[start_idx, start_idx + output.len())` into
+/// `output`, routing whole aligned blocks through [`decode_block`] and the two
+/// edges through [`decode_value`].
+///
+/// A block only starts byte-aligned -- which the kernels require -- when its
+/// first index is a multiple of 8, since 8 values occupy exactly `bit_width`
+/// bytes. So the block loop is preceded by an entrance ramp of up to 7 values,
+/// and followed by an exit ramp of up to `BLOCK_LEN - 1`.
+///
+/// # Panics
+///
+/// Panics if the requested range needs bytes past the end of `data`.
+#[inline(always)]
+pub fn decode_range<L: Lane>(bit_width: u8, start_idx: usize, data: &[u8], output: &mut [L]) {
+    let num_bits = bit_width as usize;
+    // `usize` throughout to avoid overflow issues.
+    let end_idx = start_idx + output.len();
+    assert!(
+        (end_idx * num_bits).div_ceil(8) <= data.len(),
+        "Requested index is out of bounds."
+    );
+    let mask: u64 = if bit_width == 64 {
+        !0u64
+    } else {
+        (1u64 << num_bits) - 1u64
+    };
+
+    let ramp = (8 - start_idx % 8) % 8;
+    let mut cursor = if ramp + BLOCK_LEN <= output.len() {
+        ramp
+    } else {
+        output.len()
+    };
+    for (i, out) in output[..cursor].iter_mut().enumerate() {
+        *out = L::from_u64(decode_value(num_bits, mask, start_idx + i, data));
+    }
+    while cursor + BLOCK_LEN <= output.len() {
+        let block_start_bytes = (start_idx + cursor) * num_bits / 8;
+        let block: &mut [L; BLOCK_LEN] = (&mut output[cursor..cursor + BLOCK_LEN])
+            .try_into()
+            .unwrap();
+        decode_block(bit_width, &data[block_start_bytes..], block);
+        cursor += BLOCK_LEN;
+    }
+    for (i, out) in output[cursor..].iter_mut().enumerate() {
+        *out = L::from_u64(decode_value(num_bits, mask, start_idx + cursor + i, data));
     }
 }
 
@@ -145,12 +177,8 @@ impl Lane for u64 {
 /// `data` is the slice starting at the block and running to the end of the
 /// data stream: the kernels read a few bytes past the block's own end, so
 /// short slices fall back to a bounds-checked scalar path.
-#[inline]
-pub fn decode_block(bit_width: u8, data: &[u8], out: &mut [u64; BLOCK_LEN]) {
-    decode_block_lanes(bit_width, data, out);
-}
-
-pub(crate) fn decode_block_lanes<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+#[inline(always)]
+pub fn decode_block<L: Lane>(bit_width: u8, data: &[u8], out: &mut [L; BLOCK_LEN]) {
     let w = bit_width as usize;
     if w == 0 {
         out.fill(L::from_u64(0));
@@ -164,22 +192,21 @@ pub(crate) fn decode_block_lanes<L: Lane>(bit_width: u8, data: &[u8], out: &mut 
         }
         return;
     }
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    if simd_kernel_applies(bit_width) && data.len() >= 16 * w + 16 {
-        if narrow_kernel_applies(bit_width) {
-            unsafe { neon::decode_block_neon(w, data, out) };
-        } else {
-            unsafe { neon::decode_block_neon_wide(w, data, out) };
-        }
-        return;
-    }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        target_arch = "x86_64"
+    ))]
     if simd_kernel_applies(bit_width) && data.len() >= 16 * w + 16 {
+        #[cfg(target_arch = "x86_64")]
+        use avx2::{decode_block_avx2 as narrow_kernel, decode_block_avx2_wide as wide_kernel};
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        use neon::{decode_block_neon as narrow_kernel, decode_block_neon_wide as wide_kernel};
+
         if narrow_kernel_applies(bit_width) {
-            unsafe { avx2::decode_block_avx2(w, data, out) };
+            unsafe { narrow_kernel(w, data, out) }
         } else {
-            unsafe { avx2::decode_block_avx2_wide(w, data, out) };
+            unsafe { wide_kernel(w, data, out) }
         }
         return;
     }
@@ -202,9 +229,8 @@ fn decode_block_scalar<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN])
             }
         }
     } else {
-        let unpacker = BitUnpacker::new(w as u8);
         for (i, o) in out.iter_mut().enumerate() {
-            *o = L::from_u64(unpacker.get(i as u32, data));
+            *o = L::from_u64(decode_value(w, mask, i, data));
         }
     }
 }
@@ -248,7 +274,7 @@ mod tests {
         assert_eq!(&out[..], &vals[..], "width {bit_width} pad {pad}");
         if bit_width <= 32 {
             let mut out32 = [0u32; BLOCK_LEN];
-            decode_block_lanes(bit_width, &data, &mut out32);
+            decode_block(bit_width, &data, &mut out32);
             let expected: Vec<u32> = vals.iter().map(|&v| v as u32).collect();
             assert_eq!(&out32[..], &expected[..], "width {bit_width} pad {pad} u32");
         }
@@ -259,6 +285,54 @@ mod tests {
         for bit_width in (0..=56u8).chain(std::iter::once(64u8)) {
             check_width(bit_width, 0);
             check_width(bit_width, 16);
+        }
+    }
+
+    /// `decode_range` must agree with per-value extraction for every width,
+    /// across start offsets that exercise the entrance ramp (unaligned and
+    /// 8-aligned starts), the kernel loop, and the exit ramp.
+    #[test]
+    fn test_decode_range_all_widths_and_offsets() {
+        let num_vals = 3 * BLOCK_LEN + 17;
+        for bit_width in (0..=56u8).chain(std::iter::once(64u8)) {
+            let max_val = if bit_width == 64 {
+                u64::MAX
+            } else if bit_width == 0 {
+                0
+            } else {
+                (1u64 << bit_width) - 1
+            };
+            let vals: Vec<u64> = (0..num_vals as u64)
+                .map(|i| i.wrapping_mul(0x9E3779B97F4A7C15) & max_val)
+                .collect();
+            let mut data = Vec::new();
+            let mut packer = BitPacker::new();
+            for &val in &vals {
+                packer.write(val, bit_width, &mut data).unwrap();
+            }
+            packer.close(&mut data).unwrap();
+
+            for &start in &[0usize, 1, 5, 7, 8, 64, 127, 128, 129, 255, 256, 400] {
+                for &len in &[0usize, 1, 7, 8, 100, 128, 129, 256, num_vals - start] {
+                    if start + len > num_vals {
+                        continue;
+                    }
+                    let mut out = vec![0u64; len];
+                    decode_range(bit_width, start, &data, &mut out);
+                    assert_eq!(
+                        out,
+                        &vals[start..start + len],
+                        "w={bit_width} start={start} len={len}"
+                    );
+                    if bit_width <= 32 {
+                        let mut out32 = vec![0u32; len];
+                        decode_range(bit_width, start, &data, &mut out32);
+                        let expected: Vec<u32> =
+                            vals[start..start + len].iter().map(|&v| v as u32).collect();
+                        assert_eq!(out32, expected, "w={bit_width} start={start} len={len} u32");
+                    }
+                }
+            }
         }
     }
 
@@ -276,7 +350,10 @@ mod tests {
 
         const REPS: usize = 20_000;
         assert!(simd_enabled(), "no kernel compiled in or CPU lacks it");
-        println!("{:>5} {:>10} {:>10} {:>8}  kernel", "width", "simd_ns", "scalar_ns", "ratio");
+        println!(
+            "{:>5} {:>10} {:>10} {:>8}  kernel",
+            "width", "simd_ns", "scalar_ns", "ratio"
+        );
         for bit_width in 1..=56u8 {
             let (vals, data) = pack_block(bit_width, 16);
             let mut out = [0u64; BLOCK_LEN];
@@ -330,7 +407,7 @@ mod tests {
                 "width {bit_width} has no kernel"
             );
         }
-        // 0 and 64 are served by `decode_block_lanes` itself.
+        // 0 and 64 are served by `decode_block` itself.
         assert!(!simd_kernel_applies(0) && !simd_kernel_applies(64));
         // The narrow kernel's own limit: `bit_shift (<= 7) + w <= 32`.
         assert!(narrow_kernel_applies(25) && !narrow_kernel_applies(26));
@@ -353,7 +430,7 @@ mod tests {
 
             // The u32 lane takes a different store path in both kernels.
             let mut kernel32 = [0u32; BLOCK_LEN];
-            decode_block_lanes(bit_width, &data, &mut kernel32);
+            decode_block(bit_width, &data, &mut kernel32);
             let mut scalar32 = [0u32; BLOCK_LEN];
             decode_block_scalar(bit_width as usize, &data, &mut scalar32);
             assert_eq!(&kernel32[..], &scalar32[..], "u32 width {bit_width}");

--- a/bitpacker/src/block_decode/neon.rs
+++ b/bitpacker/src/block_decode/neon.rs
@@ -1,0 +1,126 @@
+use std::arch::aarch64::*;
+
+use super::{BLOCK_LEN, Lane};
+
+/// NEON unpack for bit widths 1..=25.
+///
+/// 8 consecutive values occupy exactly `w` bytes and always start
+/// byte-aligned, so the (byte offset, bit shift) pattern of the 8 values
+/// is a compile-time-free constant per width. For each group of 4 values
+/// we gather the 4 relevant bytes of each value into u32 lanes with
+/// `tbl` (shuffle), then variable-shift right and mask.
+///
+/// Constraint: bit_shift (<=7) + w <= 32 => w <= 25.
+///
+/// # Safety
+/// `data.len() >= 16 * w + 16` must hold (we read 16 bytes at
+/// `15 * w + (4 * w) / 8`, which is `< 16 * w + 16`).
+pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+    debug_assert!((1..=25).contains(&w));
+    debug_assert!(data.len() >= 16 * w + 16);
+    let hi_base = (4 * w) / 8;
+    let mut idx_lo = [0u8; 16];
+    let mut idx_hi = [0u8; 16];
+    let mut sh_lo = [0i32; 4];
+    let mut sh_hi = [0i32; 4];
+    for j in 0..4 {
+        let bit_lo = j * w;
+        let bit_hi = (4 + j) * w;
+        for k in 0..4 {
+            idx_lo[j * 4 + k] = (bit_lo / 8 + k) as u8;
+            idx_hi[j * 4 + k] = (bit_hi / 8 - hi_base + k) as u8;
+        }
+        sh_lo[j] = -((bit_lo % 8) as i32);
+        sh_hi[j] = -((bit_hi % 8) as i32);
+    }
+    unsafe {
+        let idx_lo_v = vld1q_u8(idx_lo.as_ptr());
+        let idx_hi_v = vld1q_u8(idx_hi.as_ptr());
+        let sh_lo_v = vld1q_s32(sh_lo.as_ptr());
+        let sh_hi_v = vld1q_s32(sh_hi.as_ptr());
+        let mask = vdupq_n_u32(((1u64 << w) - 1) as u32);
+        let mut ptr = data.as_ptr();
+        let mut out_ptr = out.as_mut_ptr();
+        for _ in 0..BLOCK_LEN / 8 {
+            let bytes_lo = vld1q_u8(ptr);
+            let bytes_hi = vld1q_u8(ptr.add(hi_base));
+            let lo = vandq_u32(
+                vshlq_u32(
+                    vreinterpretq_u32_u8(vqtbl1q_u8(bytes_lo, idx_lo_v)),
+                    sh_lo_v,
+                ),
+                mask,
+            );
+            let hi = vandq_u32(
+                vshlq_u32(
+                    vreinterpretq_u32_u8(vqtbl1q_u8(bytes_hi, idx_hi_v)),
+                    sh_hi_v,
+                ),
+                mask,
+            );
+            L::store_u32x4(out_ptr, lo);
+            L::store_u32x4(out_ptr.add(4), hi);
+            ptr = ptr.add(w);
+            out_ptr = out_ptr.add(8);
+        }
+    }
+}
+
+/// NEON unpack for bit widths 26..=56, where a value plus its bit shift no
+/// longer fits a `u32` lane.
+///
+/// Same shape as [`decode_block_neon`] with the lanes doubled: a group of 8
+/// values is done as 4 pairs instead of 2 quads, each pair gathered into the
+/// two `u64` lanes of one register, variable-shifted right and masked.
+///
+/// The gather still works off a single 16-byte `tbl` per pair. Value `2p`
+/// starts at byte `b0 = 2 * p * w / 8` and value `2p + 1` at `b1`, with
+/// `b1 - b0 <= ceil(w / 8) <= 7`, so loading 16 bytes at `b0` covers both
+/// lanes' 8 bytes.
+///
+/// Constraint: bit_shift (<=7) + w <= 64 => w <= 57.
+///
+/// # Safety
+/// `data.len() >= 16 * w + 16` must hold: the last group starts at `15 * w`
+/// and its last pair loads 16 bytes at `+ 6 * w / 8`, which is `< 16 * w + 16`.
+pub(super) unsafe fn decode_block_neon_wide<L: Lane>(
+    w: usize,
+    data: &[u8],
+    out: &mut [L; BLOCK_LEN],
+) {
+    debug_assert!((26..=57).contains(&w));
+    debug_assert!(data.len() >= 16 * w + 16);
+    let mut idx = [[0u8; 16]; 4];
+    let mut sh = [[0i64; 2]; 4];
+    let mut base = [0usize; 4];
+    for (p, ((idx, sh), base)) in idx.iter_mut().zip(&mut sh).zip(&mut base).enumerate() {
+        let bit_lo = 2 * p * w;
+        let bit_hi = (2 * p + 1) * w;
+        *base = bit_lo / 8;
+        let hi_delta = bit_hi / 8 - *base;
+        for k in 0..8 {
+            idx[k] = k as u8;
+            idx[8 + k] = (hi_delta + k) as u8;
+        }
+        *sh = [-((bit_lo % 8) as i64), -((bit_hi % 8) as i64)];
+    }
+    unsafe {
+        let idx_v = idx.map(|idx| vld1q_u8(idx.as_ptr()));
+        let sh_v = sh.map(|sh| vld1q_s64(sh.as_ptr()));
+        let mask = vdupq_n_u64((1u64 << w) - 1);
+        let mut ptr = data.as_ptr();
+        let mut out_ptr = out.as_mut_ptr();
+        for _ in 0..BLOCK_LEN / 8 {
+            for p in 0..4 {
+                let bytes = vld1q_u8(ptr.add(base[p]));
+                let vals = vandq_u64(
+                    vshlq_u64(vreinterpretq_u64_u8(vqtbl1q_u8(bytes, idx_v[p])), sh_v[p]),
+                    mask,
+                );
+                L::store_u64x2(out_ptr.add(2 * p), vals);
+            }
+            ptr = ptr.add(w);
+            out_ptr = out_ptr.add(8);
+        }
+    }
+}

--- a/bitpacker/src/block_decode/neon.rs
+++ b/bitpacker/src/block_decode/neon.rs
@@ -2,6 +2,41 @@ use std::arch::aarch64::*;
 
 use super::{BLOCK_LEN, Lane};
 
+/// Stores 4 unpacked values held in `u32` lanes at `out`, widening when the
+/// output lane is `u64`. The branch folds away at monomorphization.
+///
+/// # Safety
+/// `out` must be writable for 4 elements.
+#[inline(always)]
+unsafe fn store_u32x4<L: Lane>(out: *mut L, vals: uint32x4_t) {
+    unsafe {
+        if L::IS_U64 {
+            let out = out as *mut u64;
+            vst1q_u64(out, vmovl_u32(vget_low_u32(vals)));
+            vst1q_u64(out.add(2), vmovl_high_u32(vals));
+        } else {
+            vst1q_u32(out as *mut u32, vals);
+        }
+    }
+}
+
+/// Stores 2 unpacked values held in `u64` lanes at `out`, narrowing when the
+/// output lane is `u32`. The branch folds away at monomorphization.
+///
+/// # Safety
+/// `out` must be writable for 2 elements, and every lane must fit `L` (the
+/// `u32` lane is only ever used at widths `<= 32`).
+#[inline(always)]
+unsafe fn store_u64x2<L: Lane>(out: *mut L, vals: uint64x2_t) {
+    unsafe {
+        if L::IS_U64 {
+            vst1q_u64(out as *mut u64, vals);
+        } else {
+            vst1_u32(out as *mut u32, vmovn_u64(vals));
+        }
+    }
+}
+
 /// NEON unpack for bit widths 1..=25.
 ///
 /// 8 consecutive values occupy exactly `w` bytes and always start
@@ -58,8 +93,8 @@ pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut
                 ),
                 mask,
             );
-            L::store_u32x4(out_ptr, lo);
-            L::store_u32x4(out_ptr.add(4), hi);
+            store_u32x4::<L>(out_ptr, lo);
+            store_u32x4::<L>(out_ptr.add(4), hi);
             ptr = ptr.add(w);
             out_ptr = out_ptr.add(8);
         }
@@ -117,7 +152,7 @@ pub(super) unsafe fn decode_block_neon_wide<L: Lane>(
                     vshlq_u64(vreinterpretq_u64_u8(vqtbl1q_u8(bytes, idx_v[p])), sh_v[p]),
                     mask,
                 );
-                L::store_u64x2(out_ptr.add(2 * p), vals);
+                store_u64x2::<L>(out_ptr.add(2 * p), vals);
             }
             ptr = ptr.add(w);
             out_ptr = out_ptr.add(8);

--- a/bitpacker/src/block_decode/neon.rs
+++ b/bitpacker/src/block_decode/neon.rs
@@ -1,12 +1,9 @@
 use std::arch::aarch64::*;
 
-use super::{BLOCK_LEN, Lane};
+use super::Lane;
 
-/// Stores 4 unpacked values held in `u32` lanes at `out`, widening when the
-/// output lane is `u64`. The branch folds away at monomorphization.
-///
-/// # Safety
-/// `out` must be writable for 4 elements.
+/// Stores 4 unpacked values held in `u32` lanes at `out`,
+/// widening when the output lane is `u64`.
 #[inline(always)]
 unsafe fn store_u32x4<L: Lane>(out: *mut L, vals: uint32x4_t) {
     unsafe {
@@ -20,12 +17,8 @@ unsafe fn store_u32x4<L: Lane>(out: *mut L, vals: uint32x4_t) {
     }
 }
 
-/// Stores 2 unpacked values held in `u64` lanes at `out`, narrowing when the
-/// output lane is `u32`. The branch folds away at monomorphization.
-///
-/// # Safety
-/// `out` must be writable for 2 elements, and every lane must fit `L` (the
-/// `u32` lane is only ever used at widths `<= 32`).
+/// Stores 2 unpacked values held in `u64` lanes at `out`,
+/// narrowing when the output lane is `u32`.
 #[inline(always)]
 unsafe fn store_u64x2<L: Lane>(out: *mut L, vals: uint64x2_t) {
     unsafe {
@@ -45,14 +38,17 @@ unsafe fn store_u64x2<L: Lane>(out: *mut L, vals: uint64x2_t) {
 /// we gather the 4 relevant bytes of each value into u32 lanes with
 /// `tbl` (shuffle), then variable-shift right and mask.
 ///
+/// Decodes `out.len() / 8` groups; `out.len()` must be a multiple of 8.
+///
 /// Constraint: bit_shift (<=7) + w <= 32 => w <= 25.
 ///
 /// # Safety
-/// `data.len() >= 16 * w + 16` must hold (we read 16 bytes at
-/// `15 * w + (4 * w) / 8`, which is `< 16 * w + 16`).
-pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut [L; BLOCK_LEN]) {
+/// `data.len() >= out.len() / 8 * w + 16` must hold: group `g` reads 16 bytes
+/// at `g * w + (4 * w) / 8`, and the last group has `g = out.len() / 8 - 1`.
+pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut [L]) {
     debug_assert!((1..=25).contains(&w));
-    debug_assert!(data.len() >= 16 * w + 16);
+    debug_assert!(out.len() % 8 == 0);
+    debug_assert!(data.len() >= out.len() / 8 * w + 16);
     let hi_base = (4 * w) / 8;
     let mut idx_lo = [0u8; 16];
     let mut idx_hi = [0u8; 16];
@@ -76,7 +72,7 @@ pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut
         let mask = vdupq_n_u32(((1u64 << w) - 1) as u32);
         let mut ptr = data.as_ptr();
         let mut out_ptr = out.as_mut_ptr();
-        for _ in 0..BLOCK_LEN / 8 {
+        for _ in 0..out.len() / 8 {
             let bytes_lo = vld1q_u8(ptr);
             let bytes_hi = vld1q_u8(ptr.add(hi_base));
             let lo = vandq_u32(
@@ -101,30 +97,12 @@ pub(super) unsafe fn decode_block_neon<L: Lane>(w: usize, data: &[u8], out: &mut
     }
 }
 
-/// NEON unpack for bit widths 26..=56, where a value plus its bit shift no
-/// longer fits a `u32` lane.
-///
-/// Same shape as [`decode_block_neon`] with the lanes doubled: a group of 8
-/// values is done as 4 pairs instead of 2 quads, each pair gathered into the
-/// two `u64` lanes of one register, variable-shifted right and masked.
-///
-/// The gather still works off a single 16-byte `tbl` per pair. Value `2p`
-/// starts at byte `b0 = 2 * p * w / 8` and value `2p + 1` at `b1`, with
-/// `b1 - b0 <= ceil(w / 8) <= 7`, so loading 16 bytes at `b0` covers both
-/// lanes' 8 bytes.
-///
+/// NEON unpack for bit widths 26..=56
 /// Constraint: bit_shift (<=7) + w <= 64 => w <= 57.
-///
-/// # Safety
-/// `data.len() >= 16 * w + 16` must hold: the last group starts at `15 * w`
-/// and its last pair loads 16 bytes at `+ 6 * w / 8`, which is `< 16 * w + 16`.
-pub(super) unsafe fn decode_block_neon_wide<L: Lane>(
-    w: usize,
-    data: &[u8],
-    out: &mut [L; BLOCK_LEN],
-) {
+pub(super) unsafe fn decode_block_neon_wide<L: Lane>(w: usize, data: &[u8], out: &mut [L]) {
     debug_assert!((26..=57).contains(&w));
-    debug_assert!(data.len() >= 16 * w + 16);
+    debug_assert!(out.len() % 8 == 0);
+    debug_assert!(data.len() >= out.len() / 8 * w + 16);
     let mut idx = [[0u8; 16]; 4];
     let mut sh = [[0i64; 2]; 4];
     let mut base = [0usize; 4];
@@ -145,7 +123,7 @@ pub(super) unsafe fn decode_block_neon_wide<L: Lane>(
         let mask = vdupq_n_u64((1u64 << w) - 1);
         let mut ptr = data.as_ptr();
         let mut out_ptr = out.as_mut_ptr();
-        for _ in 0..BLOCK_LEN / 8 {
+        for _ in 0..out.len() / 8 {
             for p in 0..4 {
                 let bytes = vld1q_u8(ptr.add(base[p]));
                 let vals = vandq_u64(

--- a/bitpacker/src/blocked_bitpacker.rs
+++ b/bitpacker/src/blocked_bitpacker.rs
@@ -1,6 +1,6 @@
 use super::bitpacker::BitPacker;
 use super::compute_num_bits;
-use crate::block_decode::{BLOCK_LEN, decode_block};
+use crate::block_decode::{BLOCK_LEN, decode_range};
 use crate::{BitUnpacker, minmax};
 
 const BLOCK_SIZE: usize = BLOCK_LEN;
@@ -143,8 +143,9 @@ impl BlockedBitpacker {
             .iter()
             .flat_map(move |metadata| {
                 let mut block = [0u64; BLOCK_SIZE];
-                decode_block(
+                decode_range(
                     metadata.num_bits(),
+                    0,
                     &self.compressed_blocks[metadata.offset() as usize..],
                     &mut block,
                 );

--- a/bitpacker/src/blocked_bitpacker.rs
+++ b/bitpacker/src/blocked_bitpacker.rs
@@ -1,8 +1,9 @@
 use super::bitpacker::BitPacker;
 use super::compute_num_bits;
+use crate::block_decode::{BLOCK_LEN, decode_block};
 use crate::{BitUnpacker, minmax};
 
-const BLOCK_SIZE: usize = 128;
+const BLOCK_SIZE: usize = BLOCK_LEN;
 
 /// `BlockedBitpacker` compresses data in blocks of
 /// 128 elements, while keeping an index on it
@@ -138,11 +139,18 @@ impl BlockedBitpacker {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
-        // todo performance: we could decompress a whole block and cache it instead
-        let bitpacked_elems = self.offset_and_bits.len() * BLOCK_SIZE;
-
-        (0..bitpacked_elems)
-            .map(move |idx| self.get(idx))
+        self.offset_and_bits
+            .iter()
+            .flat_map(move |metadata| {
+                let mut block = [0u64; BLOCK_SIZE];
+                decode_block(
+                    metadata.num_bits(),
+                    &self.compressed_blocks[metadata.offset() as usize..],
+                    &mut block,
+                );
+                let base_value = metadata.base_value();
+                block.into_iter().map(move |val| val + base_value)
+            })
             .chain(self.buffer.iter().cloned())
     }
 }

--- a/bitpacker/src/lib.rs
+++ b/bitpacker/src/lib.rs
@@ -1,4 +1,5 @@
 mod bitpacker;
+pub mod block_decode;
 mod blocked_bitpacker;
 mod filter_vec;
 

--- a/columnar/Cargo.toml
+++ b/columnar/Cargo.toml
@@ -42,6 +42,10 @@ name = "bench_values_u64"
 harness = false
 
 [[bench]]
+name = "bench_bitpacked_batch"
+harness = false
+
+[[bench]]
 name = "bench_values_u128"
 harness = false
 

--- a/columnar/benches/bench_bitpacked_batch.rs
+++ b/columnar/benches/bench_bitpacked_batch.rs
@@ -1,0 +1,357 @@
+//! In-process A/B of the batch block-decode paths against the per-value
+//! defaults they replaced, reproduced verbatim as the `_pervalue` variants.
+//!
+//! `TANTIVY_BITPACKER_SCALAR=1` additionally disables the SIMD kernel, which
+//! separates "batching won" from "SIMD won".
+
+use std::sync::Arc;
+
+use binggan::{InputGroup, black_box};
+use rand::prelude::*;
+use tantivy_columnar::column_values::{CodecType, serialize_and_load_u64_based_column_values};
+use tantivy_columnar::*;
+
+const NUM_VALS: usize = 100_000;
+
+/// Values needing exactly `bits` bits after gcd normalization (gcd == 1).
+fn data_with_width(bits: u32) -> Vec<u64> {
+    let mut rng = StdRng::from_seed([3u8; 32]);
+    let max = if bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << bits) - 1
+    };
+    let mut vals: Vec<u64> = (0..NUM_VALS).map(|_| rng.random_range(0..=max)).collect();
+    // Pin the amplitude to `bits` and keep gcd at 1.
+    vals[0] = 0;
+    vals[1] = max;
+    vals[2] = 1;
+    vals
+}
+
+/// The `ColumnValues::get_range` default, verbatim: 4 `get_val`s per step.
+fn get_range_per_value<T: PartialOrd + Copy + std::fmt::Debug + 'static>(
+    col: &dyn ColumnValues<T>,
+    start: usize,
+    output: &mut [T],
+) {
+    let (out_chunks, out_rem) = output.as_chunks_mut::<4>();
+    let mut idx = start as u64;
+    for out_x4 in out_chunks {
+        out_x4[0] = col.get_val(idx as u32);
+        out_x4[1] = col.get_val((idx + 1) as u32);
+        out_x4[2] = col.get_val((idx + 2) as u32);
+        out_x4[3] = col.get_val((idx + 3) as u32);
+        idx += 4;
+    }
+    for out in out_rem {
+        *out = col.get_val(idx as u32);
+        idx += 1;
+    }
+}
+
+type Col = Arc<dyn ColumnValues<u64>>;
+
+fn main() {
+    let mut inputs: Vec<(String, Col)> = Vec::new();
+    // 8: byte aligned, NEON. 17/25: NEON, unaligned. 33: above the kernel's
+    // 25-bit ceiling -> scalar block path. 64: plain u64 loads.
+    for bits in [8u32, 17, 25, 33, 64] {
+        let col: Col = serialize_and_load_u64_based_column_values(
+            &&data_with_width(bits)[..],
+            &[CodecType::Bitpacked],
+        );
+        inputs.push((format!("w{bits}"), col));
+    }
+    // The linear codecs share the residual-stream layout and take the same
+    // kernels, but pay a line evaluation (and for blockwise, a per-block
+    // metadata fetch) on top: measured separately, not assumed.
+    {
+        let mut rng = StdRng::from_seed([7u8; 32]);
+        let linear_ish: Vec<u64> = (0..NUM_VALS)
+            .map(|i| 1_000_000 + 37 * i as u64 + rng.random_range(0..256))
+            .collect();
+        let col: Col =
+            serialize_and_load_u64_based_column_values(&&linear_ish[..], &[CodecType::Linear]);
+        inputs.push(("linear".to_string(), col));
+        let col: Col = serialize_and_load_u64_based_column_values(
+            &&linear_ish[..],
+            &[CodecType::BlockwiseLinear],
+        );
+        inputs.push(("blockwise_linear".to_string(), col));
+    }
+    let mut group: InputGroup<Col> = InputGroup::new_with_inputs(inputs);
+
+    group.register("getrange_batch", |col: &Col| {
+        let n = col.num_vals() as usize;
+        let mut buf = vec![0u64; 4096];
+        let mut acc = 0u64;
+        let mut start = 0usize;
+        while start < n {
+            let take = 4096.min(n - start);
+            col.get_range(start as u64, &mut buf[..take]);
+            for &v in &buf[..take] {
+                acc += v;
+            }
+            start += take;
+        }
+        black_box(acc);
+    });
+
+    // Exactly the old `ColumnValues::get_range` default: 4 `get_val`s per step.
+    group.register("getrange_pervalue", |col: &Col| {
+        let n = col.num_vals() as usize;
+        let mut buf = vec![0u64; 4096];
+        let mut acc = 0u64;
+        let mut start = 0usize;
+        while start < n {
+            let take = 4096.min(n - start);
+            get_range_per_value(col.as_ref(), start, &mut buf[..take]);
+            for &v in &buf[..take] {
+                acc += v;
+            }
+            start += take;
+        }
+        black_box(acc);
+    });
+
+    // Short ranges at random offsets: the shape aggregations produce. These
+    // guard the partial-block threshold in `block_decode.rs`.
+    for take in [1usize, 16, 64] {
+        group.register(format!("short{take}_batch"), move |col: &Col| {
+            let n = col.num_vals() as usize;
+            let mut buf = vec![0u64; take];
+            let mut acc = 0u64;
+            let mut start = 1usize;
+            while start + take < n {
+                col.get_range(start as u64, &mut buf);
+                acc ^= buf[0];
+                // Coprime-ish stride so offsets cycle through block phases.
+                start += 191;
+            }
+            black_box(acc);
+        });
+        group.register(format!("short{take}_pervalue"), move |col: &Col| {
+            let n = col.num_vals() as usize;
+            let mut buf = vec![0u64; take];
+            let mut acc = 0u64;
+            let mut start = 1usize;
+            while start + take < n {
+                get_range_per_value(col.as_ref(), start, &mut buf);
+                acc ^= buf[0];
+                start += 191;
+            }
+            black_box(acc);
+        });
+    }
+
+    // Quantifies what the `Box<dyn Iterator>` itself costs against an inline
+    // `get_val` loop (pre-existing, unchanged by the batch decode).
+    group.register("iter_trait", |col: &Col| {
+        let acc: u64 = col.iter().sum();
+        black_box(acc);
+    });
+
+    group.register("iter_inline_getval", |col: &Col| {
+        let acc: u64 = (0..col.num_vals()).map(|idx| col.get_val(idx)).sum();
+        black_box(acc);
+    });
+
+    group.run();
+
+    bench_f64_wrapper();
+}
+
+type F64Col = (Arc<dyn ColumnValues<f64>>, Arc<dyn ColumnValues<u64>>);
+
+/// The buffered general path as it stood before the buffer moved to the
+/// stack: a `Vec<Input>` allocated per call, chunked on 512 boundaries.
+fn get_range_vec512(col: &dyn ColumnValues<u64>, start: u64, output: &mut [f64]) {
+    if output.len() >= 64 {
+        const CHUNK: usize = 512;
+        let init: u64 = col.get_val(start as u32);
+        let mut buffer: Vec<u64> = vec![init; CHUNK.min(output.len())];
+        let mut offset = 0usize;
+        while offset < output.len() {
+            let pos = start + offset as u64;
+            let len = (CHUNK - (pos as usize % CHUNK)).min(output.len() - offset);
+            let buf = &mut buffer[..len];
+            col.get_range(pos, buf);
+            for (out, inp) in output[offset..offset + len].iter_mut().zip(buf.iter()) {
+                *out = f64::from_u64(*inp);
+            }
+            offset += len;
+        }
+    } else {
+        for (i, out) in output.iter_mut().enumerate() {
+            *out = f64::from_u64(col.get_val(start as u32 + i as u32));
+        }
+    }
+}
+
+/// f64 columns take the monotonic wrapper's *buffered* forwarding path
+/// (`Input=u64 != Output=f64`). Compares:
+///
+/// - `wrapper_batch`: what ships now (buffered forward, block-sized stack buffer),
+/// - `wrapper_vec512`: the previous buffered path (per-call `Vec`, 512 chunks),
+/// - `wrapper_fused_pervalue`: the pre-batching behaviour,
+/// - `scratch_batch`: the batch decode with the buffer hoisted out of the loop entirely, the
+///   ceiling any in-wrapper buffering can reach.
+///
+/// `chunk` is the `output.len()` per call; the `_misaligned` pair drives the
+/// same calls from starts that are not on the chunk grid.
+fn bench_f64_wrapper() {
+    use tantivy_columnar::column_values::{
+        load_u64_based_column_values, serialize_u64_based_column_values,
+    };
+
+    fn build(vals: &[f64]) -> F64Col {
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&vals, &[CodecType::Bitpacked], &mut buffer).unwrap();
+        let bytes = common::OwnedBytes::new(buffer);
+        let as_f64 = load_u64_based_column_values::<f64>(bytes.clone()).unwrap();
+        // The same bytes read as raw u64s, so the scratch variant can drive the
+        // inner column directly and apply the mapping itself.
+        let as_u64 = load_u64_based_column_values::<u64>(bytes).unwrap();
+        (as_f64, as_u64)
+    }
+
+    let mut rng = StdRng::from_seed([5u8; 32]);
+    let prices: Vec<f64> = (0..NUM_VALS)
+        .map(|_| (rng.random_range(0..10_000_000) as f64) / 100.0)
+        .collect();
+    let dates: Vec<f64> = (0..NUM_VALS).map(|i| 1_700_000_000.0 + i as f64).collect();
+
+    // Guard: the scratch variant reproduces the wrapper's mapping itself, so
+    // prove all three agree before timing them.
+    for vals in [&prices, &dates] {
+        let (as_f64, as_u64) = build(vals);
+        let mut via_wrapper = vec![0f64; 300];
+        as_f64.get_range(64, &mut via_wrapper);
+        let mut raw = vec![0u64; 300];
+        as_u64.get_range(64, &mut raw);
+        let via_scratch: Vec<f64> = raw.iter().map(|&r| f64::from_u64(r)).collect();
+        assert_eq!(via_wrapper, via_scratch, "scratch variant maps differently");
+        assert_eq!(via_wrapper, vals[64..364], "wrapper get_range is wrong");
+        // Same for the previous-implementation replica, on an aligned and a
+        // deliberately misaligned start.
+        for start in [64usize, 377] {
+            let mut via_vec512 = vec![0f64; 300];
+            get_range_vec512(as_u64.as_ref(), start as u64, &mut via_vec512);
+            assert_eq!(
+                via_vec512,
+                vals[start..start + 300],
+                "vec512 replica is wrong at start={start}"
+            );
+        }
+    }
+
+    for chunk in [128usize, 512, 4096] {
+        let mut inputs: Vec<(String, F64Col)> = Vec::new();
+        inputs.push((format!("prices_chunk{chunk}"), build(&prices)));
+        inputs.push((format!("dates_chunk{chunk}"), build(&dates)));
+        let mut group: InputGroup<F64Col> = InputGroup::new_with_inputs(inputs);
+
+        group.register("wrapper_batch", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut acc = 0f64;
+            let mut start = 0usize;
+            while start < n {
+                let take = chunk.min(n - start);
+                inp.0.get_range(start as u64, &mut out[..take]);
+                for &v in &out[..take] {
+                    acc += v;
+                }
+                start += take;
+            }
+            black_box(acc);
+        });
+
+        // The previous buffered path: per-call `Vec`, 512-aligned chunks.
+        group.register("wrapper_vec512", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut acc = 0f64;
+            let mut start = 0usize;
+            while start < n {
+                let take = chunk.min(n - start);
+                get_range_vec512(inp.1.as_ref(), start as u64, &mut out[..take]);
+                for &v in &out[..take] {
+                    acc += v;
+                }
+                start += take;
+            }
+            black_box(acc);
+        });
+
+        // Misaligned starts: a coprime stride walks the range across every
+        // phase of the chunk grid instead of landing on it every time.
+        group.register("wrapper_batch_misaligned", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut acc = 0f64;
+            let mut start = 1usize;
+            while start + chunk < n {
+                inp.0.get_range(start as u64, &mut out);
+                acc += out[0];
+                start += chunk + 191;
+            }
+            black_box(acc);
+        });
+
+        group.register("wrapper_vec512_misaligned", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut acc = 0f64;
+            let mut start = 1usize;
+            while start + chunk < n {
+                get_range_vec512(inp.1.as_ref(), start as u64, &mut out);
+                acc += out[0];
+                start += chunk + 191;
+            }
+            black_box(acc);
+        });
+
+        // The wrapper's fused else-branch, verbatim: what f64 columns ran
+        // before `Bitpacked` declared a specialized `get_range`.
+        group.register("wrapper_fused_pervalue", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut acc = 0f64;
+            let mut start = 0usize;
+            while start < n {
+                let take = chunk.min(n - start);
+                get_range_per_value(inp.0.as_ref(), start, &mut out[..take]);
+                for &v in &out[..take] {
+                    acc += v;
+                }
+                start += take;
+            }
+            black_box(acc);
+        });
+
+        // Batch decode with the intermediate buffer allocated once.
+        group.register("scratch_batch", move |inp: &F64Col| {
+            let n = inp.0.num_vals() as usize;
+            let mut out = vec![0f64; chunk];
+            let mut scratch = vec![0u64; chunk];
+            let mut acc = 0f64;
+            let mut start = 0usize;
+            while start < n {
+                let take = chunk.min(n - start);
+                inp.1.get_range(start as u64, &mut scratch[..take]);
+                for (o, &raw) in out[..take].iter_mut().zip(scratch[..take].iter()) {
+                    *o = f64::from_u64(raw);
+                }
+                for &v in &out[..take] {
+                    acc += v;
+                }
+                start += take;
+            }
+            black_box(acc);
+        });
+
+        group.run();
+    }
+}

--- a/columnar/benches/bench_column_values_get.rs
+++ b/columnar/benches/bench_column_values_get.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
 
 use binggan::{InputGroup, black_box};
+use common::OwnedBytes;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use tantivy_columnar::ColumnValues;
-use tantivy_columnar::column_values::{CodecType, serialize_and_load_u64_based_column_values};
+use tantivy_columnar::column_values::{
+    CodecType, load_u64_based_column_values, serialize_and_load_u64_based_column_values,
+    serialize_u64_based_column_values,
+};
+use tantivy_columnar::{ColumnValues, MonotonicallyMappableToU64};
 
 fn get_data() -> Vec<u64> {
     let mut rng = StdRng::seed_from_u64(2u64);
@@ -20,6 +24,15 @@ fn get_data() -> Vec<u64> {
     data
 }
 
+/// Decimal values, in the u64 bit mapping the codecs see: `Alp` refuses
+/// integer data, so it can only be compared on a shape it accepts.
+fn get_decimal_data() -> Vec<u64> {
+    let mut rng = StdRng::seed_from_u64(3u64);
+    (0..55_000)
+        .map(|_| f64::to_u64(rng.random_range(0..10_000_000) as f64 / 100.0))
+        .collect()
+}
+
 #[inline(never)]
 fn value_iter() -> impl Iterator<Item = u64> {
     0..20_000
@@ -27,29 +40,23 @@ fn value_iter() -> impl Iterator<Item = u64> {
 
 type Col = Arc<dyn ColumnValues<u64>>;
 
-fn main() {
-    let data = get_data();
-    let inputs: Vec<(String, Col)> = vec![
-        (
-            "bitpacked".to_string(),
-            serialize_and_load_u64_based_column_values(&data.as_slice(), &[CodecType::Bitpacked]),
-        ),
-        (
-            "linear".to_string(),
-            serialize_and_load_u64_based_column_values(&data.as_slice(), &[CodecType::Linear]),
-        ),
-        (
-            "blockwise_linear".to_string(),
-            serialize_and_load_u64_based_column_values(
-                &data.as_slice(),
-                &[CodecType::BlockwiseLinear],
-            ),
-        ),
-    ];
+fn columns(data: &[u64], codecs: &[(&str, CodecType)]) -> Vec<(String, Col)> {
+    codecs
+        .iter()
+        .map(|(name, codec)| {
+            (
+                name.to_string(),
+                serialize_and_load_u64_based_column_values(&data, &[*codec]),
+            )
+        })
+        .collect()
+}
 
-    let mut group: InputGroup<Col> = InputGroup::new_with_inputs(inputs);
-
-    group.register("fastfield_get", |col: &Col| {
+/// `get_val` per row, plus the batched `get_range` shapes that actually occur:
+/// a doc block at a time (what an aggregation fetches), a whole-column scan,
+/// and short takes at scattered offsets (what a per-bucket doc run produces).
+fn register(group: &mut InputGroup<Col>) {
+    group.register("get_val", |col: &Col| {
         let mut sum = 0u64;
         for pos in value_iter() {
             sum = sum.wrapping_add(col.get_val(pos as u32));
@@ -57,5 +64,173 @@ fn main() {
         black_box(sum);
     });
 
+    for take in [32usize, 128] {
+        group.register(format!("get_range_seq{take}"), move |col: &Col| {
+            let n = col.num_vals() as usize;
+            let mut buf = vec![0u64; take];
+            let mut sum = 0u64;
+            let mut start = 0usize;
+            while start + take < n {
+                col.get_range(start as u64, &mut buf);
+                sum = sum.wrapping_add(buf[0]);
+                start += take;
+            }
+            black_box(sum);
+        });
+
+        // Coprime-ish stride, so takes land on every phase of the 128-value
+        // block grid instead of always on a boundary.
+        group.register(format!("get_range_scattered{take}"), move |col: &Col| {
+            let n = col.num_vals() as usize;
+            let mut buf = vec![0u64; take];
+            let mut sum = 0u64;
+            let mut start = 1usize;
+            while start + take < n {
+                col.get_range(start as u64, &mut buf);
+                sum = sum.wrapping_add(buf[0]);
+                start += take + 191;
+            }
+            black_box(sum);
+        });
+    }
+
+    group.register("get_range_scan", |col: &Col| {
+        let n = col.num_vals() as usize;
+        let mut buf = vec![0u64; 4096];
+        let mut sum = 0u64;
+        let mut start = 0usize;
+        while start < n {
+            let take = 4096.min(n - start);
+            col.get_range(start as u64, &mut buf[..take]);
+            for &v in &buf[..take] {
+                sum = sum.wrapping_add(v);
+            }
+            start += take;
+        }
+        black_box(sum);
+    });
+}
+
+const DATE_NUM_VALS: usize = 2_000_000;
+
+fn date_shapes() -> Vec<(&'static str, Vec<u64>)> {
+    let n = DATE_NUM_VALS as u64;
+    vec![
+        (
+            "timestamps",
+            (0..n)
+                .map(|i| 1_700_000_000_000 + i * 250 + (i.wrapping_mul(2_654_435_761) % 4_000))
+                .collect(),
+        ),
+        (
+            "near_sorted_ids",
+            (0..n)
+                .map(|i| i * 32 + (i.wrapping_mul(2_654_435_761) % 100_000))
+                .collect(),
+        ),
+        (
+            "noisy_ramp",
+            (0..n)
+                .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % (1 << 20)))
+                .collect(),
+        ),
+        ("const_outliers", {
+            let mut vals = vec![42_000u64; DATE_NUM_VALS];
+            for i in (0..DATE_NUM_VALS).step_by(9_973) {
+                vals[i] = u64::MAX / 2;
+            }
+            vals
+        }),
+    ]
+}
+
+fn build(vals: &[u64], codecs: &[CodecType]) -> (String, Col) {
+    let mut buffer = Vec::new();
+    serialize_u64_based_column_values(&vals, codecs, &mut buffer).unwrap();
+    let chosen = CodecType::from_code(buffer[0]).unwrap();
+    let col = load_u64_based_column_values::<u64>(OwnedBytes::new(buffer)).unwrap();
+    (chosen.to_string(), col)
+}
+
+fn register_large(group: &mut InputGroup<Col>) {
+    let probes: Vec<u32> = (0..100_000u64)
+        .map(|i| (i.wrapping_mul(0x9E37_79B9_7F4A_7C15) % DATE_NUM_VALS as u64) as u32)
+        .collect();
+    group.register("get_val_random", move |col: &Col| {
+        let mut sum = 0u64;
+        for &row in &probes {
+            sum = sum.wrapping_add(col.get_val(row));
+        }
+        black_box(sum);
+    });
+
+    group.register("filter_walk_only", |col: &Col| {
+        let hi = col.max_value();
+        let mut hits = Vec::new();
+        col.get_row_ids_for_value_range(hi + 1..=hi + 2, 0..col.num_vals(), &mut hits);
+        black_box(hits.len());
+    });
+
+    group.register("filter_decode_all", |col: &Col| {
+        let mut hits = Vec::with_capacity(col.num_vals() as usize);
+        col.get_row_ids_for_value_range(
+            col.min_value()..=col.max_value(),
+            0..col.num_vals(),
+            &mut hits,
+        );
+        black_box(hits.len());
+    });
+
+    group.register("filter_1pct_span", |col: &Col| {
+        let (lo, hi) = (col.min_value(), col.max_value());
+        let mid = lo + (hi - lo) / 2;
+        let mut hits = Vec::new();
+        col.get_row_ids_for_value_range(mid..=mid + (hi - lo) / 100, 0..col.num_vals(), &mut hits);
+        black_box(hits.len());
+    });
+}
+
+fn main() {
+    let mut group: InputGroup<Col> = InputGroup::new_with_inputs(columns(
+        &get_data(),
+        &[
+            ("bitpacked", CodecType::Bitpacked),
+            ("linear", CodecType::Linear),
+            ("blockwise_linear", CodecType::BlockwiseLinear),
+            ("block_for", CodecType::BlockFor),
+        ],
+    ));
+    register(&mut group);
     group.run();
+
+    let mut group: InputGroup<Col> = InputGroup::new_with_inputs(columns(
+        &get_decimal_data(),
+        &[
+            ("bitpacked_dec", CodecType::Bitpacked),
+            ("linear_dec", CodecType::Linear),
+            ("blockwise_linear_dec", CodecType::BlockwiseLinear),
+            ("block_for_dec", CodecType::BlockFor),
+        ],
+    ));
+    register(&mut group);
+    group.run();
+
+    for (shape, vals) in date_shapes() {
+        let (incumbent, regular) = build(
+            &vals,
+            &[
+                CodecType::Bitpacked,
+                CodecType::Linear,
+                CodecType::BlockwiseLinear,
+            ],
+        );
+        let (_, block_for) = build(&vals, &[CodecType::BlockFor]);
+        let mut group: InputGroup<Col> = InputGroup::new_with_inputs(vec![
+            (format!("{shape}_{incumbent}"), regular),
+            (format!("{shape}_block_for"), block_for),
+        ]);
+        register(&mut group);
+        register_large(&mut group);
+        group.run();
+    }
 }

--- a/columnar/benches/bench_create_column_values.rs
+++ b/columnar/benches/bench_create_column_values.rs
@@ -1,6 +1,7 @@
 use binggan::{InputGroup, black_box};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use tantivy_columnar::MonotonicallyMappableToU64;
 use tantivy_columnar::column_values::{CodecType, serialize_u64_based_column_values};
 
 fn get_data() -> Vec<u64> {
@@ -17,28 +18,54 @@ fn get_data() -> Vec<u64> {
     data
 }
 
+/// Decimal values, in the u64 bit mapping the codecs see: `Alp` refuses
+/// integer data. Its serialization searches for an exponent per block, which
+/// is the reason to watch its write side separately.
+fn get_decimal_data() -> Vec<u64> {
+    let mut rng = StdRng::seed_from_u64(3u64);
+    (0..55_000)
+        .map(|_| f64::to_u64(rng.random_range(0..10_000_000) as f64 / 100.0))
+        .collect()
+}
+
+fn inputs(
+    data: &[u64],
+    codecs: &[(&str, CodecType)],
+) -> Vec<(String, (CodecType, Vec<u64>))> {
+    codecs
+        .iter()
+        .map(|(name, codec)| (name.to_string(), (*codec, data.to_vec())))
+        .collect()
+}
+
 fn main() {
-    let data = get_data();
-    let mut group: InputGroup<(CodecType, Vec<u64>)> = InputGroup::new_with_inputs(vec![
+    for (data, codecs) in [
         (
-            "bitpacked codec".to_string(),
-            (CodecType::Bitpacked, data.clone()),
+            get_data(),
+            &[
+                ("bitpacked codec", CodecType::Bitpacked),
+                ("linear codec", CodecType::Linear),
+                ("blockwise linear codec", CodecType::BlockwiseLinear),
+                ("block_for codec", CodecType::BlockFor),
+            ][..],
         ),
         (
-            "linear codec".to_string(),
-            (CodecType::Linear, data.clone()),
+            get_decimal_data(),
+            &[
+                ("bitpacked codec dec", CodecType::Bitpacked),
+                ("linear codec dec", CodecType::Linear),
+                ("blockwise linear codec dec", CodecType::BlockwiseLinear),
+                ("block_for codec dec", CodecType::BlockFor),
+            ][..],
         ),
-        (
-            "blockwise linear codec".to_string(),
-            (CodecType::BlockwiseLinear, data.clone()),
-        ),
-    ]);
-
-    group.register("serialize column_values", |data| {
-        let mut buffer = Vec::new();
-        serialize_u64_based_column_values(&data.1.as_slice(), &[data.0], &mut buffer).unwrap();
-        black_box(buffer.len());
-    });
-
-    group.run();
+    ] {
+        let mut group: InputGroup<(CodecType, Vec<u64>)> =
+            InputGroup::new_with_inputs(inputs(&data, codecs));
+        group.register("serialize column_values", move |data| {
+            let mut buffer = Vec::new();
+            serialize_u64_based_column_values(&data.1.as_slice(), &[data.0], &mut buffer).unwrap();
+            black_box(buffer.len());
+        });
+        group.run();
+    }
 }

--- a/columnar/benches/bench_values_u64.rs
+++ b/columnar/benches/bench_values_u64.rs
@@ -54,6 +54,25 @@ fn bench_access() {
     let column_perm_gcd: Arc<dyn ColumnValues<u64>> =
         serialize_and_load(&permutation_gcd, CodecType::Bitpacked);
 
+    // Same size, different bit widths: 8 (byte aligned), 33 (above the NEON
+    // kernel's 25-bit limit -> scalar), to see each decode path.
+    let data_u8: Vec<u64> = generate_permutation().iter().map(|v| v & 0xFF).collect();
+    let column_u8: Arc<dyn ColumnValues<u64>> = serialize_and_load(&data_u8, CodecType::Bitpacked);
+    // Spread the permutation over 33 bits and pin gcd/amplitude: a value of 1
+    // forces gcd 1, the 0 and 2^33-1 endpoints force a 33-bit amplitude.
+    // (A shifted construction like `(v << 16) | 2^32` would silently collapse:
+    // every value shares the 2^16 factor, the gcd normalization strips it, and
+    // the column encodes at 16 bits on the NEON path instead.)
+    let mut data_u33: Vec<u64> = generate_permutation()
+        .iter()
+        .map(|v| v.wrapping_mul(0x9E3779B97F4A7C15) & ((1u64 << 33) - 1))
+        .collect();
+    data_u33[0] = 0;
+    data_u33[1] = (1u64 << 33) - 1;
+    data_u33[2] = 1;
+    let column_u33: Arc<dyn ColumnValues<u64>> =
+        serialize_and_load(&data_u33, CodecType::Bitpacked);
+
     let mut group: InputGroup<VecCol> = InputGroup::new_with_inputs(vec![
         (
             "access".to_string(),
@@ -63,6 +82,8 @@ fn bench_access() {
             "access_gcd".to_string(),
             (permutation_gcd.clone(), column_perm_gcd.clone()),
         ),
+        ("access_u8".to_string(), (data_u8, column_u8)),
+        ("access_u33".to_string(), (data_u33, column_u33)),
     ]);
 
     group.register("stride7_vec", |inp: &VecCol| {
@@ -97,6 +118,27 @@ fn bench_access() {
         for i in 0..n {
             a += inp.1.get_val(i as u32);
         }
+        black_box(a);
+    });
+
+    group.register("getrange_fullscan_column_values", |inp: &VecCol| {
+        let n = inp.1.num_vals() as usize;
+        let mut buf = vec![0u64; 4096];
+        let mut a = 0u64;
+        let mut start = 0usize;
+        while start < n {
+            let take = 4096.min(n - start);
+            inp.1.get_range(start as u64, &mut buf[..take]);
+            for &v in &buf[..take] {
+                a += v;
+            }
+            start += take;
+        }
+        black_box(a);
+    });
+
+    group.register("iter_fullscan_column_values", |inp: &VecCol| {
+        let a: u64 = inp.1.iter().sum();
         black_box(a);
     });
 

--- a/columnar/src/block_accessor.rs
+++ b/columnar/src/block_accessor.rs
@@ -34,6 +34,12 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
             if self.val_cache.len() != docs.len() {
                 self.val_cache.resize(docs.len(), T::default());
             }
+            // A direct `get_val` skips the `get_range` machinery, whose
+            // per-call setup outweighs one row.
+            if docs.len() == 1 {
+                self.val_cache[0] = accessor.values.get_val(docs[0]);
+                return;
+            }
             // When the docs form a contiguous ascending run we can fetch the values
             // as a single range. This lets codecs (e.g. bitpacked) bulk-decode the
             // slice instead of gathering value-by-value, and avoids per-value dynamic

--- a/columnar/src/column/serialize.rs
+++ b/columnar/src/column/serialize.rs
@@ -33,7 +33,11 @@ pub fn serialize_column_mappable_to_u64<T: MonotonicallyMappableToU64>(
     let column_index_num_bytes = serialize_column_index(column_index, output)?;
     serialize_u64_based_column_values(
         column_values,
-        &[CodecType::Bitpacked, CodecType::BlockwiseLinear],
+        &[
+            CodecType::Bitpacked,
+            CodecType::BlockwiseLinear,
+            // CodecType::BlockFor,
+        ],
         output,
     )?;
     output.write_all(&column_index_num_bytes.to_le_bytes())?;

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -27,7 +27,7 @@ mod monotonic_column;
 pub(crate) use merge::MergedColumnValues;
 pub use stats::ColumnStats;
 pub use u64_based::{
-    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values,
+    ALL_U64_CODEC_TYPES, CodecType, load_u64_based_column_values, load_u64_based_column_values_raw,
     serialize_and_load_u64_based_column_values, serialize_u64_based_column_values,
 };
 pub use u128_based::{
@@ -43,8 +43,11 @@ use crate::RowId;
 ///
 /// `Column` are just a wrapper over `ColumnValues` and a `ColumnIndex`.
 ///
-/// Any methods with a default and specialized implementation need to be called in the
-/// wrappers that implement the trait: Arc and MonotonicMappingColumn
+/// Any method with both a default and specialized implementations must be
+/// forwarded by every wrapper that implements the trait (`Arc<dyn
+/// ColumnValues>` below and `MonotonicMappingColumn`): a missing forward
+/// silently serves the default and only a benchmark notices.
+/// `tests::specializations_survive_arc` pins the set.
 pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     /// Return the value associated with the given idx.
     ///
@@ -126,6 +129,11 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
         }
     }
 
+    /// Always use batching
+    fn min_batch_rows(&self) -> usize {
+        usize::MAX
+    }
+
     /// Get the row ids of values which are in the provided value range.
     ///
     /// Note that position == docid for single value fast fields
@@ -204,6 +212,11 @@ impl<T: Copy + PartialOrd + Debug + 'static> ColumnValues<T> for Arc<dyn ColumnV
     }
 
     #[inline(always)]
+    fn get_vals(&self, indexes: &[u32], output: &mut [T]) {
+        self.as_ref().get_vals(indexes, output)
+    }
+
+    #[inline(always)]
     fn get_vals_opt(&self, indexes: &[u32], output: &mut [Option<T>]) {
         self.as_ref().get_vals_opt(indexes, output)
     }
@@ -234,6 +247,11 @@ impl<T: Copy + PartialOrd + Debug + 'static> ColumnValues<T> for Arc<dyn ColumnV
     }
 
     #[inline(always)]
+    fn min_batch_rows(&self) -> usize {
+        self.as_ref().min_batch_rows()
+    }
+
+    #[inline(always)]
     fn get_row_ids_for_value_range(
         &self,
         range: RangeInclusive<T>,
@@ -242,5 +260,91 @@ impl<T: Copy + PartialOrd + Debug + 'static> ColumnValues<T> for Arc<dyn ColumnV
     ) {
         self.as_ref()
             .get_row_ids_for_value_range(range, doc_id_range, positions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every specializable method must survive the `Arc` wrapper -- see the
+    /// note on `ColumnValues`.
+    #[test]
+    fn specializations_survive_arc() {
+        struct Specialized;
+        impl ColumnValues<u64> for Specialized {
+            fn get_val(&self, idx: u32) -> u64 {
+                u64::from(idx)
+            }
+            fn get_vals(&self, _indexes: &[u32], output: &mut [u64]) {
+                output.fill(11);
+            }
+            fn get_vals_opt(&self, _indexes: &[u32], output: &mut [Option<u64>]) {
+                output.fill(Some(22));
+            }
+            fn get_range(&self, _start: u64, output: &mut [u64]) {
+                output.fill(33);
+            }
+            fn min_batch_rows(&self) -> usize {
+                44
+            }
+            fn iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
+                Box::new(std::iter::once(55))
+            }
+            fn get_row_ids_for_value_range(
+                &self,
+                _value_range: RangeInclusive<u64>,
+                _row_id_range: Range<RowId>,
+                row_id_hits: &mut Vec<RowId>,
+            ) {
+                row_id_hits.push(66);
+            }
+            fn min_value(&self) -> u64 {
+                0
+            }
+            fn max_value(&self) -> u64 {
+                100
+            }
+            fn num_vals(&self) -> u32 {
+                10
+            }
+        }
+
+        let column: Arc<dyn ColumnValues<u64>> = Arc::new(Specialized);
+
+        let mut out = [0u64; 2];
+        column.get_vals(&[0, 1], &mut out);
+        assert_eq!(out, [11, 11], "get_vals is not forwarded");
+
+        let mut out_opt = [None; 2];
+        column.get_vals_opt(&[0, 1], &mut out_opt);
+        assert_eq!(
+            out_opt,
+            [Some(22), Some(22)],
+            "get_vals_opt is not forwarded"
+        );
+
+        let mut out = [0u64; 2];
+        column.get_range(0, &mut out);
+        assert_eq!(out, [33, 33], "get_range is not forwarded");
+
+        assert_eq!(
+            column.min_batch_rows(),
+            44,
+            "min_batch_rows is not forwarded"
+        );
+        assert_eq!(
+            column.iter().collect::<Vec<_>>(),
+            vec![55],
+            "iter is not forwarded"
+        );
+
+        let mut hits = Vec::new();
+        column.get_row_ids_for_value_range(0..=100, 0..10, &mut hits);
+        assert_eq!(
+            hits,
+            vec![66],
+            "get_row_ids_for_value_range is not forwarded"
+        );
     }
 }

--- a/columnar/src/column_values/mod.rs
+++ b/columnar/src/column_values/mod.rs
@@ -39,6 +39,38 @@ pub use vec_column::VecColumn;
 pub use self::monotonic_column::monotonic_map_column;
 use crate::RowId;
 
+/// Rows a [`ColumnValues::get_range`] call must cover before its batch decode
+/// beats a plain `get_val` loop over the same rows, one threshold per arm
+/// [`monotonic_map_column`] can take.
+///
+/// Batching is not free below its crossover: the batch arm pays a fixed
+/// per-call setup (bounds asserts, mask and ramp computation in two stacked
+/// `decode_range` layers) that a short take cannot amortize. The crossover is
+/// a property of the column -- it moves with the codec's `get_val` cost and
+/// with whether a SIMD block kernel is available -- so callers read it here
+/// instead of hardcoding a length.
+///
+/// `monotonic_column::tests::gate_sweep` re-derives both numbers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BatchThresholds {
+    /// The mapping wrapper decodes straight into the caller's buffer
+    /// (`Input == Output`, the identity wrapper every u64 column is loaded
+    /// with).
+    pub forwarding: usize,
+    /// The wrapper decodes into a scratch buffer and maps out of it
+    /// (`Input != Output`, e.g. an f64 column over u64 storage), paying a
+    /// buffer fill and a mapping pass per block on top.
+    pub buffered: usize,
+}
+
+impl BatchThresholds {
+    /// A column whose batch decode never beats a `get_val` loop.
+    pub const NEVER: Self = Self {
+        forwarding: usize::MAX,
+        buffered: usize::MAX,
+    };
+}
+
 /// `ColumnValues` provides access to a dense field column.
 ///
 /// `Column` are just a wrapper over `ColumnValues` and a `ColumnIndex`.
@@ -114,6 +146,7 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
     /// the segment's `maxdoc`.
     #[inline(always)]
     fn get_range(&self, start: u64, output: &mut [T]) {
+        // decode_range(64, start, self.data, output);
         let (out_chunks, out_rem) = output.as_chunks_mut::<4>();
         let mut idx = start;
         for out_x4 in out_chunks {
@@ -129,9 +162,10 @@ pub trait ColumnValues<T: PartialOrd = u64>: Send + Sync + DowncastSync {
         }
     }
 
-    /// Always use batching
-    fn min_batch_rows(&self) -> usize {
-        usize::MAX
+    /// See [`BatchThresholds`]. The default is
+    /// [`BatchThresholds::NEVER`]; columns that decode in batches override it.
+    fn batch_thresholds(&self) -> BatchThresholds {
+        BatchThresholds::NEVER
     }
 
     /// Get the row ids of values which are in the provided value range.
@@ -247,8 +281,8 @@ impl<T: Copy + PartialOrd + Debug + 'static> ColumnValues<T> for Arc<dyn ColumnV
     }
 
     #[inline(always)]
-    fn min_batch_rows(&self) -> usize {
-        self.as_ref().min_batch_rows()
+    fn batch_thresholds(&self) -> BatchThresholds {
+        self.as_ref().batch_thresholds()
     }
 
     #[inline(always)]
@@ -285,11 +319,14 @@ mod tests {
             fn get_range(&self, _start: u64, output: &mut [u64]) {
                 output.fill(33);
             }
-            fn min_batch_rows(&self) -> usize {
-                44
+            fn batch_thresholds(&self) -> BatchThresholds {
+                BatchThresholds {
+                    forwarding: 44,
+                    buffered: 55,
+                }
             }
             fn iter(&self) -> Box<dyn Iterator<Item = u64> + '_> {
-                Box::new(std::iter::once(55))
+                Box::new(std::iter::once(99))
             }
             fn get_row_ids_for_value_range(
                 &self,
@@ -328,14 +365,18 @@ mod tests {
         column.get_range(0, &mut out);
         assert_eq!(out, [33, 33], "get_range is not forwarded");
 
+        // Both fields, so a wrapper that forwards only one is caught too.
         assert_eq!(
-            column.min_batch_rows(),
-            44,
-            "min_batch_rows is not forwarded"
+            column.batch_thresholds(),
+            BatchThresholds {
+                forwarding: 44,
+                buffered: 55,
+            },
+            "batch_thresholds is not forwarded"
         );
         assert_eq!(
             column.iter().collect::<Vec<_>>(),
-            vec![55],
+            vec![99],
             "iter is not forwarded"
         );
 

--- a/columnar/src/column_values/monotonic_column.rs
+++ b/columnar/src/column_values/monotonic_column.rs
@@ -5,9 +5,26 @@ use std::ops::{Range, RangeInclusive};
 use crate::ColumnValues;
 use crate::column_values::monotonic_mapping::StrictlyMonotonicFn;
 
+/// The buffered path's crossover, given the codec's own: the extra buffer
+/// fill and mapping pass move it ~4/3 further out. Saturating, so a column
+/// that never batches (`usize::MAX`) still never batches here.
+#[inline]
+fn buffered_min_rows(codec_min_rows: usize) -> usize {
+    codec_min_rows.saturating_mul(4).div_ceil(3)
+}
+
+#[inline(always)]
+fn is_same_type<A: 'static, B: 'static>() -> bool {
+    std::any::TypeId::of::<A>() == std::any::TypeId::of::<B>()
+}
+
 struct MonotonicMappingColumn<C, T, Input> {
     from_column: C,
     monotonic_mapping: T,
+    /// Resolved once at construction: `get_range` consults it on every call,
+    /// and the live chain (a possibly virtual call into the codec plus an
+    /// atomic load) costs about as much as a one-row take.
+    min_batch_rows: usize,
     _phantom: PhantomData<Input>,
 }
 
@@ -36,10 +53,88 @@ where
     Input: PartialOrd + Debug + Send + Sync + Clone + 'static,
     Output: PartialOrd + Debug + Send + Sync + Clone + 'static,
 {
+    let codec_min_rows = from_column.min_batch_rows();
+    let min_batch_rows = if is_same_type::<Input, Output>() {
+        codec_min_rows
+    } else {
+        buffered_min_rows(codec_min_rows)
+    };
     MonotonicMappingColumn {
         from_column,
         monotonic_mapping,
+        min_batch_rows,
         _phantom: PhantomData,
+    }
+}
+
+/// Short takes: monomorphized, so this inlines straight into the codec and
+/// beats both batch paths below their crossover.
+#[inline(always)]
+fn map_per_value<C, T, Input, Output>(col: &C, mapping: &T, start: u64, output: &mut [Output])
+where
+    C: ColumnValues<Input>,
+    T: StrictlyMonotonicFn<Input, Output>,
+    Input: PartialOrd,
+    Output: PartialOrd,
+{
+    for (i, out) in output.iter_mut().enumerate() {
+        *out = mapping.mapping(col.get_val(start as u32 + i as u32));
+    }
+}
+
+/// `Input == Output` -- the identity wrapper every u64 column is loaded with.
+/// Decodes straight into the caller's buffer and applies the mapping in place,
+/// which for an identity mapping compiles the fix-up loop away.
+///
+/// Callers must have checked `is_same_type::<Input, Output>()`.
+#[inline(always)]
+fn forward_in_place<C, T, Input, Output>(col: &C, mapping: &T, start: u64, output: &mut [Output])
+where
+    C: ColumnValues<Input>,
+    T: StrictlyMonotonicFn<Input, Output>,
+    Input: PartialOrd + Clone + 'static,
+    Output: PartialOrd + 'static,
+{
+    debug_assert!(is_same_type::<Input, Output>());
+    // Safety (both casts): `TypeId` equality of two `'static` types proves
+    // `Input` and `Output` are the same type -- the same basis `Any::downcast`
+    // rests on. Values are duplicated with `Clone`, not bit-copied, so a
+    // mapping that panics leaves the slice holding its original, still-valid
+    // values.
+    let output_as_input: &mut [Input] = unsafe { &mut *(output as *mut [Output] as *mut [Input]) };
+    col.get_range(start, output_as_input);
+    for val in output.iter_mut() {
+        let raw: Input = unsafe { &*(val as *const Output as *const Input) }.clone();
+        *val = mapping.mapping(raw);
+    }
+}
+
+/// `Input != Output`, e.g. an f64 column over u64 storage: decode into a
+/// temporary `Input` buffer, then map into the output.
+#[inline(always)]
+fn map_via_buffer<C, T, Input, Output>(col: &C, mapping: &T, start: u64, output: &mut [Output])
+where
+    C: ColumnValues<Input>,
+    T: StrictlyMonotonicFn<Input, Output>,
+    Input: PartialOrd + Clone,
+    Output: PartialOrd,
+{
+    // One codec block, aligned on CHUNK boundaries in column space, so every
+    // take the underlying codec sees is a whole block. Block-sized so the
+    // buffer fits on the stack instead of allocating per call.
+    const CHUNK: usize = 128;
+    let init: Input = col.get_val(start as u32);
+    let mut buffer: [Input; CHUNK] = std::array::from_fn(|_| init.clone());
+    let mut offset = 0usize;
+    while offset < output.len() {
+        let pos = start + offset as u64;
+        let len = (CHUNK - (pos as usize % CHUNK)).min(output.len() - offset);
+        let buf = &mut buffer[..len];
+        col.get_range(pos, buf);
+        for (out, inp) in output[offset..offset + len].iter_mut().zip(buf.iter()) {
+            *out = mapping.mapping(inp.clone());
+        }
+        offset += len;
     }
 }
 
@@ -92,12 +187,32 @@ where
         )
     }
 
-    // We voluntarily do not implement get_range as it yields a regression,
-    // and we do not have any specialized implementation anyway.
+    #[inline(always)]
+    fn min_batch_rows(&self) -> usize {
+        self.min_batch_rows
+    }
+
+    /// Three ways to fill `output`, cheapest applicable one first. The
+    /// threshold comes from the column rather than a constant here because it
+    /// moves with the codec's `get_val` cost and with whether a SIMD block
+    /// kernel is available. A column that does not decode in batches reports
+    /// `usize::MAX` and only ever takes the first.
+    fn get_range(&self, start: u64, output: &mut [Output]) {
+        let (col, mapping) = (&self.from_column, &self.monotonic_mapping);
+        if output.len() < self.min_batch_rows() {
+            map_per_value(col, mapping, start, output);
+        } else if is_same_type::<Input, Output>() {
+            forward_in_place(col, mapping, start, output);
+        } else {
+            map_via_buffer(col, mapping, start, output);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::column_values::VecColumn;
     use crate::column_values::monotonic_mapping::{
@@ -116,5 +231,358 @@ mod tests {
         for i in 0..100 {
             assert_eq!(val_i64s[i as usize], mapped.get_val(i));
         }
+    }
+
+    /// `get_range` on the buffered general path (`Input=u64 != Output=f64`)
+    /// must agree with `get_val` for every (start, len) phase.
+    #[test]
+    fn test_get_range_buffered_path_matches_get_val() {
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+
+        let vals: Vec<f64> = (0..1_000u64).map(|i| (i as f64) / 100.0).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buffer)
+            .unwrap();
+        let column = load_u64_based_column_values::<f64>(common::OwnedBytes::new(buffer)).unwrap();
+
+        for len in [1usize, 63, 64, 65, 127, 128, 129, 200, 256, 512, 600] {
+            for start in (0..300usize).chain([1_000 - len]) {
+                if start + len > vals.len() {
+                    continue;
+                }
+                let mut output = vec![0f64; len];
+                column.get_range(start as u64, &mut output);
+                let expected: Vec<f64> = (0..len)
+                    .map(|i| column.get_val((start + i) as u32))
+                    .collect();
+                assert_eq!(output, expected, "start={start} len={len}");
+                assert_eq!(output, vals[start..start + len], "start={start} len={len}");
+            }
+        }
+    }
+
+    /// Every wrapper in the chain has to forward `min_batch_rows` or the
+    /// value silently reverts to `usize::MAX` and `get_range` never batches.
+    #[test]
+    fn test_min_batch_rows_survives_wrappers() {
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+
+        let vals: Vec<u64> = (0..1_000u64).map(|i| i * 7 + 3).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buffer)
+            .unwrap();
+        let column: Arc<dyn ColumnValues<u64>> =
+            load_u64_based_column_values(common::OwnedBytes::new(buffer)).unwrap();
+
+        let batched = column.min_batch_rows();
+        assert!(
+            batched < usize::MAX,
+            "Bitpacked reports a batch threshold, but it did not survive the wrappers"
+        );
+
+        // `VecColumn` reports 1, so this also pins that the buffered path's
+        // scaling never rounds a real threshold down to zero.
+        let buffered: Box<dyn ColumnValues<i64>> = Box::new(monotonic_map_column(
+            VecColumn::from(vals.clone()),
+            StrictlyMonotonicMappingInverter::from(StrictlyMonotonicMappingToInternal::<i64>::new()),
+        ));
+        assert_eq!(VecColumn::from(vals).min_batch_rows(), 1);
+        assert_eq!(buffered.min_batch_rows(), 2);
+
+        // A column that does not batch must not have one invented for it:
+        // `usize::MAX` has to survive the buffered path's multiplication.
+        struct NoBatch;
+        impl ColumnValues<u64> for NoBatch {
+            fn get_val(&self, idx: u32) -> u64 {
+                idx as u64
+            }
+            fn min_value(&self) -> u64 {
+                0
+            }
+            fn max_value(&self) -> u64 {
+                1_000
+            }
+            fn num_vals(&self) -> u32 {
+                1_000
+            }
+        }
+        assert_eq!(NoBatch.min_batch_rows(), usize::MAX);
+        let over_no_batch: Box<dyn ColumnValues<i64>> = Box::new(monotonic_map_column(
+            NoBatch,
+            StrictlyMonotonicMappingInverter::from(StrictlyMonotonicMappingToInternal::<i64>::new()),
+        ));
+        assert!(
+            over_no_batch.min_batch_rows() >= 1_000,
+            "a non-batching column must not get a usable threshold from the wrapper"
+        );
+    }
+
+    /// The same, on the identity fast path (`Input == Output`), which forwards
+    /// straight to the codec instead of buffering.
+    #[test]
+    fn test_get_range_identity_path_matches_get_val() {
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+
+        let vals: Vec<u64> = (0..1_000u64).map(|i| i * 7 + 3).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buffer)
+            .unwrap();
+        let column = load_u64_based_column_values::<u64>(common::OwnedBytes::new(buffer)).unwrap();
+
+        for len in [1usize, 64, 128, 129, 512] {
+            for start in (0..300usize).chain([1_000 - len]) {
+                if start + len > vals.len() {
+                    continue;
+                }
+                let mut output = vec![0u64; len];
+                column.get_range(start as u64, &mut output);
+                assert_eq!(output, vals[start..start + len], "start={start} len={len}");
+            }
+        }
+    }
+
+    /// Calibration harness for `min_batch_rows`: A/Bs the batch and per-value
+    /// arms of `get_range` over a (start phase x length) grid per codec, and
+    /// scores what the shipped gate decides at each cell.
+    ///
+    /// ```text
+    /// cargo test --release -p tantivy-columnar --lib gate_sweep \
+    ///     -- --ignored --nocapture
+    /// TANTIVY_BITPACKER_SCALAR=1 cargo test --release ...   # scalar kernel
+    /// ```
+    ///
+    /// It lives here rather than in `benches/` because it drives the arms the
+    /// gate rejects, and those are private to this module. Run both arms over
+    /// the concrete codec reader (through `Arc<dyn ColumnValues>` the
+    /// per-value arm pays a virtual call per row that production never pays),
+    /// and sweep both `simd_enabled()` states.
+    #[test]
+    #[ignore]
+    fn gate_sweep() {
+        use std::time::Instant;
+
+        use crate::column_values::monotonic_mapping::{
+            StrictlyMonotonicMappingInverter, StrictlyMonotonicMappingToInternal,
+        };
+        use crate::column_values::u64_based::{
+            BitpackedCodec, BlockwiseLinearCodec, ColumnCodec, LinearCodec,
+        };
+        use crate::column_values::{CodecType, serialize_u64_based_column_values};
+
+        const N: usize = 1 << 16;
+        const SWEEP_BLOCK: usize = 128;
+
+        fn header(label: &str, threshold: usize) {
+            println!("\n=== {label} (min_batch_rows={threshold}) ===");
+            println!(
+                "{:>5} {:>6} {:>7} {:>9} {:>9} {:>7}  verdict",
+                "len", "phase", "maxblk", "batch_ns", "loop_ns", "ratio"
+            );
+        }
+
+        /// `max_block_take`: rows the take gets from whichever block it takes
+        /// the most from -- the rejected alignment term, kept here only to
+        /// score it against the shipped flat gate.
+        fn maxblk(phase: usize, len: usize) -> usize {
+            let first = (SWEEP_BLOCK - phase % SWEEP_BLOCK).min(len);
+            if first == len {
+                return len;
+            }
+            first.max((len - first).min(SWEEP_BLOCK))
+        }
+
+        fn verdict(threshold: usize, phase: usize, len: usize, ratio: f64) -> String {
+            let score = |batches: bool| {
+                if batches && ratio < 0.95 {
+                    "LOSS"
+                } else if !batches && ratio > 1.05 {
+                    "misses"
+                } else {
+                    "ok"
+                }
+            };
+            format!(
+                "old={:<6} new={}",
+                score(len >= threshold),
+                score(maxblk(phase, len) >= threshold)
+            )
+        }
+
+        // `Input == Output`: the forwarding path.
+        fn sweep<C: ColumnCodec<u64>>(label: &str, bytes: Vec<u8>) {
+            let col = C::load(common::OwnedBytes::new(bytes)).unwrap();
+            let mapping = StrictlyMonotonicMappingToInternal::<u64>::new();
+            let threshold = col.min_batch_rows();
+            header(&format!("{label} forwarding"), threshold);
+            for len in [16usize, 32, 64, 96, 128, 192, 256, 512, 1024, 4096, 16384] {
+                for phase in [0usize, 16, 32, 64, 96, 100, 112, 127] {
+                    let mut out = vec![0u64; len];
+                    let reps = (1 << 21) / len;
+                    let starts: Vec<u64> = (0..64)
+                        .map(|k| (phase + k * 512 * SWEEP_BLOCK) as u64)
+                        .filter(|s| *s as usize + len <= N)
+                        .collect();
+                    for _ in 0..64 {
+                        forward_in_place(&col, &mapping, starts[0], &mut out);
+                        map_per_value(&col, &mapping, starts[0], &mut out);
+                    }
+                    let mut sink = 0u64;
+                    let t0 = Instant::now();
+                    for i in 0..reps {
+                        forward_in_place(&col, &mapping, starts[i % starts.len()], &mut out);
+                        sink = sink.wrapping_add(out[len - 1]);
+                    }
+                    let batch_ns = t0.elapsed().as_nanos() as f64 / (reps * len) as f64;
+                    let t1 = Instant::now();
+                    for i in 0..reps {
+                        map_per_value(&col, &mapping, starts[i % starts.len()], &mut out);
+                        sink = sink.wrapping_add(out[len - 1]);
+                    }
+                    let loop_ns = t1.elapsed().as_nanos() as f64 / (reps * len) as f64;
+                    std::hint::black_box(sink);
+                    let ratio = loop_ns / batch_ns;
+                    println!(
+                        "{len:>5} {phase:>6} {:>7} {batch_ns:>9.3} {loop_ns:>9.3} {ratio:>7.2}  {}",
+                        maxblk(phase, len),
+                        verdict(threshold, phase, len, ratio)
+                    );
+                }
+            }
+        }
+
+        // `Input != Output`: the buffered path.
+        fn sweep_buffered<C: ColumnCodec<u64>>(label: &str, bytes: Vec<u8>) {
+            let col = C::load(common::OwnedBytes::new(bytes)).unwrap();
+            let mapping = StrictlyMonotonicMappingInverter::from(
+                StrictlyMonotonicMappingToInternal::<f64>::new(),
+            );
+            let threshold = buffered_min_rows(col.min_batch_rows());
+            header(&format!("{label} buffered"), threshold);
+            for len in [16usize, 32, 64, 96, 128, 192, 256, 512, 768] {
+                for phase in [0usize, 32, 64, 100, 127] {
+                    let mut out = vec![0f64; len];
+                    let reps = (1 << 21) / len;
+                    let starts: Vec<u64> = (0..64)
+                        .map(|k| (phase + k * 512 * SWEEP_BLOCK) as u64)
+                        .filter(|s| *s as usize + len <= N)
+                        .collect();
+                    for _ in 0..64 {
+                        map_via_buffer(&col, &mapping, starts[0], &mut out);
+                        map_per_value(&col, &mapping, starts[0], &mut out);
+                    }
+                    let mut sink = 0f64;
+                    let t0 = Instant::now();
+                    for i in 0..reps {
+                        map_via_buffer(&col, &mapping, starts[i % starts.len()], &mut out);
+                        sink += out[len - 1];
+                    }
+                    let batch_ns = t0.elapsed().as_nanos() as f64 / (reps * len) as f64;
+                    let t1 = Instant::now();
+                    for i in 0..reps {
+                        map_per_value(&col, &mapping, starts[i % starts.len()], &mut out);
+                        sink += out[len - 1];
+                    }
+                    let loop_ns = t1.elapsed().as_nanos() as f64 / (reps * len) as f64;
+                    std::hint::black_box(sink);
+                    let ratio = loop_ns / batch_ns;
+                    println!(
+                        "{len:>5} {phase:>6} {:>7} {batch_ns:>9.3} {loop_ns:>9.3} {ratio:>7.2}  {}",
+                        maxblk(phase, len),
+                        verdict(threshold, phase, len, ratio)
+                    );
+                }
+            }
+        }
+
+        println!(
+            "SIMD block kernel: {}",
+            if std::env::var_os("TANTIVY_BITPACKER_SCALAR").is_some() {
+                "disabled (TANTIVY_BITPACKER_SCALAR set)"
+            } else {
+                "enabled"
+            }
+        );
+
+        let ints: Vec<u64> = (0..N as u64)
+            .map(|i| (i.wrapping_mul(2_654_435_761)) % 100_000)
+            .collect();
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ints[..], &[CodecType::Bitpacked], &mut buf).unwrap();
+        sweep::<BitpackedCodec>("Bitpacked", buf[1..].to_vec());
+
+        // A noisy ramp, which is what the two line codecs are chosen for.
+        let ramp: Vec<u64> = (0..N as u64)
+            .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % (1 << 20)))
+            .collect();
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ramp[..], &[CodecType::Linear], &mut buf).unwrap();
+        sweep::<LinearCodec>("Linear", buf[1..].to_vec());
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ramp[..], &[CodecType::BlockwiseLinear], &mut buf)
+            .unwrap();
+        sweep::<BlockwiseLinearCodec>("BlockwiseLinear", buf[1..].to_vec());
+
+        // Residual width drives which unpack kernel runs: the narrow (u32
+        // lane) one covers 1..=25 and the wide (u64 lane) one 26..=56, at
+        // 3.10-3.29x and 2.83-2.96x over scalar. Sweep across that boundary.
+        // Same question for a second Flat codec: is the crossover a property
+        // of the unpack kernel rather than of the codec?
+        for bits in [10u32, 16, 22, 24, 26, 30, 40] {
+            let vals: Vec<u64> = (0..N as u64)
+                .map(|i| i.wrapping_mul(2_654_435_761) % (1u64 << bits))
+                .collect();
+            let mut buf = Vec::new();
+            serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buf)
+                .unwrap();
+            let packed = (buf.len() as f64 * 8.0) / N as f64;
+            println!("\n[Bitpacked-w{bits}] ~{packed:.1} packed bits/value");
+            sweep::<BitpackedCodec>(&format!("Bitpacked-w{bits}"), buf[1..].to_vec());
+        }
+
+        for (label, bits) in [
+            ("Linear-w4", 4u32),
+            ("Linear-w8", 8),
+            ("Linear-w12", 12),
+            ("Linear-w14", 14),
+            ("Linear-w16", 16),
+            ("Linear-w20", 20),
+            ("Linear-w25", 25),
+            ("Linear-w32", 32),
+            ("Linear-w40", 40),
+        ] {
+            let vals: Vec<u64> = (0..N as u64)
+                .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % (1u64 << bits)))
+                .collect();
+            let mut buf = Vec::new();
+            serialize_u64_based_column_values(&&vals[..], &[CodecType::Linear], &mut buf).unwrap();
+            // What actually got packed, rather than what the generator asked
+            // for: the bitpacked residual is the deviation from the trained
+            // line, not the noise term.
+            let packed_bits = (buf.len() as f64 * 8.0) / N as f64;
+            println!("\n[{label}] generator bits={bits} -> ~{packed_bits:.1} packed bits/value");
+            sweep::<LinearCodec>(label, buf[1..].to_vec());
+
+            // Same width, the other line codec: does its per-block hoisting
+            // carry it past the scalar cutoff the way Bitpacked's does?
+            let mut buf = Vec::new();
+            serialize_u64_based_column_values(&&vals[..], &[CodecType::BlockwiseLinear], &mut buf)
+                .unwrap();
+            let packed_bits = (buf.len() as f64 * 8.0) / N as f64;
+            let bwl_label = label.replace("Linear", "BWL");
+            println!("\n[{bwl_label}] generator bits={bits} -> ~{packed_bits:.1} packed bits/value");
+            sweep::<BlockwiseLinearCodec>(&bwl_label, buf[1..].to_vec());
+        }
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ints[..], &[CodecType::Bitpacked], &mut buf).unwrap();
+        sweep_buffered::<BitpackedCodec>("Bitpacked", buf[1..].to_vec());
     }
 }

--- a/columnar/src/column_values/monotonic_column.rs
+++ b/columnar/src/column_values/monotonic_column.rs
@@ -3,15 +3,8 @@ use std::marker::PhantomData;
 use std::ops::{Range, RangeInclusive};
 
 use crate::ColumnValues;
+use crate::column_values::BatchThresholds;
 use crate::column_values::monotonic_mapping::StrictlyMonotonicFn;
-
-/// The buffered path's crossover, given the codec's own: the extra buffer
-/// fill and mapping pass move it ~4/3 further out. Saturating, so a column
-/// that never batches (`usize::MAX`) still never batches here.
-#[inline]
-fn buffered_min_rows(codec_min_rows: usize) -> usize {
-    codec_min_rows.saturating_mul(4).div_ceil(3)
-}
 
 #[inline(always)]
 fn is_same_type<A: 'static, B: 'static>() -> bool {
@@ -23,7 +16,8 @@ struct MonotonicMappingColumn<C, T, Input> {
     monotonic_mapping: T,
     /// Resolved once at construction: `get_range` consults it on every call,
     /// and the live chain (a possibly virtual call into the codec plus an
-    /// atomic load) costs about as much as a one-row take.
+    /// atomic load) costs about as much as a one-row take. Already narrowed
+    /// to the arm this wrapper takes.
     min_batch_rows: usize,
     _phantom: PhantomData<Input>,
 }
@@ -53,11 +47,11 @@ where
     Input: PartialOrd + Debug + Send + Sync + Clone + 'static,
     Output: PartialOrd + Debug + Send + Sync + Clone + 'static,
 {
-    let codec_min_rows = from_column.min_batch_rows();
+    let thresholds = from_column.batch_thresholds();
     let min_batch_rows = if is_same_type::<Input, Output>() {
-        codec_min_rows
+        thresholds.forwarding
     } else {
-        buffered_min_rows(codec_min_rows)
+        thresholds.buffered
     };
     MonotonicMappingColumn {
         from_column,
@@ -188,18 +182,22 @@ where
     }
 
     #[inline(always)]
-    fn min_batch_rows(&self) -> usize {
-        self.min_batch_rows
+    fn batch_thresholds(&self) -> BatchThresholds {
+        // Already narrowed to this wrapper's arm, so both are the same
+        // number: a wrapper over this wrapper takes whichever it likes.
+        BatchThresholds {
+            forwarding: self.min_batch_rows,
+            buffered: self.min_batch_rows,
+        }
     }
 
     /// Three ways to fill `output`, cheapest applicable one first. The
-    /// threshold comes from the column rather than a constant here because it
-    /// moves with the codec's `get_val` cost and with whether a SIMD block
-    /// kernel is available. A column that does not decode in batches reports
+    /// threshold comes from the column rather than a constant here -- see
+    /// [`BatchThresholds`]. A column that does not decode in batches reports
     /// `usize::MAX` and only ever takes the first.
     fn get_range(&self, start: u64, output: &mut [Output]) {
         let (col, mapping) = (&self.from_column, &self.monotonic_mapping);
-        if output.len() < self.min_batch_rows() {
+        if output.len() < self.min_batch_rows {
             map_per_value(col, mapping, start, output);
         } else if is_same_type::<Input, Output>() {
             forward_in_place(col, mapping, start, output);
@@ -263,10 +261,10 @@ mod tests {
         }
     }
 
-    /// Every wrapper in the chain has to forward `min_batch_rows` or the
+    /// Every wrapper in the chain has to forward `batch_thresholds` or the
     /// value silently reverts to `usize::MAX` and `get_range` never batches.
     #[test]
-    fn test_min_batch_rows_survives_wrappers() {
+    fn test_batch_thresholds_survive_wrappers() {
         use crate::column_values::{
             CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
         };
@@ -278,23 +276,25 @@ mod tests {
         let column: Arc<dyn ColumnValues<u64>> =
             load_u64_based_column_values(common::OwnedBytes::new(buffer)).unwrap();
 
-        let batched = column.min_batch_rows();
+        let batched = column.batch_thresholds();
         assert!(
-            batched < usize::MAX,
+            batched.forwarding < usize::MAX,
             "Bitpacked reports a batch threshold, but it did not survive the wrappers"
         );
 
-        // `VecColumn` reports 1, so this also pins that the buffered path's
-        // scaling never rounds a real threshold down to zero.
+        // The wrapper narrows to the arm it takes: `Input != Output` here, so
+        // both fields report `VecColumn`'s buffered threshold, not its
+        // forwarding one.
         let buffered: Box<dyn ColumnValues<i64>> = Box::new(monotonic_map_column(
             VecColumn::from(vals.clone()),
             StrictlyMonotonicMappingInverter::from(StrictlyMonotonicMappingToInternal::<i64>::new()),
         ));
-        assert_eq!(VecColumn::from(vals).min_batch_rows(), 1);
-        assert_eq!(buffered.min_batch_rows(), 2);
+        let vec_thresholds = VecColumn::from(vals).batch_thresholds();
+        assert_eq!(vec_thresholds.forwarding, 1);
+        assert_eq!(vec_thresholds.buffered, 2);
+        assert_eq!(buffered.batch_thresholds().buffered, 2);
 
-        // A column that does not batch must not have one invented for it:
-        // `usize::MAX` has to survive the buffered path's multiplication.
+        // A column that does not batch must not have one invented for it.
         struct NoBatch;
         impl ColumnValues<u64> for NoBatch {
             fn get_val(&self, idx: u32) -> u64 {
@@ -310,13 +310,13 @@ mod tests {
                 1_000
             }
         }
-        assert_eq!(NoBatch.min_batch_rows(), usize::MAX);
+        assert_eq!(NoBatch.batch_thresholds(), BatchThresholds::NEVER);
         let over_no_batch: Box<dyn ColumnValues<i64>> = Box::new(monotonic_map_column(
             NoBatch,
             StrictlyMonotonicMappingInverter::from(StrictlyMonotonicMappingToInternal::<i64>::new()),
         ));
         assert!(
-            over_no_batch.min_batch_rows() >= 1_000,
+            over_no_batch.batch_thresholds().buffered >= 1_000,
             "a non-batching column must not get a usable threshold from the wrapper"
         );
     }
@@ -347,9 +347,39 @@ mod tests {
         }
     }
 
-    /// Calibration harness for `min_batch_rows`: A/Bs the batch and per-value
-    /// arms of `get_range` over a (start phase x length) grid per codec, and
-    /// scores what the shipped gate decides at each cell.
+    /// Calibration harness for [`BatchThresholds`]: A/Bs the batch and
+    /// per-value arms of `get_range` over a (start phase x length) grid per
+    /// codec, and scores what the shipped gate decides at each cell.
+    ///
+    /// The grid starts at len 1 because that is where the gate earns its
+    /// keep. `tantivy_bitpacker::block_decode::decode_range` falling back to
+    /// per-value extraction removed the old *cliff* (a one-row take no longer
+    /// decodes a whole 128-slot block) but not the fixed per-call setup, so
+    /// the batch arm still loses badly on short takes and the gate cannot be
+    /// dropped. Measured on an M4 (loop_ns/batch_ns, median over phases,
+    /// SIMD kernels enabled):
+    ///
+    /// ```text
+    /// len                         1     2     4     8    16    32    64   128
+    /// Alp forwarding           0.51  0.91  1.38  1.99  3.01  4.22  5.06  5.83
+    /// BlockFor forwarding      0.36  0.44  0.98  1.83  2.67  3.60  5.36  6.61
+    /// BWL forwarding           0.37  0.54  0.81  0.94  1.13  1.61  1.92  2.27
+    /// Bitpacked forwarding     0.18  0.40  0.61  0.71  0.95  1.27  1.88  2.39
+    /// Linear forwarding        0.24  0.39  0.64  0.55  0.79  0.96  1.12  1.29
+    /// Alp buffered             0.14  0.26  0.39  0.76  1.23  2.05  2.95  3.65
+    /// BlockFor buffered        0.12  0.18  0.32  0.64  1.01  1.76  2.80  3.43
+    /// BWL buffered             0.15  0.17  0.27  0.36  0.68  1.03  1.32  1.54
+    /// Bitpacked buffered       0.08  0.10  0.18  0.33  0.43  0.76  1.16  1.51
+    /// Linear buffered          0.08  0.12  0.15  0.27  0.41  0.63  0.82  0.98
+    /// ```
+    ///
+    /// Two things that table settles. The crossovers span ~3 (`Alp`) to never
+    /// (`Linear` on scalar), so one flat threshold cannot replace the
+    /// families. And the buffered arm's crossover is 2-4x the forwarding
+    /// one, not the 4/3 an earlier revision derived it as -- the buffer fill
+    /// and mapping pass are a flat per-value cost, so how far they move the
+    /// crossover depends on how expensive that codec's `get_val` is. Both
+    /// numbers are measured per family instead.
     ///
     /// ```text
     /// cargo test --release -p tantivy-columnar --lib gate_sweep \
@@ -370,16 +400,42 @@ mod tests {
         use crate::column_values::monotonic_mapping::{
             StrictlyMonotonicMappingInverter, StrictlyMonotonicMappingToInternal,
         };
+        use crate::MonotonicallyMappableToU64;
         use crate::column_values::u64_based::{
-            BitpackedCodec, BlockForCodec, BlockwiseLinearCodec, ColumnCodec, LinearCodec,
+            AlpCodec, BitpackedCodec, BlockForCodec, BlockwiseLinearCodec, ColumnCodec,
+            ColumnCodecEstimator, LinearCodec, StatsCollector,
         };
         use crate::column_values::{CodecType, serialize_u64_based_column_values};
+
+        /// Serializes through the codec's own estimator, skipping the
+        /// `CodecType` selection path -- `Alp` is deliberately not wired into
+        /// that enum, so this is the only way to reach it. Returns the codec
+        /// payload with no leading `CodecType` byte, matching what the
+        /// `buf[1..]` slicing below produces for the other codecs.
+        fn serialize_via_estimator<C: ColumnCodec<u64>>(vals: &[u64]) -> Vec<u8> {
+            let mut stats_collector = StatsCollector::default();
+            let mut estimator = C::estimator();
+            for &val in vals {
+                stats_collector.collect(val);
+                estimator.collect(val);
+            }
+            estimator.finalize();
+            let stats = stats_collector.stats();
+            estimator
+                .estimate(&stats)
+                .expect("codec rejected the sweep data");
+            let mut buffer = Vec::new();
+            estimator
+                .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+                .unwrap();
+            buffer
+        }
 
         const N: usize = 1 << 16;
         const SWEEP_BLOCK: usize = 128;
 
         fn header(label: &str, threshold: usize) {
-            println!("\n=== {label} (min_batch_rows={threshold}) ===");
+            println!("\n=== {label} (threshold={threshold}) ===");
             println!(
                 "{:>5} {:>6} {:>7} {:>9} {:>9} {:>7}  verdict",
                 "len", "phase", "maxblk", "batch_ns", "loop_ns", "ratio"
@@ -418,10 +474,10 @@ mod tests {
         fn sweep<C: ColumnCodec<u64>>(label: &str, bytes: Vec<u8>) {
             let col = C::load(common::OwnedBytes::new(bytes)).unwrap();
             let mapping = StrictlyMonotonicMappingToInternal::<u64>::new();
-            let threshold = col.min_batch_rows();
+            let threshold = col.batch_thresholds().forwarding;
             header(&format!("{label} forwarding"), threshold);
-            for len in [16usize, 32, 64, 96, 128, 192, 256, 512, 1024, 4096, 16384] {
-                for phase in [0usize, 16, 32, 64, 96, 100, 112, 127] {
+            for len in [1usize, 2, 4, 8, 16, 32, 64, 96, 128, 192, 256, 512, 1024, 4096, 16384] {
+                for phase in [0usize, 1, 7, 16, 32, 64, 96, 100, 112, 127] {
                     let mut out = vec![0u64; len];
                     let reps = (1 << 21) / len;
                     let starts: Vec<u64> = (0..64)
@@ -462,10 +518,10 @@ mod tests {
             let mapping = StrictlyMonotonicMappingInverter::from(
                 StrictlyMonotonicMappingToInternal::<f64>::new(),
             );
-            let threshold = buffered_min_rows(col.min_batch_rows());
+            let threshold = col.batch_thresholds().buffered;
             header(&format!("{label} buffered"), threshold);
-            for len in [16usize, 32, 64, 96, 128, 192, 256, 512, 768] {
-                for phase in [0usize, 32, 64, 100, 127] {
+            for len in [1usize, 2, 4, 8, 16, 32, 64, 96, 128, 192, 256, 512, 768] {
+                for phase in [0usize, 1, 7, 32, 64, 100, 127] {
                     let mut out = vec![0f64; len];
                     let reps = (1 << 21) / len;
                     let starts: Vec<u64> = (0..64)
@@ -519,6 +575,14 @@ mod tests {
         let mut buf = Vec::new();
         serialize_u64_based_column_values(&&ints[..], &[CodecType::BlockFor], &mut buf).unwrap();
         sweep::<BlockForCodec>("BlockFor", buf[1..].to_vec());
+
+        // Pseudo-decimals, the only shape `Alp` accepts. It shares the
+        // `Blocked` family with `BlockFor` and `BlockwiseLinear`, so its
+        // crossover has to sit in the same place theirs does.
+        let decimals: Vec<u64> = (0..N as u64)
+            .map(|i| (((i.wrapping_mul(7919) % 1_000_000) as f64) / 100.0).to_u64())
+            .collect();
+        sweep::<AlpCodec>("Alp", serialize_via_estimator::<AlpCodec>(&decimals));
 
         // A noisy ramp, which is what the two line codecs are chosen for.
         let ramp: Vec<u64> = (0..N as u64)
@@ -585,6 +649,10 @@ mod tests {
             sweep::<BlockwiseLinearCodec>(&bwl_label, buf[1..].to_vec());
         }
 
+        // The buffered arm for every codec, not just two: its crossover is
+        // not the codec's own scaled by a constant -- the buffer fill and
+        // mapping pass are a flat per-value cost, so the gap between the two
+        // arms is set by how expensive that codec's `get_val` is.
         let mut buf = Vec::new();
         serialize_u64_based_column_values(&&ints[..], &[CodecType::Bitpacked], &mut buf).unwrap();
         sweep_buffered::<BitpackedCodec>("Bitpacked", buf[1..].to_vec());
@@ -592,5 +660,16 @@ mod tests {
         let mut buf = Vec::new();
         serialize_u64_based_column_values(&&ints[..], &[CodecType::BlockFor], &mut buf).unwrap();
         sweep_buffered::<BlockForCodec>("BlockFor", buf[1..].to_vec());
+
+        sweep_buffered::<AlpCodec>("Alp", serialize_via_estimator::<AlpCodec>(&decimals));
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ramp[..], &[CodecType::Linear], &mut buf).unwrap();
+        sweep_buffered::<LinearCodec>("Linear", buf[1..].to_vec());
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ramp[..], &[CodecType::BlockwiseLinear], &mut buf)
+            .unwrap();
+        sweep_buffered::<BlockwiseLinearCodec>("BlockwiseLinear", buf[1..].to_vec());
     }
 }

--- a/columnar/src/column_values/monotonic_column.rs
+++ b/columnar/src/column_values/monotonic_column.rs
@@ -371,7 +371,7 @@ mod tests {
             StrictlyMonotonicMappingInverter, StrictlyMonotonicMappingToInternal,
         };
         use crate::column_values::u64_based::{
-            BitpackedCodec, BlockwiseLinearCodec, ColumnCodec, LinearCodec,
+            BitpackedCodec, BlockForCodec, BlockwiseLinearCodec, ColumnCodec, LinearCodec,
         };
         use crate::column_values::{CodecType, serialize_u64_based_column_values};
 
@@ -516,6 +516,10 @@ mod tests {
         serialize_u64_based_column_values(&&ints[..], &[CodecType::Bitpacked], &mut buf).unwrap();
         sweep::<BitpackedCodec>("Bitpacked", buf[1..].to_vec());
 
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ints[..], &[CodecType::BlockFor], &mut buf).unwrap();
+        sweep::<BlockForCodec>("BlockFor", buf[1..].to_vec());
+
         // A noisy ramp, which is what the two line codecs are chosen for.
         let ramp: Vec<u64> = (0..N as u64)
             .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % (1 << 20)))
@@ -584,5 +588,9 @@ mod tests {
         let mut buf = Vec::new();
         serialize_u64_based_column_values(&&ints[..], &[CodecType::Bitpacked], &mut buf).unwrap();
         sweep_buffered::<BitpackedCodec>("Bitpacked", buf[1..].to_vec());
+
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&ints[..], &[CodecType::BlockFor], &mut buf).unwrap();
+        sweep_buffered::<BlockForCodec>("BlockFor", buf[1..].to_vec());
     }
 }

--- a/columnar/src/column_values/u64_based/alp.rs
+++ b/columnar/src/column_values/u64_based/alp.rs
@@ -9,10 +9,6 @@
 //! rather than multiplying by `10^-e`: the rounded division reproduces the
 //! bits where e.g. `k * 0.01` is one ulp off.
 //!
-//! Non-decimal columns self-detect (exception rate over the first blocks)
-//! and opt out of selection; the size estimate is inflated so Alp only wins
-//! with a real margin.
-//!
 //! The codec is not wired into [`super::CodecType`] yet -- it needs more
 //! validation before columns serialize with it in production.
 //!
@@ -20,73 +16,77 @@
 //!
 //! ```text
 //! [ColumnStats]
-//! [block 0 packed scaled values]...        // 16 * bit_width bytes each
-//! [footer per block: exponent u8, bit_width u8, block_min VInt(zigzag),
-//!                    num_exceptions u8, (position u8, raw u64 LE) * n]
+//! [block 0 packed scaled values][block 1 packed scaled values]...  // 16 * bit_width bytes each
+//! [exception values: num_exceptions * u64 LE]        // flat, in block order
+//! [exception positions: num_exceptions * u8]         // sorted within each block
+//! [block records: num_blocks * stride bytes]         // (offset | bit_width | exponent | count,
+//! [16 zero bytes]                                    //  exc_start, block_min zigzag)
+//! [offset_bit_width: u8][width_bit_width: u8][exponent_bit_width: u8]
+//! [count_bit_width: u8][exc_bit_width: u8][min_bit_width: u8]
+//! [num_exceptions: u32 LE]
 //! [footer_len: u32 LE]
 //! ```
+//!
+//! The per-block exception count lives in the head word, so a block without
+//! exceptions (and any column without exceptions, where the count and
+//! `exc_start` fields are 0 bits wide) never touches the exception fields or
+//! regions at read time.
 
-use std::io::{self, Read, Write};
-use std::sync::Arc;
+use std::io::{self, Write};
 
 use common::{
-    BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes, VInt, f64_to_u64, u64_to_f64,
+    BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes, f64_to_u64, u64_to_f64,
 };
-use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
+use tantivy_bitpacker::block_decode::decode_range;
+use tantivy_bitpacker::{BitPacker, compute_num_bits};
 
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, decode_block, iter_via_blocks,
-    DecodeCost, min_batch_rows, partial_block_min_rows,
+    BLOCK_LEN, BlockDecode, DecodeCost, iter_via_blocks, min_batch_rows,
 };
-use crate::column_values::u64_based::block_for::vint_len;
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
 
-/// Powers of ten tried as decimal scale (all exactly representable as f64).
 const MAX_EXPONENT: usize = 13;
 const POW10: [f64; MAX_EXPONENT + 1] = [
     1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13,
 ];
 
-/// Kept well below 2^53 so integer<->f64 conversions stay exact.
 const MAX_ABS_SCALED: f64 = (1i64 << 51) as f64;
-
-/// Cost of one exception in bytes: position byte + raw value.
 const EXCEPTION_COST: u64 = 9;
-
-/// Estimate inflation: Alp is only picked with a >= 12.5% real size win.
+const FOOTER_PAD: usize = 16;
+const FOOTER_TAIL: usize = 6 + 4;
 const SELECTION_MARGIN_NUM: u64 = 9;
 const SELECTION_MARGIN_DEN: u64 = 8;
-
-/// After this many analyzed blocks, columns whose exception rate exceeds
-/// [`DEAD_EXCEPTION_RATE`] stop being analyzed and opt out of selection.
 const DEAD_DETECTION_BLOCKS: usize = 4;
 const DEAD_EXCEPTION_RATE: f64 = 0.25;
 
-#[inline]
+#[inline(always)]
 fn zigzag_encode(val: i64) -> u64 {
     ((val << 1) ^ (val >> 63)) as u64
 }
 
-#[inline]
+#[inline(always)]
 fn zigzag_decode(val: u64) -> i64 {
     ((val >> 1) as i64) ^ -((val & 1) as i64)
 }
 
-/// Encoding plan for one block.
+#[inline(always)]
+fn low_mask(num_bits: u8) -> u64 {
+    if num_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << num_bits) - 1
+    }
+}
+
 struct BlockPlan {
     exponent: u8,
     bit_width: u8,
-    /// Minimum scaled value among encodable values (0 if none).
     block_min: i64,
-    /// Positions of values stored as raw exceptions.
     exceptions: Vec<u8>,
-    /// Exact payload bytes: packed data + exception bytes + meta.
-    cost: u64,
 }
 
-/// Returns the scaled integer if `mapped` round-trips at this exponent.
-#[inline]
+#[inline(always)]
 fn try_encode(mapped: u64, exponent: usize) -> Option<i64> {
     let val = u64_to_f64(mapped);
     let scaled_f = (val * POW10[exponent]).round();
@@ -94,7 +94,6 @@ fn try_encode(mapped: u64, exponent: usize) -> Option<i64> {
         return None;
     }
     let scaled = scaled_f as i64;
-    // Bit-exact round-trip check (catches -0.0, NaN payloads, precision).
     if f64_to_u64(scaled as f64 / POW10[exponent]) == mapped {
         Some(scaled)
     } else {
@@ -103,7 +102,7 @@ fn try_encode(mapped: u64, exponent: usize) -> Option<i64> {
 }
 
 fn analyze_block(vals: &[u64]) -> BlockPlan {
-    let mut best: Option<BlockPlan> = None;
+    let mut best: Option<(BlockPlan, u64)> = None;
     for exponent in 0..=MAX_EXPONENT {
         let mut min_scaled = i64::MAX;
         let mut max_scaled = i64::MIN;
@@ -117,38 +116,142 @@ fn analyze_block(vals: &[u64]) -> BlockPlan {
             }
         }
         if min_scaled > max_scaled {
-            // Every value is an exception at this exponent.
             continue;
         }
         let bit_width = compute_num_bits((max_scaled - min_scaled) as u64);
-        let cost = 16 * bit_width as u64
-            + exceptions.len() as u64 * EXCEPTION_COST
-            + 3
-            + vint_len(zigzag_encode(min_scaled));
-        if best.as_ref().map(|b| cost < b.cost).unwrap_or(true) {
+        let cost = 16 * bit_width as u64 + exceptions.len() as u64 * EXCEPTION_COST;
+        if best.as_ref().map(|&(_, c)| cost < c).unwrap_or(true) {
             let no_exceptions = exceptions.is_empty();
-            best = Some(BlockPlan {
-                exponent: exponent as u8,
-                bit_width,
-                block_min: min_scaled,
-                exceptions,
+            best = Some((
+                BlockPlan {
+                    exponent: exponent as u8,
+                    bit_width,
+                    block_min: min_scaled,
+                    exceptions,
+                },
                 cost,
-            });
-            // Larger exponents only widen the integers: once everything
-            // round-trips, stop.
+            ));
+
             if no_exceptions {
                 break;
             }
         }
     }
-    best.unwrap_or_else(|| BlockPlan {
-        // All-exception block (e.g. non-float data).
+    best.map(|(plan, _)| plan).unwrap_or_else(|| BlockPlan {
+        // All-exception block (e.g. non-float data). The range is built over
+        // usize before narrowing so all of 0..=127 survive for a full block.
         exponent: 0,
         bit_width: 0,
         block_min: 0,
-        exceptions: (0..vals.len() as u8).collect(),
-        cost: vals.len() as u64 * EXCEPTION_COST + 4,
+        exceptions: (0..vals.len()).map(|pos| pos as u8).collect(),
     })
+}
+
+#[derive(Clone, Copy)]
+struct BlockStat {
+    bit_width: u8,
+    exponent: u8,
+    num_exceptions: u32,
+    zigzag_min: u64,
+}
+
+impl BlockStat {
+    fn of(plan: &BlockPlan) -> BlockStat {
+        BlockStat {
+            bit_width: plan.bit_width,
+            exponent: plan.exponent,
+            num_exceptions: plan.exceptions.len() as u32,
+            zigzag_min: zigzag_encode(plan.block_min),
+        }
+    }
+}
+
+/// Column-wide bit width of each record field.
+#[derive(Clone, Copy)]
+struct FieldWidths {
+    offset: u8,
+    width: u8,
+    exponent: u8,
+    /// Per-block exception count. 0 for the common all-round-tripping column,
+    /// so exception handling costs those columns nothing at read time.
+    count: u8,
+    exc: u8,
+    min: u8,
+}
+
+impl FieldWidths {
+    fn of(block_stats: &[BlockStat]) -> FieldWidths {
+        let mut total_units = 0u64;
+        let mut exc_start = 0u64;
+        let mut max_width = 0u8;
+        let mut max_exponent = 0u8;
+        let mut max_count = 0u32;
+        let mut max_exc_start = 0u64;
+        let mut max_zigzag_min = 0u64;
+        for stat in block_stats {
+            max_width = max_width.max(stat.bit_width);
+            max_exponent = max_exponent.max(stat.exponent);
+            max_count = max_count.max(stat.num_exceptions);
+            max_exc_start = max_exc_start.max(exc_start);
+            max_zigzag_min = max_zigzag_min.max(stat.zigzag_min);
+            total_units += stat.bit_width as u64;
+            exc_start += stat.num_exceptions as u64;
+        }
+        FieldWidths {
+            offset: compute_num_bits(total_units),
+            width: compute_num_bits(max_width as u64),
+            exponent: compute_num_bits(max_exponent as u64),
+            count: compute_num_bits(max_count as u64),
+            exc: compute_num_bits(max_exc_start),
+            min: compute_num_bits(max_zigzag_min),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RecordLayout {
+    /// Bytes per record.
+    stride: usize,
+    offset_mask: u64,
+    width_shift: u32,
+    width_mask: u64,
+    exponent_shift: u32,
+    exponent_mask: u64,
+    count_shift: u32,
+    count_mask: u64,
+    /// Byte offset of the exception start inside the record.
+    exc_byte: usize,
+    exc_mask: u64,
+    /// Byte offset of the zigzag minimum inside the record.
+    min_byte: usize,
+    min_mask: u64,
+}
+
+impl RecordLayout {
+    fn new(widths: FieldWidths) -> RecordLayout {
+        // offset <= 31 bits (2^32 rows), width <= 7, exponent <= 4,
+        // count <= 8: the head always fits one unaligned 8-byte load.
+        let head_bytes = (widths.offset as usize
+            + widths.width as usize
+            + widths.exponent as usize
+            + widths.count as usize)
+            .div_ceil(8);
+        let exc_bytes = (widths.exc as usize).div_ceil(8);
+        RecordLayout {
+            stride: head_bytes + exc_bytes + (widths.min as usize).div_ceil(8),
+            offset_mask: low_mask(widths.offset),
+            width_shift: widths.offset as u32,
+            width_mask: low_mask(widths.width),
+            exponent_shift: widths.offset as u32 + widths.width as u32,
+            exponent_mask: low_mask(widths.exponent),
+            count_shift: widths.offset as u32 + widths.width as u32 + widths.exponent as u32,
+            count_mask: low_mask(widths.count),
+            exc_byte: head_bytes,
+            exc_mask: low_mask(widths.exc),
+            min_byte: head_bytes + exc_bytes,
+            min_mask: low_mask(widths.min),
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -157,52 +260,97 @@ struct AlpBlockMeta {
     block_min: i64,
     /// `10^exponent`.
     scale: f64,
-    /// Start of this block's exceptions in the flat raw-values array.
-    exceptions_start: u32,
-    /// Bitmap of exception positions within the block.
-    exceptions_bitmap: [u64; 2],
-    unpacker: BitUnpacker,
-}
-
-impl AlpBlockMeta {
-    #[inline]
-    fn exception_rank(&self, pos: u32) -> Option<u32> {
-        let word = (pos >> 6) as usize;
-        let bit = pos & 63;
-        if (self.exceptions_bitmap[word] >> bit) & 1 == 0 {
-            return None;
-        }
-        let mask = (1u64 << bit) - 1;
-        let mut rank = (self.exceptions_bitmap[word] & mask).count_ones();
-        if word == 1 {
-            rank += self.exceptions_bitmap[0].count_ones();
-        }
-        Some(rank)
-    }
+    num_exceptions: u32,
+    bit_width: u8,
 }
 
 #[derive(Clone)]
 pub struct AlpReader {
     data: OwnedBytes,
-    blocks: Arc<[AlpBlockMeta]>,
-    /// Raw (mapped u64) exception values, in position order per block.
-    exceptions: Arc<[u64]>,
+    /// The records and everything after them.
+    meta: OwnedBytes,
+    layout: RecordLayout,
+    num_blocks: usize,
+    num_exceptions: u32,
+    /// Byte offset of the flat exception value region in `data`.
+    exc_values_start: usize,
+    /// Byte offset of the flat exception position region in `data`.
+    exc_positions_start: usize,
     stats: ColumnStats,
+}
+
+impl AlpReader {
+    #[inline(always)]
+    fn block_meta(&self, block_idx: usize) -> AlpBlockMeta {
+        let record = block_idx * self.layout.stride;
+        let head = u64::from_le_bytes(self.meta[record..record + 8].try_into().unwrap());
+        let start_units = head & self.layout.offset_mask;
+        let bit_width = (head >> self.layout.width_shift) & self.layout.width_mask;
+        let exponent = (head >> self.layout.exponent_shift) & self.layout.exponent_mask;
+        let num_exceptions = (head >> self.layout.count_shift) & self.layout.count_mask;
+        let min_at = record + self.layout.min_byte;
+        let zigzag_min = u64::from_le_bytes(self.meta[min_at..min_at + 8].try_into().unwrap())
+            & self.layout.min_mask;
+        AlpBlockMeta {
+            start_byte_offset: start_units * 16,
+            block_min: zigzag_decode(zigzag_min),
+            scale: POW10[(exponent as usize).min(MAX_EXPONENT)],
+            num_exceptions: num_exceptions as u32,
+            bit_width: bit_width as u8,
+        }
+    }
+
+    /// Start of this block's exceptions in the flat exception regions. Only
+    /// read on the exception path: blocks without exceptions never touch it.
+    #[inline(always)]
+    fn exceptions_start(&self, block_idx: usize) -> u32 {
+        let exc_at = block_idx * self.layout.stride + self.layout.exc_byte;
+        (u64::from_le_bytes(self.meta[exc_at..exc_at + 8].try_into().unwrap())
+            & self.layout.exc_mask) as u32
+    }
+
+    /// The sorted in-block positions of exceptions `start..end`.
+    #[inline(always)]
+    fn exception_positions(&self, start: u32, end: u32) -> &[u8] {
+        let region = self.exc_positions_start;
+        &self.data[region + start as usize..region + end as usize]
+    }
+
+    /// The raw (mapped u64) value of the column-wide exception `rank`.
+    #[inline(always)]
+    fn exception_value(&self, rank: u32) -> u64 {
+        let at = self.exc_values_start + rank as usize * 8;
+        u64::from_le_bytes(self.data[at..at + 8].try_into().unwrap())
+    }
+
+    /// The `bit_width`-bit slot `slot` of the block, still scaled and
+    /// min-relative. Reading 8 bytes needs no bounds handling of its own
+    /// because the exception regions and footer follow the block data.
+    #[inline(always)]
+    fn slot(&self, meta: &AlpBlockMeta, slot: u32) -> u64 {
+        let bit = slot as usize * meta.bit_width as usize;
+        let byte = meta.start_byte_offset as usize + bit / 8;
+        let raw = u64::from_le_bytes(self.data[byte..byte + 8].try_into().unwrap());
+        (raw >> (bit % 8)) & low_mask(meta.bit_width)
+    }
+
+    #[inline(always)]
+    fn decode_slot(&self, meta: &AlpBlockMeta, pos: u32) -> u64 {
+        let scaled = meta.block_min.wrapping_add(self.slot(meta, pos) as i64);
+        f64_to_u64(scaled as f64 / meta.scale)
+    }
 }
 
 impl BlockDecode for AlpReader {
     fn num_full_blocks(&self) -> usize {
-        self.blocks.len()
+        self.num_blocks
     }
 
-    fn partial_min_rows(&self, block_idx: usize) -> usize {
-        partial_block_min_rows(self.blocks[block_idx].unpacker.bit_width())
-    }
-
-    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
-        let meta = &self.blocks[block_idx];
-        decode_block(
-            meta.unpacker.bit_width(),
+    fn decode_block_range(&self, block_idx: usize, in_block: usize, out: &mut [u64]) {
+        let meta = self.block_meta(block_idx);
+        decode_range(
+            meta.bit_width,
+            in_block,
             &self.data[meta.start_byte_offset as usize..],
             out,
         );
@@ -210,32 +358,59 @@ impl BlockDecode for AlpReader {
             let scaled = meta.block_min.wrapping_add(*slot as i64);
             *slot = f64_to_u64(scaled as f64 / meta.scale);
         }
-        let mut exc_idx = meta.exceptions_start as usize;
-        for word in 0..2 {
-            let mut bits = meta.exceptions_bitmap[word];
-            while bits != 0 {
-                let pos = word * 64 + bits.trailing_zeros() as usize;
-                out[pos] = self.exceptions[exc_idx];
-                exc_idx += 1;
-                bits &= bits - 1;
+        if meta.num_exceptions != 0 {
+            let start = self.exceptions_start(block_idx);
+            let end = start + meta.num_exceptions;
+            let window = in_block..in_block + out.len();
+            for (rank, &pos) in (start..end).zip(self.exception_positions(start, end)) {
+                if window.contains(&(pos as usize)) {
+                    out[pos as usize - in_block] = self.exception_value(rank);
+                }
             }
         }
     }
 }
 
 impl ColumnValues for AlpReader {
+    #[inline(always)]
+    fn get_vals(&self, indexes: &[u32], out: &mut [u64]) {
+        let mut i: usize = 0;
+        while i < indexes.len() {
+            let block_idx = indexes[i] as usize / BLOCK_LEN;
+            let j = i + indexes[i..].partition_point(|&idx| idx as usize / BLOCK_LEN <= block_idx);
+            let meta = self.block_meta(block_idx);
+            if meta.num_exceptions == 0 {
+                for (k, &idx) in indexes[i..j].iter().enumerate() {
+                    out[i + k] = self.decode_slot(&meta, idx % BLOCK_LEN as u32);
+                }
+            } else {
+                let start = self.exceptions_start(block_idx);
+                let positions = self.exception_positions(start, start + meta.num_exceptions);
+                for (k, &idx) in indexes[i..j].iter().enumerate() {
+                    let pos = idx % BLOCK_LEN as u32;
+                    out[i + k] = match positions.binary_search(&(pos as u8)) {
+                        Ok(rank) => self.exception_value(start + rank as u32),
+                        Err(_) => self.decode_slot(&meta, pos),
+                    };
+                }
+            }
+            i = j;
+        }
+    }
+
     #[inline]
     fn get_val(&self, idx: u32) -> u64 {
-        let meta = &self.blocks[idx as usize / BLOCK_LEN];
+        let block_idx = idx as usize / BLOCK_LEN;
+        let meta = self.block_meta(block_idx);
         let pos = idx % BLOCK_LEN as u32;
-        if let Some(rank) = meta.exception_rank(pos) {
-            return self.exceptions[meta.exceptions_start as usize + rank as usize];
+        if meta.num_exceptions != 0 {
+            let start = self.exceptions_start(block_idx);
+            let positions = self.exception_positions(start, start + meta.num_exceptions);
+            if let Ok(rank) = positions.binary_search(&(pos as u8)) {
+                return self.exception_value(start + rank as u32);
+            }
         }
-        let rel = meta
-            .unpacker
-            .get(pos, &self.data[meta.start_byte_offset as usize..]);
-        let scaled = meta.block_min.wrapping_add(rel as i64);
-        f64_to_u64(scaled as f64 / meta.scale)
+        self.decode_slot(&meta, pos)
     }
 
     #[inline]
@@ -274,6 +449,8 @@ impl ColumnValues for AlpReader {
         min_batch_rows(DecodeCost::Blocked)
     }
 
+    /// Worth the `Box<dyn Iterator>` here where it is not for the flat codecs:
+    /// `get_val` re-reads the block record and does a float divide per value.
     fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = u64> + 'a> {
         iter_via_blocks(self, self.stats.num_rows as usize)
     }
@@ -281,8 +458,7 @@ impl ColumnValues for AlpReader {
 
 pub struct AlpEstimator {
     block: Vec<u64>,
-    payload_bytes: u64,
-    num_blocks: usize,
+    block_stats: Vec<BlockStat>,
     num_exceptions: u64,
     num_values: u64,
     dead: bool,
@@ -292,8 +468,7 @@ impl Default for AlpEstimator {
     fn default() -> Self {
         AlpEstimator {
             block: Vec::with_capacity(BLOCK_LEN),
-            payload_bytes: 0,
-            num_blocks: 0,
+            block_stats: Vec::new(),
             num_exceptions: 0,
             num_values: 0,
             dead: false,
@@ -308,18 +483,30 @@ impl AlpEstimator {
             return;
         }
         let plan = analyze_block(&self.block);
-        self.payload_bytes += plan.cost;
-        self.num_blocks += 1;
         self.num_exceptions += plan.exceptions.len() as u64;
         self.num_values += self.block.len() as u64;
+        self.block_stats.push(BlockStat::of(&plan));
         self.block.clear();
-        if self.num_blocks >= DEAD_DETECTION_BLOCKS
+        if self.block_stats.len() >= DEAD_DETECTION_BLOCKS
             && (self.num_exceptions as f64) > (self.num_values as f64) * DEAD_EXCEPTION_RATE
         {
             // Not decimal data: stop wasting cycles, opt out of selection.
             self.dead = true;
         }
     }
+}
+
+/// Exact serialized length of a column with these per-block stats.
+fn serialized_len(stats: &ColumnStats, block_stats: &[BlockStat]) -> u64 {
+    let widths = FieldWidths::of(block_stats);
+    let total_units: u64 = block_stats.iter().map(|s| s.bit_width as u64).sum();
+    let num_exceptions: u64 = block_stats.iter().map(|s| s.num_exceptions as u64).sum();
+    stats.num_bytes()
+        + 16 * total_units
+        + num_exceptions * EXCEPTION_COST
+        + block_stats.len() as u64 * RecordLayout::new(widths).stride as u64
+        + (FOOTER_PAD + FOOTER_TAIL) as u64
+        + 4
 }
 
 impl ColumnCodecEstimator for AlpEstimator {
@@ -341,8 +528,7 @@ impl ColumnCodecEstimator for AlpEstimator {
         if self.dead {
             return None;
         }
-        let num_bytes = stats.num_bytes() + 4 + self.payload_bytes;
-        Some(num_bytes * SELECTION_MARGIN_NUM / SELECTION_MARGIN_DEN)
+        Some(serialized_len(stats, &self.block_stats) * SELECTION_MARGIN_NUM / SELECTION_MARGIN_DEN)
     }
 
     fn serialize(
@@ -354,8 +540,9 @@ impl ColumnCodecEstimator for AlpEstimator {
         assert!(!self.dead, "alp codec serialize called on a dead estimator");
         stats.serialize(wrt)?;
         let mut block: Vec<u64> = Vec::with_capacity(BLOCK_LEN);
-        // (plan, raw exception values)
-        let mut block_metas: Vec<(BlockPlan, Vec<u64>)> = Vec::new();
+        let mut block_stats: Vec<BlockStat> = Vec::new();
+        let mut exc_values: Vec<u8> = Vec::new();
+        let mut exc_positions: Vec<u8> = Vec::new();
         let mut bit_packer = BitPacker::new();
         loop {
             block.clear();
@@ -364,7 +551,6 @@ impl ColumnCodecEstimator for AlpEstimator {
                 break;
             }
             let plan = analyze_block(&block);
-            let mut exception_values: Vec<u64> = Vec::with_capacity(plan.exceptions.len());
             let mut next_exception = 0usize;
             for (pos, &mapped) in block.iter().enumerate() {
                 let is_exception = plan
@@ -374,7 +560,8 @@ impl ColumnCodecEstimator for AlpEstimator {
                     .unwrap_or(false);
                 let rel = if is_exception {
                     next_exception += 1;
-                    exception_values.push(mapped);
+                    exc_values.extend_from_slice(&mapped.to_le_bytes());
+                    exc_positions.push(pos as u8);
                     0u64
                 } else {
                     let scaled = try_encode(mapped, plan.exponent as usize)
@@ -386,23 +573,49 @@ impl ColumnCodecEstimator for AlpEstimator {
             for _ in block.len()..BLOCK_LEN {
                 bit_packer.write(0u64, plan.bit_width, wrt)?;
             }
+            // 128 * bit_width bits is a multiple of 64: the packer is empty.
             bit_packer.flush(wrt)?;
-            block_metas.push((plan, exception_values));
+            block_stats.push(BlockStat::of(&plan));
         }
+        wrt.write_all(&exc_values)?;
+        wrt.write_all(&exc_positions)?;
+
+        let widths = FieldWidths::of(&block_stats);
+        let layout = RecordLayout::new(widths);
+        let head_bytes = layout.exc_byte;
+        let exc_bytes = layout.min_byte - layout.exc_byte;
+        let min_bytes = layout.stride - layout.min_byte;
         let mut counting_wrt = CountingWriter::wrap(wrt);
-        for (plan, exception_values) in &block_metas {
-            plan.exponent.serialize(&mut counting_wrt)?;
-            plan.bit_width.serialize(&mut counting_wrt)?;
-            VInt(zigzag_encode(plan.block_min)).serialize(&mut counting_wrt)?;
-            (plan.exceptions.len() as u8).serialize(&mut counting_wrt)?;
-            for (&pos, &raw) in plan.exceptions.iter().zip(exception_values) {
-                pos.serialize(&mut counting_wrt)?;
-                counting_wrt.write_all(&raw.to_le_bytes())?;
-            }
+        let mut units = 0u64;
+        let mut exc_start = 0u64;
+        for stat in &block_stats {
+            let head = units
+                | ((stat.bit_width as u64) << layout.width_shift)
+                | ((stat.exponent as u64) << layout.exponent_shift)
+                | ((stat.num_exceptions as u64) << layout.count_shift);
+            counting_wrt.write_all(&head.to_le_bytes()[..head_bytes])?;
+            counting_wrt.write_all(&exc_start.to_le_bytes()[..exc_bytes])?;
+            counting_wrt.write_all(&stat.zigzag_min.to_le_bytes()[..min_bytes])?;
+            units += stat.bit_width as u64;
+            exc_start += stat.num_exceptions as u64;
         }
+        counting_wrt.write_all(&[0u8; FOOTER_PAD])?;
+        widths.offset.serialize(&mut counting_wrt)?;
+        widths.width.serialize(&mut counting_wrt)?;
+        widths.exponent.serialize(&mut counting_wrt)?;
+        widths.count.serialize(&mut counting_wrt)?;
+        widths.exc.serialize(&mut counting_wrt)?;
+        widths.min.serialize(&mut counting_wrt)?;
+        u32::try_from(exc_start)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "too many alp exceptions"))?
+            .serialize(&mut counting_wrt)?;
         let footer_len = u32::try_from(counting_wrt.written_bytes()).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, "column footer exceeds u32::MAX")
         })?;
+        debug_assert_eq!(
+            u64::from(footer_len),
+            block_stats.len() as u64 * layout.stride as u64 + (FOOTER_PAD + FOOTER_TAIL) as u64
+        );
         footer_len.serialize(&mut counting_wrt)?;
         Ok(())
     }
@@ -418,39 +631,30 @@ impl ColumnCodec for AlpCodec {
         let stats = ColumnStats::deserialize(&mut bytes)?;
         let footer_len: u32 = (&bytes[bytes.len() - 4..]).deserialize()?;
         let footer_offset = bytes.len() - 4 - footer_len as usize;
-        let (data, mut footer) = bytes.split(footer_offset);
-        let num_blocks = (stats.num_rows as usize).div_ceil(BLOCK_LEN);
-        let mut blocks = Vec::with_capacity(num_blocks);
-        let mut exceptions: Vec<u64> = Vec::new();
-        let mut start_byte_offset = 0u64;
-        for _ in 0..num_blocks {
-            let exponent = u8::deserialize(&mut footer)?;
-            let bit_width = u8::deserialize(&mut footer)?;
-            let block_min = zigzag_decode(VInt::deserialize(&mut footer)?.0);
-            let exceptions_start = exceptions.len() as u32;
-            let num_exceptions = u8::deserialize(&mut footer)?;
-            let mut bitmap = [0u64; 2];
-            for _ in 0..num_exceptions {
-                let pos = u8::deserialize(&mut footer)?;
-                let mut raw = [0u8; 8];
-                footer.read_exact(&mut raw)?;
-                bitmap[(pos >> 6) as usize] |= 1u64 << (pos & 63);
-                exceptions.push(u64::from_le_bytes(raw));
-            }
-            blocks.push(AlpBlockMeta {
-                start_byte_offset,
-                block_min,
-                scale: POW10[(exponent as usize).min(MAX_EXPONENT)],
-                exceptions_start,
-                exceptions_bitmap: bitmap,
-                unpacker: BitUnpacker::new(bit_width),
-            });
-            start_byte_offset += (BLOCK_LEN as u64 * bit_width as u64) / 8;
-        }
+
+        let data = bytes.clone();
+        let meta = bytes.slice(footer_offset..bytes.len());
+        let tail = meta.len();
+        let num_exceptions: u32 = (&meta[tail - 8..tail - 4]).deserialize()?;
+        let widths = FieldWidths {
+            offset: meta[tail - 14],
+            width: meta[tail - 13],
+            exponent: meta[tail - 12],
+            count: meta[tail - 11],
+            exc: meta[tail - 10],
+            min: meta[tail - 9],
+        };
+        let exc_positions_start = footer_offset - num_exceptions as usize;
+        let exc_values_start = exc_positions_start - num_exceptions as usize * 8;
+
         Ok(AlpReader {
             data,
-            blocks: blocks.into(),
-            exceptions: exceptions.into(),
+            meta,
+            layout: RecordLayout::new(widths),
+            num_blocks: (stats.num_rows as usize).div_ceil(BLOCK_LEN),
+            num_exceptions,
+            exc_values_start,
+            exc_positions_start,
             stats,
         })
     }
@@ -491,6 +695,12 @@ mod tests {
         assert_eq!(col.num_vals() as usize, vals.len());
         for (idx, &expected) in vals.iter().enumerate() {
             assert_eq!(col.get_val(idx as u32), expected, "mismatch at {idx}");
+        }
+        let indexes: Vec<u32> = (0..vals.len() as u32).step_by(3).collect();
+        let mut out = vec![0u64; indexes.len()];
+        col.get_vals(&indexes, &mut out);
+        for (k, &idx) in indexes.iter().enumerate() {
+            assert_eq!(out[k], vals[idx as usize], "get_vals mismatch at {idx}");
         }
         let mut out = vec![0u64; vals.len()];
         col.get_range(0, &mut out);
@@ -563,7 +773,7 @@ mod tests {
         // A whole 128-value block where no exponent round-trips, inside a
         // column that is otherwise plain two-decimal data. The block falls
         // back to the all-exception plan, whose 128 positions must survive
-        // the u8 position encoding and the u8 exception count.
+        // the u8 position encoding and the exception-count derivation.
         let vals: Vec<f64> = (0..1024usize)
             .map(|i| {
                 if (640..768).contains(&i) {
@@ -574,6 +784,43 @@ mod tests {
             })
             .collect();
         serialize_and_check(&vals).unwrap();
+    }
+
+    /// `decode_block_range` patches exceptions by their *block-relative*
+    /// position into an output that starts at `in_block`, so every start and
+    /// length must land the patch on the same row `get_val` does. Exceptions
+    /// are placed to hit the first and last slot of a block, both ramps of the
+    /// unpacker, and the short chunks that fall back to `get_val`.
+    #[test]
+    fn test_alp_get_range_exception_windows() {
+        let vals: Vec<f64> = (0..1024usize)
+            .map(|i| {
+                let in_block = i % BLOCK_LEN;
+                if matches!(in_block, 0 | 1 | 7 | 8 | 63 | 120 | 126 | 127) {
+                    (i as f64).sqrt() * std::f64::consts::PI
+                } else {
+                    (i % 100_000) as f64 / 100.0
+                }
+            })
+            .collect();
+        let mapped: Vec<u64> = vals.iter().map(|&v| f64_to_u64(v)).collect();
+        let bytes = serialize_alp(&mapped).expect("alp should take this column");
+        let col = AlpCodec::load(OwnedBytes::new(bytes)).unwrap();
+
+        for start in 0..(2 * BLOCK_LEN + 9) {
+            for len in [1usize, 7, 8, 15, 16, 17, 64, 128, 129, 200] {
+                if start + len > mapped.len() {
+                    continue;
+                }
+                let mut out = vec![0u64; len];
+                col.get_range(start as u64, &mut out);
+                assert_eq!(
+                    &out[..],
+                    &mapped[start..start + len],
+                    "get_range({start}, {len}) mismatch"
+                );
+            }
+        }
     }
 
     #[test]
@@ -617,5 +864,85 @@ mod tests {
     fn test_alp_empty() {
         let vals: Vec<f64> = Vec::new();
         serialize_and_check(&vals);
+    }
+
+    fn stats_of(vals: &[u64]) -> ColumnStats {
+        let mut collector = StatsCollector::default();
+        for &val in vals {
+            collector.collect(val);
+        }
+        collector.stats()
+    }
+
+    #[test]
+    fn test_alp_footer_layout() {
+        // 3 blocks of two-decimal data: scaled amplitudes 127, 127, 43 at
+        // exponent 2, no exceptions.
+        let vals: Vec<u64> = (0..300u64).map(|i| (i as f64 / 100.0).to_u64()).collect();
+        let buffer = serialize_alp(&vals).unwrap();
+        let stats = stats_of(&vals);
+
+        let total_units = 7 + 7 + 6usize;
+        // offset: num_bits(20) = 5, width: num_bits(7) = 3, exponent:
+        // num_bits(2) = 2, count/exc_start: 0 bits -> head 10 bits -> 2
+        // bytes, no exception bytes. Minima scaled: 0, 12800, 25600;
+        // zigzag(25600) = 51200 -> 16 bits -> 2 bytes.
+        let widths = FieldWidths {
+            offset: 5,
+            width: 3,
+            exponent: 2,
+            count: 0,
+            exc: 0,
+            min: 16,
+        };
+        let stride = RecordLayout::new(widths).stride;
+        assert_eq!(stride, 4);
+        let footer_len = 3 * stride + FOOTER_PAD + 6 + 4;
+        assert_eq!(
+            buffer.len(),
+            stats.num_bytes() as usize + 16 * total_units + footer_len + 4
+        );
+    }
+
+    /// The estimate is the exact serialized length inflated by the selection
+    /// margin, so codec selection sees real bytes.
+    #[test]
+    fn test_alp_estimate_matches_serialized_len() {
+        let cases: Vec<(Vec<f64>, &str)> = vec![
+            ((0..300).map(|i| i as f64 / 100.0).collect(), "ramp"),
+            (vec![42.42; 1000], "constant"),
+            ((0..128).map(|i| i as f64 * 0.25).collect(), "one block"),
+            (vec![7.5], "single value"),
+            (
+                (0..3000usize)
+                    .map(|i| {
+                        if i % 10 == 3 {
+                            (i as f64).sqrt() * std::f64::consts::PI
+                        } else {
+                            (i % 100_000) as f64 / 100.0
+                        }
+                    })
+                    .collect(),
+                "mixed exceptions",
+            ),
+        ];
+        for (f64_vals, name) in cases {
+            let vals: Vec<u64> = f64_vals.iter().map(|&v| v.to_u64()).collect();
+            let stats = stats_of(&vals);
+            let mut estimator = AlpEstimator::default();
+            for &val in &vals {
+                estimator.collect(val);
+            }
+            estimator.finalize();
+            let mut buffer = Vec::new();
+            estimator
+                .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+                .unwrap();
+            assert_eq!(
+                estimator.estimate(&stats),
+                Some(buffer.len() as u64 * SELECTION_MARGIN_NUM / SELECTION_MARGIN_DEN),
+                "{name}: estimate must be the serialized length times the selection margin"
+            );
+        }
     }
 }

--- a/columnar/src/column_values/u64_based/alp.rs
+++ b/columnar/src/column_values/u64_based/alp.rs
@@ -1,0 +1,621 @@
+//! ALP (Adaptive Lossless Floating-Point) pseudo-decimal codec for f64 columns.
+//!
+//! f64 values arrive as monotonically mapped u64s (`common::f64_to_u64`),
+//! which no integer codec can compress. Per 128-value block: find the
+//! smallest power of ten so that `round(v * 10^e)` round-trips to the exact
+//! original bits via `scaled as f64 / 10^e`; store the scaled integers
+//! min-relative and bitpacked like `BlockFor`; keep non-round-tripping
+//! values as raw 8-byte exceptions patched by position. Decoding divides
+//! rather than multiplying by `10^-e`: the rounded division reproduces the
+//! bits where e.g. `k * 0.01` is one ulp off.
+//!
+//! Non-decimal columns self-detect (exception rate over the first blocks)
+//! and opt out of selection; the size estimate is inflated so Alp only wins
+//! with a real margin.
+//!
+//! The codec is not wired into [`super::CodecType`] yet -- it needs more
+//! validation before columns serialize with it in production.
+//!
+//! ## Layout
+//!
+//! ```text
+//! [ColumnStats]
+//! [block 0 packed scaled values]...        // 16 * bit_width bytes each
+//! [footer per block: exponent u8, bit_width u8, block_min VInt(zigzag),
+//!                    num_exceptions u8, (position u8, raw u64 LE) * n]
+//! [footer_len: u32 LE]
+//! ```
+
+use std::io::{self, Read, Write};
+use std::sync::Arc;
+
+use common::{
+    BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes, VInt, f64_to_u64, u64_to_f64,
+};
+use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
+
+use crate::column_values::u64_based::block_decode::{
+    BLOCK_LEN, BlockDecode, decode_block, iter_via_blocks,
+    DecodeCost, min_batch_rows, partial_block_min_rows,
+};
+use crate::column_values::u64_based::block_for::vint_len;
+use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
+use crate::{ColumnValues, RowId};
+
+/// Powers of ten tried as decimal scale (all exactly representable as f64).
+const MAX_EXPONENT: usize = 13;
+const POW10: [f64; MAX_EXPONENT + 1] = [
+    1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13,
+];
+
+/// Kept well below 2^53 so integer<->f64 conversions stay exact.
+const MAX_ABS_SCALED: f64 = (1i64 << 51) as f64;
+
+/// Cost of one exception in bytes: position byte + raw value.
+const EXCEPTION_COST: u64 = 9;
+
+/// Estimate inflation: Alp is only picked with a >= 12.5% real size win.
+const SELECTION_MARGIN_NUM: u64 = 9;
+const SELECTION_MARGIN_DEN: u64 = 8;
+
+/// After this many analyzed blocks, columns whose exception rate exceeds
+/// [`DEAD_EXCEPTION_RATE`] stop being analyzed and opt out of selection.
+const DEAD_DETECTION_BLOCKS: usize = 4;
+const DEAD_EXCEPTION_RATE: f64 = 0.25;
+
+#[inline]
+fn zigzag_encode(val: i64) -> u64 {
+    ((val << 1) ^ (val >> 63)) as u64
+}
+
+#[inline]
+fn zigzag_decode(val: u64) -> i64 {
+    ((val >> 1) as i64) ^ -((val & 1) as i64)
+}
+
+/// Encoding plan for one block.
+struct BlockPlan {
+    exponent: u8,
+    bit_width: u8,
+    /// Minimum scaled value among encodable values (0 if none).
+    block_min: i64,
+    /// Positions of values stored as raw exceptions.
+    exceptions: Vec<u8>,
+    /// Exact payload bytes: packed data + exception bytes + meta.
+    cost: u64,
+}
+
+/// Returns the scaled integer if `mapped` round-trips at this exponent.
+#[inline]
+fn try_encode(mapped: u64, exponent: usize) -> Option<i64> {
+    let val = u64_to_f64(mapped);
+    let scaled_f = (val * POW10[exponent]).round();
+    if scaled_f.is_nan() || scaled_f.abs() > MAX_ABS_SCALED {
+        return None;
+    }
+    let scaled = scaled_f as i64;
+    // Bit-exact round-trip check (catches -0.0, NaN payloads, precision).
+    if f64_to_u64(scaled as f64 / POW10[exponent]) == mapped {
+        Some(scaled)
+    } else {
+        None
+    }
+}
+
+fn analyze_block(vals: &[u64]) -> BlockPlan {
+    let mut best: Option<BlockPlan> = None;
+    for exponent in 0..=MAX_EXPONENT {
+        let mut min_scaled = i64::MAX;
+        let mut max_scaled = i64::MIN;
+        let mut exceptions: Vec<u8> = Vec::new();
+        for (pos, &mapped) in vals.iter().enumerate() {
+            if let Some(scaled) = try_encode(mapped, exponent) {
+                min_scaled = min_scaled.min(scaled);
+                max_scaled = max_scaled.max(scaled);
+            } else {
+                exceptions.push(pos as u8);
+            }
+        }
+        if min_scaled > max_scaled {
+            // Every value is an exception at this exponent.
+            continue;
+        }
+        let bit_width = compute_num_bits((max_scaled - min_scaled) as u64);
+        let cost = 16 * bit_width as u64
+            + exceptions.len() as u64 * EXCEPTION_COST
+            + 3
+            + vint_len(zigzag_encode(min_scaled));
+        if best.as_ref().map(|b| cost < b.cost).unwrap_or(true) {
+            let no_exceptions = exceptions.is_empty();
+            best = Some(BlockPlan {
+                exponent: exponent as u8,
+                bit_width,
+                block_min: min_scaled,
+                exceptions,
+                cost,
+            });
+            // Larger exponents only widen the integers: once everything
+            // round-trips, stop.
+            if no_exceptions {
+                break;
+            }
+        }
+    }
+    best.unwrap_or_else(|| BlockPlan {
+        // All-exception block (e.g. non-float data).
+        exponent: 0,
+        bit_width: 0,
+        block_min: 0,
+        exceptions: (0..vals.len() as u8).collect(),
+        cost: vals.len() as u64 * EXCEPTION_COST + 4,
+    })
+}
+
+#[derive(Clone, Copy)]
+struct AlpBlockMeta {
+    start_byte_offset: u64,
+    block_min: i64,
+    /// `10^exponent`.
+    scale: f64,
+    /// Start of this block's exceptions in the flat raw-values array.
+    exceptions_start: u32,
+    /// Bitmap of exception positions within the block.
+    exceptions_bitmap: [u64; 2],
+    unpacker: BitUnpacker,
+}
+
+impl AlpBlockMeta {
+    #[inline]
+    fn exception_rank(&self, pos: u32) -> Option<u32> {
+        let word = (pos >> 6) as usize;
+        let bit = pos & 63;
+        if (self.exceptions_bitmap[word] >> bit) & 1 == 0 {
+            return None;
+        }
+        let mask = (1u64 << bit) - 1;
+        let mut rank = (self.exceptions_bitmap[word] & mask).count_ones();
+        if word == 1 {
+            rank += self.exceptions_bitmap[0].count_ones();
+        }
+        Some(rank)
+    }
+}
+
+#[derive(Clone)]
+pub struct AlpReader {
+    data: OwnedBytes,
+    blocks: Arc<[AlpBlockMeta]>,
+    /// Raw (mapped u64) exception values, in position order per block.
+    exceptions: Arc<[u64]>,
+    stats: ColumnStats,
+}
+
+impl BlockDecode for AlpReader {
+    fn num_full_blocks(&self) -> usize {
+        self.blocks.len()
+    }
+
+    fn partial_min_rows(&self, block_idx: usize) -> usize {
+        partial_block_min_rows(self.blocks[block_idx].unpacker.bit_width())
+    }
+
+    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+        let meta = &self.blocks[block_idx];
+        decode_block(
+            meta.unpacker.bit_width(),
+            &self.data[meta.start_byte_offset as usize..],
+            out,
+        );
+        for slot in out.iter_mut() {
+            let scaled = meta.block_min.wrapping_add(*slot as i64);
+            *slot = f64_to_u64(scaled as f64 / meta.scale);
+        }
+        let mut exc_idx = meta.exceptions_start as usize;
+        for word in 0..2 {
+            let mut bits = meta.exceptions_bitmap[word];
+            while bits != 0 {
+                let pos = word * 64 + bits.trailing_zeros() as usize;
+                out[pos] = self.exceptions[exc_idx];
+                exc_idx += 1;
+                bits &= bits - 1;
+            }
+        }
+    }
+}
+
+impl ColumnValues for AlpReader {
+    #[inline]
+    fn get_val(&self, idx: u32) -> u64 {
+        let meta = &self.blocks[idx as usize / BLOCK_LEN];
+        let pos = idx % BLOCK_LEN as u32;
+        if let Some(rank) = meta.exception_rank(pos) {
+            return self.exceptions[meta.exceptions_start as usize + rank as usize];
+        }
+        let rel = meta
+            .unpacker
+            .get(pos, &self.data[meta.start_byte_offset as usize..]);
+        let scaled = meta.block_min.wrapping_add(rel as i64);
+        f64_to_u64(scaled as f64 / meta.scale)
+    }
+
+    #[inline]
+    fn min_value(&self) -> u64 {
+        self.stats.min_value
+    }
+
+    #[inline]
+    fn max_value(&self) -> u64 {
+        self.stats.max_value
+    }
+
+    #[inline]
+    fn num_vals(&self) -> RowId {
+        self.stats.num_rows
+    }
+
+    fn get_row_ids_for_value_range(
+        &self,
+        value_range: std::ops::RangeInclusive<u64>,
+        row_id_range: std::ops::Range<u32>,
+        row_id_hits: &mut Vec<u32>,
+    ) {
+        super::get_row_ids_for_value_range_batched(self, value_range, row_id_range, row_id_hits)
+    }
+
+    fn get_range(&self, start: u64, output: &mut [u64]) {
+        assert!(
+            start + output.len() as u64 <= u64::from(self.stats.num_rows),
+            "get_range out of bounds"
+        );
+        self.decode_range(start, output);
+    }
+
+    fn min_batch_rows(&self) -> usize {
+        min_batch_rows(DecodeCost::Blocked)
+    }
+
+    fn iter<'a>(&'a self) -> Box<dyn Iterator<Item = u64> + 'a> {
+        iter_via_blocks(self, self.stats.num_rows as usize)
+    }
+}
+
+pub struct AlpEstimator {
+    block: Vec<u64>,
+    payload_bytes: u64,
+    num_blocks: usize,
+    num_exceptions: u64,
+    num_values: u64,
+    dead: bool,
+}
+
+impl Default for AlpEstimator {
+    fn default() -> Self {
+        AlpEstimator {
+            block: Vec::with_capacity(BLOCK_LEN),
+            payload_bytes: 0,
+            num_blocks: 0,
+            num_exceptions: 0,
+            num_values: 0,
+            dead: false,
+        }
+    }
+}
+
+impl AlpEstimator {
+    fn flush_block(&mut self) {
+        if self.block.is_empty() || self.dead {
+            self.block.clear();
+            return;
+        }
+        let plan = analyze_block(&self.block);
+        self.payload_bytes += plan.cost;
+        self.num_blocks += 1;
+        self.num_exceptions += plan.exceptions.len() as u64;
+        self.num_values += self.block.len() as u64;
+        self.block.clear();
+        if self.num_blocks >= DEAD_DETECTION_BLOCKS
+            && (self.num_exceptions as f64) > (self.num_values as f64) * DEAD_EXCEPTION_RATE
+        {
+            // Not decimal data: stop wasting cycles, opt out of selection.
+            self.dead = true;
+        }
+    }
+}
+
+impl ColumnCodecEstimator for AlpEstimator {
+    fn collect(&mut self, value: u64) {
+        if self.dead {
+            return;
+        }
+        self.block.push(value);
+        if self.block.len() == BLOCK_LEN {
+            self.flush_block();
+        }
+    }
+
+    fn finalize(&mut self) {
+        self.flush_block();
+    }
+
+    fn estimate(&self, stats: &ColumnStats) -> Option<u64> {
+        if self.dead {
+            return None;
+        }
+        let num_bytes = stats.num_bytes() + 4 + self.payload_bytes;
+        Some(num_bytes * SELECTION_MARGIN_NUM / SELECTION_MARGIN_DEN)
+    }
+
+    fn serialize(
+        &self,
+        stats: &ColumnStats,
+        vals: &mut dyn Iterator<Item = u64>,
+        wrt: &mut dyn Write,
+    ) -> io::Result<()> {
+        assert!(!self.dead, "alp codec serialize called on a dead estimator");
+        stats.serialize(wrt)?;
+        let mut block: Vec<u64> = Vec::with_capacity(BLOCK_LEN);
+        // (plan, raw exception values)
+        let mut block_metas: Vec<(BlockPlan, Vec<u64>)> = Vec::new();
+        let mut bit_packer = BitPacker::new();
+        loop {
+            block.clear();
+            block.extend((&mut *vals).take(BLOCK_LEN));
+            if block.is_empty() {
+                break;
+            }
+            let plan = analyze_block(&block);
+            let mut exception_values: Vec<u64> = Vec::with_capacity(plan.exceptions.len());
+            let mut next_exception = 0usize;
+            for (pos, &mapped) in block.iter().enumerate() {
+                let is_exception = plan
+                    .exceptions
+                    .get(next_exception)
+                    .map(|&p| p as usize == pos)
+                    .unwrap_or(false);
+                let rel = if is_exception {
+                    next_exception += 1;
+                    exception_values.push(mapped);
+                    0u64
+                } else {
+                    let scaled = try_encode(mapped, plan.exponent as usize)
+                        .expect("value must round-trip according to the block plan");
+                    (scaled - plan.block_min) as u64
+                };
+                bit_packer.write(rel, plan.bit_width, wrt)?;
+            }
+            for _ in block.len()..BLOCK_LEN {
+                bit_packer.write(0u64, plan.bit_width, wrt)?;
+            }
+            bit_packer.flush(wrt)?;
+            block_metas.push((plan, exception_values));
+        }
+        let mut counting_wrt = CountingWriter::wrap(wrt);
+        for (plan, exception_values) in &block_metas {
+            plan.exponent.serialize(&mut counting_wrt)?;
+            plan.bit_width.serialize(&mut counting_wrt)?;
+            VInt(zigzag_encode(plan.block_min)).serialize(&mut counting_wrt)?;
+            (plan.exceptions.len() as u8).serialize(&mut counting_wrt)?;
+            for (&pos, &raw) in plan.exceptions.iter().zip(exception_values) {
+                pos.serialize(&mut counting_wrt)?;
+                counting_wrt.write_all(&raw.to_le_bytes())?;
+            }
+        }
+        let footer_len = u32::try_from(counting_wrt.written_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "column footer exceeds u32::MAX")
+        })?;
+        footer_len.serialize(&mut counting_wrt)?;
+        Ok(())
+    }
+}
+
+pub struct AlpCodec;
+
+impl ColumnCodec for AlpCodec {
+    type ColumnValues = AlpReader;
+    type Estimator = AlpEstimator;
+
+    fn load(mut bytes: OwnedBytes) -> io::Result<Self::ColumnValues> {
+        let stats = ColumnStats::deserialize(&mut bytes)?;
+        let footer_len: u32 = (&bytes[bytes.len() - 4..]).deserialize()?;
+        let footer_offset = bytes.len() - 4 - footer_len as usize;
+        let (data, mut footer) = bytes.split(footer_offset);
+        let num_blocks = (stats.num_rows as usize).div_ceil(BLOCK_LEN);
+        let mut blocks = Vec::with_capacity(num_blocks);
+        let mut exceptions: Vec<u64> = Vec::new();
+        let mut start_byte_offset = 0u64;
+        for _ in 0..num_blocks {
+            let exponent = u8::deserialize(&mut footer)?;
+            let bit_width = u8::deserialize(&mut footer)?;
+            let block_min = zigzag_decode(VInt::deserialize(&mut footer)?.0);
+            let exceptions_start = exceptions.len() as u32;
+            let num_exceptions = u8::deserialize(&mut footer)?;
+            let mut bitmap = [0u64; 2];
+            for _ in 0..num_exceptions {
+                let pos = u8::deserialize(&mut footer)?;
+                let mut raw = [0u8; 8];
+                footer.read_exact(&mut raw)?;
+                bitmap[(pos >> 6) as usize] |= 1u64 << (pos & 63);
+                exceptions.push(u64::from_le_bytes(raw));
+            }
+            blocks.push(AlpBlockMeta {
+                start_byte_offset,
+                block_min,
+                scale: POW10[(exponent as usize).min(MAX_EXPONENT)],
+                exceptions_start,
+                exceptions_bitmap: bitmap,
+                unpacker: BitUnpacker::new(bit_width),
+            });
+            start_byte_offset += (BLOCK_LEN as u64 * bit_width as u64) / 8;
+        }
+        Ok(AlpReader {
+            data,
+            blocks: blocks.into(),
+            exceptions: exceptions.into(),
+            stats,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::OwnedBytes;
+
+    use super::*;
+    use crate::MonotonicallyMappableToU64;
+    use crate::column_values::u64_based::{ColumnCodec, StatsCollector};
+
+    /// Serializes through the estimator directly: the codec is not wired into
+    /// `CodecType`, so the public selection path cannot reach it.
+    fn serialize_alp(vals: &[u64]) -> Option<Vec<u8>> {
+        let mut stats_collector = StatsCollector::default();
+        let mut estimator = AlpEstimator::default();
+        for &val in vals {
+            stats_collector.collect(val);
+            estimator.collect(val);
+        }
+        estimator.finalize();
+        let stats = stats_collector.stats();
+        estimator.estimate(&stats)?;
+        let mut buffer = Vec::new();
+        estimator
+            .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+            .unwrap();
+        Some(buffer)
+    }
+
+    fn serialize_and_check(f64_vals: &[f64]) -> Option<f64> {
+        let vals: Vec<u64> = f64_vals.iter().map(|&v| v.to_u64()).collect();
+        let buffer = serialize_alp(&vals)?;
+        let bits_per_value = buffer.len() as f64 * 8.0 / vals.len().max(1) as f64;
+        let col = AlpCodec::load(OwnedBytes::new(buffer)).unwrap();
+        assert_eq!(col.num_vals() as usize, vals.len());
+        for (idx, &expected) in vals.iter().enumerate() {
+            assert_eq!(col.get_val(idx as u32), expected, "mismatch at {idx}");
+        }
+        let mut out = vec![0u64; vals.len()];
+        col.get_range(0, &mut out);
+        assert_eq!(out, vals, "get_range mismatch");
+        if vals.len() > 100 {
+            let mut out = vec![0u64; vals.len() - 63];
+            col.get_range(63, &mut out);
+            assert_eq!(&out[..], &vals[63..], "unaligned get_range mismatch");
+        }
+        let iter_vals: Vec<u64> = col.iter().collect();
+        assert_eq!(iter_vals, vals, "iter mismatch");
+        Some(bits_per_value)
+    }
+
+    #[test]
+    fn test_alp_two_decimals() {
+        let vals: Vec<f64> = (0..5000u64)
+            .map(|i| ((i * 37) % 1_000_000) as f64 / 100.0)
+            .collect();
+        let bits = serialize_and_check(&vals).unwrap();
+        assert!(bits < 30.0, "expected < 30 bits/value, got {bits}");
+    }
+
+    #[test]
+    fn test_alp_special_values() {
+        let vals = vec![
+            0.0,
+            -0.0,
+            1.25,
+            -3.75,
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            f64::MIN_POSITIVE,
+            1e300,
+            -1e-300,
+            42.42,
+        ];
+        serialize_and_check(&vals).unwrap();
+    }
+
+    #[test]
+    fn test_alp_block_boundaries() {
+        for num_vals in [1usize, 127, 128, 129, 256, 1027] {
+            let vals: Vec<f64> = (0..num_vals)
+                .map(|i| (i as f64 * 5.0 - 300.0) / 100.0)
+                .collect();
+            serialize_and_check(&vals).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_alp_mixed_exceptions() {
+        // 90% two-decimal values, 10% arbitrary doubles.
+        let vals: Vec<f64> = (0..3000usize)
+            .map(|i| {
+                if i % 10 == 3 {
+                    (i as f64).sqrt() * std::f64::consts::PI
+                } else {
+                    (i % 100_000) as f64 / 100.0
+                }
+            })
+            .collect();
+        let bits = serialize_and_check(&vals).unwrap();
+        assert!(bits < 40.0, "expected < 40 bits/value, got {bits}");
+    }
+
+    #[test]
+    fn test_alp_full_block_of_exceptions() {
+        // A whole 128-value block where no exponent round-trips, inside a
+        // column that is otherwise plain two-decimal data. The block falls
+        // back to the all-exception plan, whose 128 positions must survive
+        // the u8 position encoding and the u8 exception count.
+        let vals: Vec<f64> = (0..1024usize)
+            .map(|i| {
+                if (640..768).contains(&i) {
+                    f64::NAN
+                } else {
+                    (i % 100_000) as f64 / 100.0
+                }
+            })
+            .collect();
+        serialize_and_check(&vals).unwrap();
+    }
+
+    #[test]
+    fn test_alp_rejects_non_decimal_column() {
+        // Integer-mapped values look like garbage floats: the estimator must
+        // detect this and opt out.
+        let vals: Vec<u64> = (0..5000u64).map(|i| i * 12345 + 7).collect();
+        assert!(
+            serialize_alp(&vals).is_none(),
+            "alp must opt out of non-decimal columns"
+        );
+    }
+
+    #[test]
+    fn test_alp_rejects_full_precision_floats() {
+        let mut state = 0x9E3779B97F4A7C15u64;
+        let vals: Vec<f64> = (0..5000)
+            .map(|_| {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                (state >> 11) as f64 / (1u64 << 53) as f64 + 0.123456789123456
+            })
+            .collect();
+        let mapped: Vec<u64> = vals.iter().map(|&v| v.to_u64()).collect();
+        assert!(
+            serialize_alp(&mapped).is_none(),
+            "alp must opt out of full-precision floats"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "get_range out of bounds")]
+    fn test_alp_get_range_rejects_padding() {
+        let vals: Vec<u64> = (0..5u64).map(|i| (i as f64 / 100.0).to_u64()).collect();
+        let buffer = serialize_alp(&vals).unwrap();
+        let reader = AlpCodec::load(OwnedBytes::new(buffer)).unwrap();
+        let mut out = [0u64; 2];
+        reader.get_range(4, &mut out);
+    }
+
+    #[test]
+    fn test_alp_empty() {
+        let vals: Vec<f64> = Vec::new();
+        serialize_and_check(&vals);
+    }
+}

--- a/columnar/src/column_values/u64_based/alp.rs
+++ b/columnar/src/column_values/u64_based/alp.rs
@@ -41,7 +41,7 @@ use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, compute_num_bits};
 
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, iter_via_blocks, min_batch_rows,
+    BLOCK_LEN, BatchThresholds, BlockDecode, DecodeCost, batch_thresholds, iter_via_blocks,
 };
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
@@ -445,8 +445,8 @@ impl ColumnValues for AlpReader {
         self.decode_range(start, output);
     }
 
-    fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Blocked)
+    fn batch_thresholds(&self) -> BatchThresholds {
+        batch_thresholds(DecodeCost::Blocked)
     }
 
     /// Worth the `Box<dyn Iterator>` here where it is not for the flat codecs:

--- a/columnar/src/column_values/u64_based/bitpacked.rs
+++ b/columnar/src/column_values/u64_based/bitpacked.rs
@@ -4,10 +4,11 @@ use std::ops::{Range, RangeInclusive};
 
 use common::{BinarySerializable, OwnedBytes};
 use fastdivide::DividerU64;
+use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
 };
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
@@ -19,9 +20,6 @@ pub struct BitpackedReader {
     data: OwnedBytes,
     bit_unpacker: BitUnpacker,
     stats: ColumnStats,
-    /// One stream-wide bit width, so this is fixed for the column and
-    /// resolved at load time (see `BlockDecode::partial_min_rows`).
-    partial_min_rows: usize,
 }
 
 #[inline(always)]
@@ -59,15 +57,11 @@ impl BlockDecode for BitpackedReader {
         self.stats.num_rows as usize / BLOCK_LEN
     }
 
-    fn partial_min_rows(&self, _block_idx: usize) -> usize {
-        self.partial_min_rows
-    }
-
     #[inline]
-    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+    fn decode_block_range(&self, block_idx: usize, in_block: usize, out: &mut [u64]) {
         let bit_width = self.bit_unpacker.bit_width();
         let byte_offset = block_idx * BLOCK_LEN * bit_width as usize / 8;
-        decode_block(bit_width, &self.data[byte_offset..], out);
+        decode_range(bit_width, in_block, &self.data[byte_offset..], out);
         let (min_value, gcd) = (self.stats.min_value, self.stats.gcd.get());
         if gcd == 1 {
             for o in out.iter_mut() {
@@ -176,7 +170,6 @@ impl ColumnCodec for BitpackedCodec {
         let num_bits = num_bits(&stats);
         let bit_unpacker = BitUnpacker::new(num_bits);
         Ok(BitpackedReader {
-            partial_min_rows: partial_block_min_rows(bit_unpacker.bit_width()),
             data,
             bit_unpacker,
             stats,

--- a/columnar/src/column_values/u64_based/bitpacked.rs
+++ b/columnar/src/column_values/u64_based/bitpacked.rs
@@ -6,6 +6,9 @@ use common::{BinarySerializable, OwnedBytes};
 use fastdivide::DividerU64;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
+use crate::column_values::u64_based::block_decode::{
+    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+};
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
 
@@ -16,6 +19,9 @@ pub struct BitpackedReader {
     data: OwnedBytes,
     bit_unpacker: BitUnpacker,
     stats: ColumnStats,
+    /// One stream-wide bit width, so this is fixed for the column and
+    /// resolved at load time (see `BlockDecode::partial_min_rows`).
+    partial_min_rows: usize,
 }
 
 #[inline(always)]
@@ -48,19 +54,57 @@ fn transform_range_before_linear_transformation(
     Some(start_before_gcd_multiplication..=end_before_gcd_multiplication)
 }
 
+impl BlockDecode for BitpackedReader {
+    fn num_full_blocks(&self) -> usize {
+        self.stats.num_rows as usize / BLOCK_LEN
+    }
+
+    fn partial_min_rows(&self, _block_idx: usize) -> usize {
+        self.partial_min_rows
+    }
+
+    #[inline]
+    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+        let bit_width = self.bit_unpacker.bit_width();
+        let byte_offset = block_idx * BLOCK_LEN * bit_width as usize / 8;
+        decode_block(bit_width, &self.data[byte_offset..], out);
+        let (min_value, gcd) = (self.stats.min_value, self.stats.gcd.get());
+        if gcd == 1 {
+            for o in out.iter_mut() {
+                *o += min_value;
+            }
+        } else {
+            for o in out.iter_mut() {
+                *o = min_value + gcd * *o;
+            }
+        }
+    }
+}
+
 impl ColumnValues for BitpackedReader {
     #[inline(always)]
     fn get_val(&self, doc: u32) -> u64 {
         self.stats.min_value + self.stats.gcd.get() * self.bit_unpacker.get(doc, &self.data)
     }
+
+    fn get_range(&self, start: u64, output: &mut [u64]) {
+        self.decode_range(start, output);
+    }
+
+    fn min_batch_rows(&self) -> usize {
+        min_batch_rows(DecodeCost::Flat)
+    }
+
     #[inline]
     fn min_value(&self) -> u64 {
         self.stats.min_value
     }
+
     #[inline]
     fn max_value(&self) -> u64 {
         self.stats.max_value
     }
+
     #[inline]
     fn num_vals(&self) -> RowId {
         self.stats.num_rows
@@ -132,6 +176,7 @@ impl ColumnCodec for BitpackedCodec {
         let num_bits = num_bits(&stats);
         let bit_unpacker = BitUnpacker::new(num_bits);
         Ok(BitpackedReader {
+            partial_min_rows: partial_block_min_rows(bit_unpacker.bit_width()),
             data,
             bit_unpacker,
             stats,
@@ -162,6 +207,125 @@ mod tests {
             data.reverse();
             create_and_validate::<BitpackedCodec>(&data, name);
         }
+    }
+
+    /// Every bit width, every offset class: batch `get_range` and `iter` must
+    /// agree with the per-value `get_val` they replace.
+    #[test]
+    fn test_bitpacked_batch_decode_all_widths() {
+        for w in 0..=64u32 {
+            let max = if w == 64 { u64::MAX } else { (1u64 << w) - 1 };
+            // Lengths around block boundaries: no full block, exact multiples,
+            // and partial trailing blocks.
+            for num_vals in [1usize, 127, 128, 129, 255, 256, 300, 512, 517] {
+                let vals: Vec<u64> = (0..num_vals as u64)
+                    .map(|i| i.wrapping_mul(0x9E3779B97F4A7C15) & max)
+                    .collect();
+                let mut buffer = Vec::new();
+                let stats = {
+                    let mut collector = crate::column_values::u64_based::StatsCollector::default();
+                    for &v in &vals {
+                        collector.collect(v);
+                    }
+                    collector.stats()
+                };
+                BitpackedCodecEstimator
+                    .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+                    .unwrap();
+                let reader = BitpackedCodec::load(OwnedBytes::new(buffer)).unwrap();
+
+                let mut out = vec![0u64; num_vals];
+                reader.get_range(0, &mut out);
+                assert_eq!(out, vals, "get_range(0) w={w} n={num_vals}");
+
+                // Every start offset in the first two blocks plus the tail,
+                // so the entrance ramp and the partial-block exit both run.
+                for &start in &[1usize, 7, 63, 127, 128, 129, 200] {
+                    if start >= num_vals {
+                        continue;
+                    }
+                    let mut out = vec![0u64; num_vals - start];
+                    reader.get_range(start as u64, &mut out);
+                    assert_eq!(out, vals[start..], "get_range({start}) w={w} n={num_vals}");
+                    // Short ranges that end inside a full block.
+                    let short = (num_vals - start).min(5);
+                    let mut out = vec![0u64; short];
+                    reader.get_range(start as u64, &mut out);
+                    assert_eq!(
+                        out,
+                        vals[start..start + short],
+                        "get_range({start}, {short}) w={w} n={num_vals}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The gcd transformation must survive the batch path, including the
+    /// trailing partial block that stays per-value.
+    #[test]
+    fn test_bitpacked_batch_decode_gcd() {
+        let vals: Vec<u64> = (0..1000u64).map(|i| 5_000 + i * 1_000).collect();
+        let mut buffer = Vec::new();
+        let stats = {
+            let mut collector = crate::column_values::u64_based::StatsCollector::default();
+            for &v in &vals {
+                collector.collect(v);
+            }
+            collector.stats()
+        };
+        assert!(stats.gcd.get() > 1, "test needs a gcd column");
+        BitpackedCodecEstimator
+            .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+            .unwrap();
+        let reader = BitpackedCodec::load(OwnedBytes::new(buffer)).unwrap();
+        let mut out = vec![0u64; vals.len()];
+        reader.get_range(0, &mut out);
+        assert_eq!(out, vals);
+        // A range that starts in a full block and ends in the partial one.
+        let mut out = vec![0u64; vals.len() - 900];
+        reader.get_range(900, &mut out);
+        assert_eq!(out, vals[900..]);
+    }
+
+    /// The monotonic wrapper forwards `get_range` on two paths (in-place when
+    /// the mapping is type-preserving, buffered otherwise). Exercise both
+    /// through the public load path.
+    #[test]
+    fn test_bitpacked_wrapped_get_range() {
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+
+        let vals: Vec<u64> = (0..5000u64).map(|i| i * 3 + (i % 17)).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buffer)
+            .unwrap();
+        let col = load_u64_based_column_values::<u64>(OwnedBytes::new(buffer)).unwrap();
+        let mut out = vec![0u64; 3000];
+        col.get_range(137, &mut out);
+        assert_eq!(&vals[137..137 + 3000], &out[..]);
+        let mut out = vec![0u64; 5000];
+        col.get_range(0, &mut out);
+        assert_eq!(&vals[..], &out[..]);
+        // Ends inside the trailing partial block.
+        let mut out = vec![0u64; 200];
+        col.get_range(4800, &mut out);
+        assert_eq!(&vals[4800..], &out[..]);
+        // Short ranges go through the fused per-value path.
+        let mut out = vec![0u64; 5];
+        col.get_range(4990, &mut out);
+        assert_eq!(&vals[4990..4995], &out[..]);
+
+        // f64 takes the buffered path (Input u64 != Output f64).
+        let vals: Vec<f64> = (0..3000u64).map(|i| (i as f64) * 0.25 - 100.0).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::Bitpacked], &mut buffer)
+            .unwrap();
+        let col = load_u64_based_column_values::<f64>(OwnedBytes::new(buffer)).unwrap();
+        let mut out = vec![0f64; 2000];
+        col.get_range(11, &mut out);
+        assert_eq!(&vals[11..11 + 2000], &out[..]);
     }
 
     #[test]

--- a/columnar/src/column_values/u64_based/bitpacked.rs
+++ b/columnar/src/column_values/u64_based/bitpacked.rs
@@ -8,7 +8,7 @@ use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
+    BLOCK_LEN, BatchThresholds, BlockDecode, DecodeCost, batch_thresholds,
 };
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
@@ -85,8 +85,8 @@ impl ColumnValues for BitpackedReader {
         self.decode_range(start, output);
     }
 
-    fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Flat)
+    fn batch_thresholds(&self) -> BatchThresholds {
+        batch_thresholds(DecodeCost::Flat)
     }
 
     #[inline]

--- a/columnar/src/column_values/u64_based/block_decode.rs
+++ b/columnar/src/column_values/u64_based/block_decode.rs
@@ -1,0 +1,139 @@
+//! Block-decode policy for the u64 codecs: when a `get_range` is worth routing
+//! through whole-block unpacking, and the loop that drives it.
+//!
+//! The unpack kernels live in `tantivy_bitpacker::block_decode`. Everything
+//! below is about *whether* to call them, which is a columnar-side question
+//! because it depends on how expensive each codec's `get_val` is.
+
+pub(crate) use tantivy_bitpacker::block_decode::{
+    BLOCK_LEN, decode_block, simd_enabled, simd_kernel_applies,
+};
+
+/// Minimum rows a range must take from a *partial* block before whole-block
+/// decode + copy beats the per-value unpacker.
+///
+/// A partial-block decode costs a fixed amount regardless of how few rows the
+/// range needs; without this floor a 1-row range pays for 128 decoded values.
+#[inline]
+pub(crate) fn partial_block_min_rows(bit_width: u8) -> usize {
+    match bit_width as usize {
+        0 | 64 => 48,
+        w if simd_kernel_applies(w as u8) => 48,
+        _ => 80,
+    }
+}
+
+/// How expensive a codec's `get_val` is, which is what decides where its
+/// batch `get_range` starts beating a per-value loop. See [`min_batch_rows`].
+#[derive(Clone, Copy)]
+pub(crate) enum DecodeCost {
+    /// One bitpacked residual stream (`Bitpacked`, `Linear`, `BlockwiseLinear`):
+    /// `get_val` is a load, shift and mask, so the loop stays competitive for
+    /// a long time.
+    Flat,
+}
+
+/// Minimum rows a whole `get_range` call must cover before routing it through
+/// [`get_range_via_blocks`] beats a plain `get_val` loop over the same rows --
+/// the value these codecs report from [`crate::ColumnValues::min_batch_rows`].
+///
+/// Distinct from [`partial_block_min_rows`], which decides per *block* whether
+/// to decode one; this decides whether the call is worth batching at all.
+/// Calibrated with the `gate_sweep` ignored test in `monotonic_column`, which
+/// A/Bs both arms in one process over the concrete readers. Both thresholds
+/// sit further out without the SIMD kernel, which only the batch side uses.
+#[inline]
+pub(crate) fn min_batch_rows(cost: DecodeCost) -> usize {
+    match (cost, simd_enabled()) {
+        (DecodeCost::Flat, true) => 96,
+        (DecodeCost::Flat, false) => 128,
+    }
+}
+
+/// A codec that decodes whole 128-value blocks, already mapped to final
+/// column values. The three required methods are everything
+/// [`get_range_via_blocks`] needs that differs between codecs, so the codecs
+/// cannot drift apart in how they drive the block loop.
+pub(crate) trait BlockDecode: crate::ColumnValues<u64> {
+    /// Decodes the 128 rows of `block_idx`, already mapped to column values.
+    ///
+    /// Only called for blocks reported by [`Self::num_full_blocks`].
+    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]);
+
+    /// Number of leading blocks whose 128 slots are all present in the packed
+    /// stream. Columns are not padded to a block boundary, so the trailing
+    /// partial block has no bytes for its missing slots and is served by
+    /// `get_val` instead.
+    fn num_full_blocks(&self) -> usize;
+
+    /// This block's [`partial_block_min_rows`]. Called once per block touched,
+    /// so codecs with a single stream-wide bit width should resolve it at load
+    /// time rather than recompute it here.
+    fn partial_min_rows(&self, block_idx: usize) -> usize;
+
+    /// Batched [`crate::ColumnValues::get_range`]. See [`get_range_via_blocks`].
+    #[inline]
+    fn decode_range(&self, start: u64, output: &mut [u64]) {
+        get_range_via_blocks(
+            start,
+            output,
+            self.num_full_blocks(),
+            |block_idx| self.partial_min_rows(block_idx),
+            |block_idx, out| self.decode_block_mapped(block_idx, out),
+            |row| self.get_val(row),
+        );
+    }
+}
+
+/// Drives a codec's whole-block decode for [`crate::ColumnValues::get_range`].
+///
+/// Rows in full 128-value blocks go through `decode_block_mapped(block_idx,
+/// out)`, which must produce final column values. A range boundary inside a
+/// block goes through a stack buffer when the range takes at least
+/// `partial_min_rows(block_idx)` rows from that block (see
+/// [`partial_block_min_rows`]); fewer rows, rows at or past `num_full_blocks *
+/// BLOCK_LEN` (the trailing partial block, whose missing slots have no bytes
+/// in the packed stream), and everything past it use `get_val(row)`.
+#[inline]
+pub(crate) fn get_range_via_blocks(
+    start: u64,
+    output: &mut [u64],
+    num_full_blocks: usize,
+    mut partial_min_rows: impl FnMut(usize) -> usize,
+    mut decode_block_mapped: impl FnMut(usize, &mut [u64; BLOCK_LEN]),
+    mut get_val: impl FnMut(u32) -> u64,
+) {
+    let first_row = start as usize;
+    let end_row = first_row + output.len();
+
+    let mut row = first_row;
+    let mut out_offset = 0usize;
+    while row < end_row {
+        let block_idx = row / BLOCK_LEN;
+        let in_block = row % BLOCK_LEN;
+        let take = (BLOCK_LEN - in_block).min(end_row - row);
+        if block_idx >= num_full_blocks {
+            break;
+        }
+        if take == BLOCK_LEN {
+            let out: &mut [u64; BLOCK_LEN] = (&mut output[out_offset..out_offset + BLOCK_LEN])
+                .try_into()
+                .unwrap();
+            decode_block_mapped(block_idx, out);
+        } else if take >= partial_min_rows(block_idx) {
+            let mut buf = [0u64; BLOCK_LEN];
+            decode_block_mapped(block_idx, &mut buf);
+            output[out_offset..out_offset + take].copy_from_slice(&buf[in_block..in_block + take]);
+        } else {
+            for (i, o) in output[out_offset..out_offset + take].iter_mut().enumerate() {
+                *o = get_val((row + i) as u32);
+            }
+        }
+        row += take;
+        out_offset += take;
+    }
+    // Trailing partial block (and everything past it).
+    for (i, o) in output[out_offset..].iter_mut().enumerate() {
+        *o = get_val((row + i) as u32);
+    }
+}

--- a/columnar/src/column_values/u64_based/block_decode.rs
+++ b/columnar/src/column_values/u64_based/block_decode.rs
@@ -1,98 +1,84 @@
 //! Block-decode policy for the u64 codecs: when a `get_range` is worth routing
-//! through whole-block unpacking, and the loop that drives it.
+//! through the batch unpacker, and the loop that drives it.
 //!
 //! The unpack kernels live in `tantivy_bitpacker::block_decode`. Everything
 //! below is about *whether* to call them, which is a columnar-side question
 //! because it depends on how expensive each codec's `get_val` is.
 
-pub(crate) use tantivy_bitpacker::block_decode::{
-    BLOCK_LEN, decode_block, simd_enabled, simd_kernel_applies,
-};
+use tantivy_bitpacker::block_decode::simd_enabled;
 
-/// Minimum rows a range must take from a *partial* block before whole-block
-/// decode + copy beats the per-value unpacker.
-///
-/// A partial-block decode costs a fixed amount regardless of how few rows the
-/// range needs; without this floor a 1-row range pays for 128 decoded values.
-#[inline]
-pub(crate) fn partial_block_min_rows(bit_width: u8) -> usize {
-    match bit_width as usize {
-        0 | 64 => 48,
-        w if simd_kernel_applies(w as u8) => 48,
-        _ => 80,
-    }
-}
+pub(crate) use tantivy_bitpacker::block_decode::BLOCK_LEN;
 
-/// How expensive a codec's `get_val` is, which is what decides where its
-/// batch `get_range` starts beating a per-value loop. See [`min_batch_rows`].
+/// How much of a codec's per-value work the batch arm *also* pays
 #[derive(Clone, Copy)]
 pub(crate) enum DecodeCost {
-    /// One bitpacked residual stream (`Bitpacked`, `Linear`, `BlockwiseLinear`):
-    /// `get_val` is a load, shift and mask, so the loop stays competitive for
-    /// a long time.
+    /// `Bitpacked`: batch applies the mapping as a flat add/multiply.
     Flat,
-    /// Per-block metadata re-read on every `get_val` (`BlockFor`, `Alp`), so
-    /// the loop falls behind sooner.
+    /// `Linear`: as `Flat`, plus a line eval per row that both arms pay.
+    Interpolated,
+    /// `BlockFor`, `Alp`, `BlockwiseLinear`: `get_val` re-reads per-block
+    /// metadata per row, which the batch arm hoists out of the loop.
     Blocked,
 }
 
-/// Minimum rows a whole `get_range` call must cover before routing it through
-/// [`get_range_via_blocks`] beats a plain `get_val` loop over the same rows --
-/// the value these codecs report from [`crate::ColumnValues::min_batch_rows`].
-///
-/// Distinct from [`partial_block_min_rows`], which decides per *block* whether
-/// to decode one; this decides whether the call is worth batching at all.
-/// Calibrated with the `gate_sweep` ignored test in `monotonic_column`, which
-/// A/Bs both arms in one process over the concrete readers. Both thresholds
-/// sit further out without the SIMD kernel, which only the batch side uses.
+/// Rows a whole `get_range` call must cover before batching it beats a `get_val` loop;
 #[inline]
 pub(crate) fn min_batch_rows(cost: DecodeCost) -> usize {
     match (cost, simd_enabled()) {
-        (DecodeCost::Flat, true) => 96,
-        (DecodeCost::Flat, false) => 128,
-        (DecodeCost::Blocked, true) => 48,
-        (DecodeCost::Blocked, false) => 96,
+        (DecodeCost::Flat, true) => 32,
+        (DecodeCost::Flat, false) => 64,
+        (DecodeCost::Interpolated, true) => 64,
+        (DecodeCost::Interpolated, false) => usize::MAX,
+        (DecodeCost::Blocked, _) => 16,
     }
 }
 
-/// A codec that decodes whole 128-value blocks, already mapped to final
-/// column values. The three required methods are everything
-/// [`get_range_via_blocks`] needs that differs between codecs, so the codecs
-/// cannot drift apart in how they drive the block loop.
+/// A codec that decodes runs of packed values, already mapped to final column
+/// values. The two required methods are everything [`Self::decode_range`]
+/// needs that differs between codecs, so the codecs cannot drift apart in how
+/// they drive the loop.
 pub(crate) trait BlockDecode: crate::ColumnValues<u64> {
-    /// Decodes the 128 rows of `block_idx`, already mapped to column values.
+    /// Decodes `out.len()` rows from `block_idx * BLOCK_LEN + in_block`,
+    /// already mapped to column values.
     ///
-    /// Only called for blocks reported by [`Self::num_full_blocks`].
-    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]);
+    /// Callers guarantee `in_block + out.len() <= BLOCK_LEN` and `block_idx <
+    /// num_full_blocks()`, so every slot asked for is in the packed stream.
+    fn decode_block_range(&self, block_idx: usize, in_block: usize, out: &mut [u64]);
 
-    /// Number of leading blocks whose 128 slots are all present in the packed
-    /// stream. Columns are not padded to a block boundary, so the trailing
-    /// partial block has no bytes for its missing slots and is served by
-    /// `get_val` instead.
+    /// Leading blocks whose 128 slots are all present in the packed stream.
+    /// Columns are not padded to a block boundary, so the trailing partial
+    /// block has no bytes for its missing slots.
     fn num_full_blocks(&self) -> usize;
 
-    /// This block's [`partial_block_min_rows`]. Called once per block touched,
-    /// so codecs with a single stream-wide bit width should resolve it at load
-    /// time rather than recompute it here.
-    fn partial_min_rows(&self, block_idx: usize) -> usize;
-
-    /// Batched [`crate::ColumnValues::get_range`]. See [`get_range_via_blocks`].
+    /// Batched [`crate::ColumnValues::get_range`].
     #[inline]
     fn decode_range(&self, start: u64, output: &mut [u64]) {
-        get_range_via_blocks(
-            start,
-            output,
-            self.num_full_blocks(),
-            |block_idx| self.partial_min_rows(block_idx),
-            |block_idx, out| self.decode_block_mapped(block_idx, out),
-            |row| self.get_val(row),
-        );
+        let mut row = start as usize;
+        let packed_rows = self.num_full_blocks() * BLOCK_LEN;
+        let head_len = output.len().min(packed_rows.saturating_sub(row));
+        let (mut head, tail) = output.split_at_mut(head_len);
+        while !head.is_empty() {
+            let in_block = row % BLOCK_LEN;
+            let take = (BLOCK_LEN - in_block).min(head.len());
+            let (chunk, rest) = head.split_at_mut(take);
+            self.decode_block_range(row / BLOCK_LEN, in_block, chunk);
+            row += take;
+            head = rest;
+        }
+        self.fill_per_value(row, tail);
+    }
+
+    /// Fallback for the trailing partial block, whose missing slots have no
+    /// bytes in the packed stream. Not meant to be overridden.
+    #[inline]
+    fn fill_per_value(&self, first_row: usize, output: &mut [u64]) {
+        for (i, o) in output.iter_mut().enumerate() {
+            *o = self.get_val((first_row + i) as u32);
+        }
     }
 }
 
-/// Block-at-a-time [`crate::ColumnValues::iter`]. Opt in only when measured:
-/// every `next()` is a virtual call into a flat_map state machine, so this
-/// only beats the default `(0..n).map(get_val)` when `get_val` is expensive.
+/// This only beats the default `(0..n).map(get_val)` when `get_val` is expensive.
 /// Requires padded streams (every block fully decodable).
 pub(crate) fn iter_via_blocks<'a, C: BlockDecode + ?Sized>(
     column: &'a C,
@@ -103,62 +89,9 @@ pub(crate) fn iter_via_blocks<'a, C: BlockDecode + ?Sized>(
         (0..num_blocks)
             .flat_map(move |block_idx| {
                 let mut buf = [0u64; BLOCK_LEN];
-                column.decode_block_mapped(block_idx, &mut buf);
+                column.decode_block_range(block_idx, 0, &mut buf);
                 buf.into_iter()
             })
             .take(num_rows),
     )
-}
-
-/// Drives a codec's whole-block decode for [`crate::ColumnValues::get_range`].
-///
-/// Rows in full 128-value blocks go through `decode_block_mapped(block_idx,
-/// out)`, which must produce final column values. A range boundary inside a
-/// block goes through a stack buffer when the range takes at least
-/// `partial_min_rows(block_idx)` rows from that block (see
-/// [`partial_block_min_rows`]); fewer rows, rows at or past `num_full_blocks *
-/// BLOCK_LEN` (the trailing partial block, whose missing slots have no bytes
-/// in the packed stream), and everything past it use `get_val(row)`.
-#[inline]
-pub(crate) fn get_range_via_blocks(
-    start: u64,
-    output: &mut [u64],
-    num_full_blocks: usize,
-    mut partial_min_rows: impl FnMut(usize) -> usize,
-    mut decode_block_mapped: impl FnMut(usize, &mut [u64; BLOCK_LEN]),
-    mut get_val: impl FnMut(u32) -> u64,
-) {
-    let first_row = start as usize;
-    let end_row = first_row + output.len();
-
-    let mut row = first_row;
-    let mut out_offset = 0usize;
-    while row < end_row {
-        let block_idx = row / BLOCK_LEN;
-        let in_block = row % BLOCK_LEN;
-        let take = (BLOCK_LEN - in_block).min(end_row - row);
-        if block_idx >= num_full_blocks {
-            break;
-        }
-        if take == BLOCK_LEN {
-            let out: &mut [u64; BLOCK_LEN] = (&mut output[out_offset..out_offset + BLOCK_LEN])
-                .try_into()
-                .unwrap();
-            decode_block_mapped(block_idx, out);
-        } else if take >= partial_min_rows(block_idx) {
-            let mut buf = [0u64; BLOCK_LEN];
-            decode_block_mapped(block_idx, &mut buf);
-            output[out_offset..out_offset + take].copy_from_slice(&buf[in_block..in_block + take]);
-        } else {
-            for (i, o) in output[out_offset..out_offset + take].iter_mut().enumerate() {
-                *o = get_val((row + i) as u32);
-            }
-        }
-        row += take;
-        out_offset += take;
-    }
-    // Trailing partial block (and everything past it).
-    for (i, o) in output[out_offset..].iter_mut().enumerate() {
-        *o = get_val((row + i) as u32);
-    }
 }

--- a/columnar/src/column_values/u64_based/block_decode.rs
+++ b/columnar/src/column_values/u64_based/block_decode.rs
@@ -9,6 +9,8 @@ use tantivy_bitpacker::block_decode::simd_enabled;
 
 pub(crate) use tantivy_bitpacker::block_decode::BLOCK_LEN;
 
+pub(crate) use crate::column_values::BatchThresholds;
+
 /// How much of a codec's per-value work the batch arm *also* pays
 #[derive(Clone, Copy)]
 pub(crate) enum DecodeCost {
@@ -16,20 +18,32 @@ pub(crate) enum DecodeCost {
     Flat,
     /// `Linear`: as `Flat`, plus a line eval per row that both arms pay.
     Interpolated,
-    /// `BlockFor`, `Alp`, `BlockwiseLinear`: `get_val` re-reads per-block
-    /// metadata per row, which the batch arm hoists out of the loop.
+    /// `BlockFor`, `Alp`: `get_val` re-reads per-block metadata per row,
+    /// which the batch arm hoists out of the loop. That hoist is most of the
+    /// win, so these cross over after only a handful of rows.
     Blocked,
+    /// `BlockwiseLinear`: hoists per-block metadata like [`Self::Blocked`],
+    /// but also evaluates a line per row that *both* arms pay, which dilutes
+    /// the hoist and pushes the crossover out.
+    BlockedInterpolated,
 }
 
-/// Rows a whole `get_range` call must cover before batching it beats a `get_val` loop;
+/// Rows a whole `get_range` call must cover before batching it beats a
+/// `get_val` loop, per arm of `MonotonicMappingColumn::get_range`.
 #[inline]
-pub(crate) fn min_batch_rows(cost: DecodeCost) -> usize {
-    match (cost, simd_enabled()) {
-        (DecodeCost::Flat, true) => 32,
-        (DecodeCost::Flat, false) => 64,
-        (DecodeCost::Interpolated, true) => 64,
-        (DecodeCost::Interpolated, false) => usize::MAX,
-        (DecodeCost::Blocked, _) => 16,
+pub(crate) fn batch_thresholds(cost: DecodeCost) -> BatchThresholds {
+    let (forwarding, buffered) = match (cost, simd_enabled()) {
+        (DecodeCost::Flat, true) => (32, 64),
+        (DecodeCost::Flat, false) => (32, 96),
+        (DecodeCost::Interpolated, true) => (64, 256),
+        (DecodeCost::Interpolated, false) => (usize::MAX, usize::MAX),
+        (DecodeCost::Blocked, _) => (4, 16),
+        (DecodeCost::BlockedInterpolated, true) => (16, 32),
+        (DecodeCost::BlockedInterpolated, false) => (16, 64),
+    };
+    BatchThresholds {
+        forwarding,
+        buffered,
     }
 }
 

--- a/columnar/src/column_values/u64_based/block_decode.rs
+++ b/columnar/src/column_values/u64_based/block_decode.rs
@@ -90,6 +90,26 @@ pub(crate) trait BlockDecode: crate::ColumnValues<u64> {
     }
 }
 
+/// Block-at-a-time [`crate::ColumnValues::iter`]. Opt in only when measured:
+/// every `next()` is a virtual call into a flat_map state machine, so this
+/// only beats the default `(0..n).map(get_val)` when `get_val` is expensive.
+/// Requires padded streams (every block fully decodable).
+pub(crate) fn iter_via_blocks<'a, C: BlockDecode + ?Sized>(
+    column: &'a C,
+    num_rows: usize,
+) -> Box<dyn Iterator<Item = u64> + 'a> {
+    let num_blocks = num_rows.div_ceil(BLOCK_LEN);
+    Box::new(
+        (0..num_blocks)
+            .flat_map(move |block_idx| {
+                let mut buf = [0u64; BLOCK_LEN];
+                column.decode_block_mapped(block_idx, &mut buf);
+                buf.into_iter()
+            })
+            .take(num_rows),
+    )
+}
+
 /// Drives a codec's whole-block decode for [`crate::ColumnValues::get_range`].
 ///
 /// Rows in full 128-value blocks go through `decode_block_mapped(block_idx,

--- a/columnar/src/column_values/u64_based/block_decode.rs
+++ b/columnar/src/column_values/u64_based/block_decode.rs
@@ -31,6 +31,9 @@ pub(crate) enum DecodeCost {
     /// `get_val` is a load, shift and mask, so the loop stays competitive for
     /// a long time.
     Flat,
+    /// Per-block metadata re-read on every `get_val` (`BlockFor`, `Alp`), so
+    /// the loop falls behind sooner.
+    Blocked,
 }
 
 /// Minimum rows a whole `get_range` call must cover before routing it through
@@ -47,6 +50,8 @@ pub(crate) fn min_batch_rows(cost: DecodeCost) -> usize {
     match (cost, simd_enabled()) {
         (DecodeCost::Flat, true) => 96,
         (DecodeCost::Flat, false) => 128,
+        (DecodeCost::Blocked, true) => 48,
+        (DecodeCost::Blocked, false) => 96,
     }
 }
 

--- a/columnar/src/column_values/u64_based/block_for.rs
+++ b/columnar/src/column_values/u64_based/block_for.rs
@@ -26,7 +26,7 @@ use fastdivide::DividerU64;
 use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, compute_num_bits};
 
-use super::block_decode::{BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows};
+use super::block_decode::{BLOCK_LEN, BatchThresholds, BlockDecode, DecodeCost, batch_thresholds};
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
 
@@ -247,8 +247,8 @@ impl ColumnValues for BlockForReader {
         self.decode_range(start, output)
     }
 
-    fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Blocked)
+    fn batch_thresholds(&self) -> BatchThresholds {
+        batch_thresholds(DecodeCost::Blocked)
     }
 }
 

--- a/columnar/src/column_values/u64_based/block_for.rs
+++ b/columnar/src/column_values/u64_based/block_for.rs
@@ -1,0 +1,667 @@
+//! Per-block Frame-of-Reference codec ("BlockFor").
+//!
+//! Values are normalized like in `Bitpacked` (`v' = (v - column_min) / gcd`)
+//! and cut into blocks of 128. Each block stores its own minimum and bit
+//! width, so outliers or a drifting baseline only inflate the blocks they
+//! live in.
+//!
+//! ## Layout
+//!
+//! ```text
+//! [ColumnStats]
+//! [block 0 packed values][block 1 packed values]...   // 16 * bit_width bytes each
+//! [block records: num_blocks * stride bits]           // (offset, bit_width, block_min)
+//! [16 zero bytes]
+//! [offset_bit_width: u8][width_bit_width: u8][min_bit_width: u8]
+//! [footer_len: u32 LE]
+//! ```
+//!
+//! Blocks are padded to exactly 128 slots: always `16 * bit_width` bytes,
+//! byte aligned, independently decodable by the shared block kernels.
+//!
+use std::io::{self, Write};
+
+use common::{BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes};
+use fastdivide::DividerU64;
+use tantivy_bitpacker::{BitPacker, compute_num_bits};
+
+use super::block_decode::{
+    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+};
+use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
+use crate::{ColumnValues, RowId};
+
+/// Zero bytes written after the block records.
+///
+/// [`BlockForReader::block_meta`] reads each of a record's two halves with an
+/// unaligned 8-byte load and masks; the padding is what keeps those in bounds
+/// for the last blocks of every column, so neither read needs a length check
+/// of its own.
+const FOOTER_PAD: usize = 16;
+
+/// Mask of the low `num_bits`, for widths up to and including 64.
+#[inline(always)]
+fn low_mask(num_bits: u8) -> u64 {
+    if num_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << num_bits) - 1
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BlockMeta {
+    start_byte_offset: u64,
+    /// The block's minimum, normalized as `(v - column_min) / gcd`. Left
+    /// normalized so a slot's value is `column_min + gcd * (block_min + slot)`
+    /// -- one multiply per value, and a hoistable base per block.
+    block_min: u64,
+    bit_width: u8,
+}
+
+#[derive(Clone, Copy)]
+struct RecordLayout {
+    /// Bytes per record.
+    stride: usize,
+    offset_mask: u64,
+    width_shift: u32,
+    width_mask: u64,
+    /// Byte offset of the minimum inside the record.
+    min_byte: usize,
+    min_mask: u64,
+}
+
+impl RecordLayout {
+    fn new(offset_bits: u8, width_bits: u8, min_bits: u8) -> RecordLayout {
+        let head_bytes = (offset_bits as usize + width_bits as usize).div_ceil(8);
+        RecordLayout {
+            stride: head_bytes + (min_bits as usize).div_ceil(8),
+            offset_mask: low_mask(offset_bits),
+            width_shift: offset_bits as u32,
+            width_mask: low_mask(width_bits),
+            min_byte: head_bytes,
+            min_mask: low_mask(min_bits),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BlockForReader {
+    data: OwnedBytes,
+    meta: OwnedBytes,
+    layout: RecordLayout,
+    num_blocks: usize,
+    gcd: u64,
+    stats: ColumnStats,
+}
+
+impl BlockForReader {
+    #[inline(always)]
+    fn block_meta(&self, block_idx: usize) -> BlockMeta {
+        let record = block_idx * self.layout.stride;
+        let head = u64::from_le_bytes(self.meta[record..record + 8].try_into().unwrap());
+        let start_units = head & self.layout.offset_mask;
+        let bit_width = (head >> self.layout.width_shift) & self.layout.width_mask;
+        let min_at = record + self.layout.min_byte;
+        let block_min = u64::from_le_bytes(self.meta[min_at..min_at + 8].try_into().unwrap())
+            & self.layout.min_mask;
+        BlockMeta {
+            start_byte_offset: start_units * 16,
+            block_min,
+            bit_width: bit_width as u8,
+        }
+    }
+
+    /// The value a `0` slot of this block maps to.
+    #[inline(always)]
+    fn base(&self, meta: &BlockMeta) -> u64 {
+        self.stats.min_value + self.gcd * meta.block_min
+    }
+
+    /// The `bit_width`-bit slot `slot` of the block at `start_byte_offset`,
+    /// still normalized. Reading 8 bytes needs no bounds handling of its own
+    /// because `data` runs to the end of the column rather than stopping at
+    /// the last block.
+    #[inline(always)]
+    fn slot(&self, meta: &BlockMeta, slot: u32) -> u64 {
+        // `bit_width` is 0..=56 or 64 (`compute_num_bits`), and at 64 the bit
+        // offset is a whole number of bytes, so the shift below never drops
+        // bits off the top of the 8 loaded.
+        let bit = slot as usize * meta.bit_width as usize;
+        let byte = meta.start_byte_offset as usize + bit / 8;
+        let raw = u64::from_le_bytes(self.data[byte..byte + 8].try_into().unwrap());
+        (raw >> (bit % 8)) & low_mask(meta.bit_width)
+    }
+}
+
+impl BlockDecode for BlockForReader {
+    fn num_full_blocks(&self) -> usize {
+        self.num_blocks
+    }
+
+    #[inline]
+    fn partial_min_rows(&self, block_idx: usize) -> usize {
+        partial_block_min_rows(self.block_meta(block_idx).bit_width)
+    }
+
+    #[inline]
+    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+        let meta = self.block_meta(block_idx);
+        decode_block(
+            meta.bit_width,
+            &self.data[meta.start_byte_offset as usize..],
+            out,
+        );
+        let base = self.base(&meta);
+        if self.gcd == 1 {
+            for o in out.iter_mut() {
+                *o += base;
+            }
+        } else {
+            for o in out.iter_mut() {
+                *o = base + self.gcd * *o;
+            }
+        }
+    }
+}
+
+impl ColumnValues for BlockForReader {
+    #[inline(always)]
+    fn get_vals(self: &BlockForReader, indexes: &[u32], out: &mut [u64]) {
+        let mut i: usize = 0;
+        while i < indexes.len() {
+            let block_idx = indexes[i] as usize / BLOCK_LEN;
+            let j = i + indexes[i..].partition_point(|&idx| idx as usize / BLOCK_LEN <= block_idx);
+            let meta = self.block_meta(block_idx);
+            let base = self.base(&meta);
+            for (k, &idx) in indexes[i..j].iter().enumerate() {
+                out[i + k] = base + self.gcd * self.slot(&meta, idx % BLOCK_LEN as u32);
+            }
+            i = j;
+        }
+    }
+
+    #[inline(always)]
+    fn get_val(self: &BlockForReader, idx: u32) -> u64 {
+        let meta = self.block_meta(idx as usize / BLOCK_LEN);
+        let slot = self.slot(&meta, idx % BLOCK_LEN as u32);
+        self.stats.min_value + self.gcd * (meta.block_min + slot)
+    }
+
+    #[inline]
+    fn min_value(&self) -> u64 {
+        self.stats.min_value
+    }
+
+    #[inline]
+    fn max_value(&self) -> u64 {
+        self.stats.max_value
+    }
+
+    #[inline]
+    fn num_vals(&self) -> RowId {
+        self.stats.num_rows
+    }
+
+    fn get_row_ids_for_value_range(
+        &self,
+        value_range: std::ops::RangeInclusive<u64>,
+        row_id_range: std::ops::Range<u32>,
+        row_id_hits: &mut Vec<u32>,
+    ) {
+        let end = row_id_range.end.min(self.num_vals());
+        let start = row_id_range.start;
+        if start >= end {
+            return;
+        }
+        let (value_lo, value_hi) = (*value_range.start(), *value_range.end());
+        let mut buf = [0u64; BLOCK_LEN];
+        let first_block = start as usize / BLOCK_LEN;
+        let last_block = (end as usize - 1) / BLOCK_LEN;
+        for block_idx in first_block..=last_block {
+            let meta = self.block_meta(block_idx);
+            let bit_width = meta.bit_width;
+            let rel_max = if bit_width >= 64 {
+                u64::MAX
+            } else {
+                (1u64 << bit_width) - 1
+            };
+            let block_min = self.base(&meta);
+            let block_max = block_min.saturating_add(self.gcd.saturating_mul(rel_max));
+            if block_min > value_hi || block_max < value_lo {
+                continue;
+            }
+            self.decode_block_mapped(block_idx, &mut buf);
+            let row_base = (block_idx * BLOCK_LEN) as u32;
+            let from = start.max(row_base) - row_base;
+            let to = end.min(row_base + BLOCK_LEN as u32) - row_base;
+            for offset in from..to {
+                let val = buf[offset as usize];
+                if value_lo <= val && val <= value_hi {
+                    row_id_hits.push(row_base + offset);
+                }
+            }
+        }
+    }
+
+    fn get_range(&self, start: u64, output: &mut [u64]) {
+        assert!(
+            start + output.len() as u64 <= u64::from(self.stats.num_rows),
+            "get_range out of bounds"
+        );
+        self.decode_range(start, output);
+    }
+
+    fn min_batch_rows(&self) -> usize {
+        min_batch_rows(DecodeCost::Blocked)
+    }
+}
+
+pub struct BlockForEstimator {
+    block: Vec<u64>,
+    block_stats: Vec<(u64, u64)>,
+}
+
+impl Default for BlockForEstimator {
+    fn default() -> Self {
+        BlockForEstimator {
+            block: Vec::with_capacity(BLOCK_LEN),
+            block_stats: Vec::new(),
+        }
+    }
+}
+
+impl BlockForEstimator {
+    fn flush_block(&mut self) {
+        if self.block.is_empty() {
+            return;
+        }
+        let min = *self.block.iter().min().unwrap();
+        let max = *self.block.iter().max().unwrap();
+        self.block_stats.push((min, max - min));
+        self.block.clear();
+    }
+}
+
+impl ColumnCodecEstimator for BlockForEstimator {
+    fn collect(&mut self, value: u64) {
+        self.block.push(value);
+        if self.block.len() == BLOCK_LEN {
+            self.flush_block();
+        }
+    }
+
+    fn finalize(&mut self) {
+        self.flush_block();
+    }
+
+    fn estimate(&self, stats: &ColumnStats) -> Option<u64> {
+        let gcd = stats.gcd.get();
+        let num_blocks = self.block_stats.len() as u64;
+        let mut total_units = 0u64;
+        let mut max_width = 0u8;
+        let mut max_block_min = 0u64;
+        for &(block_min, amplitude) in &self.block_stats {
+            let bit_width = compute_num_bits(amplitude / gcd);
+            total_units += bit_width as u64;
+            max_width = max_width.max(bit_width);
+            max_block_min = max_block_min.max((block_min - stats.min_value) / gcd);
+        }
+        Some(
+            stats.num_bytes()
+                + 16 * total_units
+                + footer_len(num_blocks, total_units, max_width, max_block_min)
+                + 4,
+        )
+    }
+
+    fn serialize(
+        &self,
+        stats: &ColumnStats,
+        vals: &mut dyn Iterator<Item = u64>,
+        wrt: &mut dyn Write,
+    ) -> io::Result<()> {
+        stats.serialize(wrt)?;
+        let gcd_divider = DividerU64::divide_by(stats.gcd.get());
+        let mut block: Vec<u64> = Vec::with_capacity(BLOCK_LEN);
+        let mut widths: Vec<u8> = Vec::with_capacity(self.block_stats.len());
+        let mut mins: Vec<u64> = Vec::with_capacity(self.block_stats.len());
+        let mut bit_packer = BitPacker::new();
+        loop {
+            block.clear();
+            block.extend((&mut *vals).take(BLOCK_LEN));
+            if block.is_empty() {
+                break;
+            }
+            for val in block.iter_mut() {
+                *val = gcd_divider.divide(*val - stats.min_value);
+            }
+            let block_min = *block.iter().min().unwrap();
+            let amplitude = *block.iter().max().unwrap() - block_min;
+            let bit_width = compute_num_bits(amplitude);
+            for &val in &block {
+                bit_packer.write(val - block_min, bit_width, wrt)?;
+            }
+
+            for _ in block.len()..BLOCK_LEN {
+                bit_packer.write(0u64, bit_width, wrt)?;
+            }
+            // 128 * bit_width bits is a multiple of 64: the packer is empty.
+            bit_packer.flush(wrt)?;
+            widths.push(bit_width);
+            mins.push(block_min);
+        }
+
+        let total_units = widths.iter().map(|&w| w as u64).sum();
+        let max_width = widths.iter().copied().max().unwrap_or(0);
+        let max_block_min = mins.iter().copied().max().unwrap_or(0);
+        let offset_bit_width = compute_num_bits(total_units);
+        let width_bit_width = compute_num_bits(max_width as u64);
+        let min_bit_width = compute_num_bits(max_block_min);
+        let mut counting_wrt = CountingWriter::wrap(wrt);
+
+        let head_bytes = (offset_bit_width as usize + width_bit_width as usize).div_ceil(8);
+        let min_bytes = (min_bit_width as usize).div_ceil(8);
+        let mut units = 0u64;
+        for (&bit_width, &block_min) in widths.iter().zip(&mins) {
+            let head = units | ((bit_width as u64) << offset_bit_width);
+            counting_wrt.write_all(&head.to_le_bytes()[..head_bytes])?;
+            counting_wrt.write_all(&block_min.to_le_bytes()[..min_bytes])?;
+            units += bit_width as u64;
+        }
+        counting_wrt.write_all(&[0u8; FOOTER_PAD])?;
+        offset_bit_width.serialize(&mut counting_wrt)?;
+        width_bit_width.serialize(&mut counting_wrt)?;
+        min_bit_width.serialize(&mut counting_wrt)?;
+        let footer_len = u32::try_from(counting_wrt.written_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "column footer exceeds u32::MAX")
+        })?;
+        debug_assert_eq!(
+            u64::from(footer_len),
+            self::footer_len(widths.len() as u64, total_units, max_width, max_block_min)
+        );
+        footer_len.serialize(&mut counting_wrt)?;
+        Ok(())
+    }
+}
+
+fn footer_len(num_blocks: u64, total_units: u64, max_width: u8, max_block_min: u64) -> u64 {
+    num_blocks
+        * RecordLayout::new(
+            compute_num_bits(total_units),
+            compute_num_bits(max_width as u64),
+            compute_num_bits(max_block_min),
+        )
+        .stride as u64
+        + FOOTER_PAD as u64
+        + 3
+}
+
+pub struct BlockForCodec;
+
+impl ColumnCodec for BlockForCodec {
+    type ColumnValues = BlockForReader;
+    type Estimator = BlockForEstimator;
+
+    fn load(mut bytes: OwnedBytes) -> io::Result<Self::ColumnValues> {
+        let stats = ColumnStats::deserialize(&mut bytes)?;
+        let footer_len: u32 = (&bytes[bytes.len() - 4..]).deserialize()?;
+        let footer_offset = bytes.len() - 4 - footer_len as usize;
+
+        let data = bytes.clone();
+        let meta = bytes.slice(footer_offset..bytes.len());
+
+        let offset_bit_width = meta[meta.len() - 7];
+        let width_bit_width = meta[meta.len() - 6];
+        let min_bit_width = meta[meta.len() - 5];
+
+        Ok(BlockForReader {
+            data,
+            meta,
+            layout: RecordLayout::new(offset_bit_width, width_bit_width, min_bit_width),
+            num_blocks: (stats.num_rows as usize).div_ceil(BLOCK_LEN),
+            gcd: stats.gcd.get(),
+            stats,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::column_values::u64_based::tests::create_and_validate;
+
+    #[test]
+    fn test_block_for_simple() {
+        create_and_validate::<BlockForCodec>(&[4, 3, 12], "simple");
+    }
+
+    #[test]
+    fn test_block_for_gcd() {
+        create_and_validate::<BlockForCodec>(&[1000, 2000, 3000], "gcd");
+    }
+
+    #[test]
+    fn test_block_for_block_boundaries() {
+        for num_vals in [1usize, 127, 128, 129, 255, 256, 257, 1024, 1027] {
+            let vals: Vec<u64> = (0..num_vals as u64).map(|i| i * 7 + (i % 5)).collect();
+            create_and_validate::<BlockForCodec>(&vals, "block boundaries");
+        }
+    }
+
+    #[test]
+    fn test_block_for_outliers() {
+        let mut vals: Vec<u64> = vec![42_000; 1000];
+        vals[137] = u64::MAX / 2;
+        vals[999] = 1 << 60;
+        create_and_validate::<BlockForCodec>(&vals, "outliers");
+    }
+
+    #[test]
+    fn test_block_for_all_widths() {
+        // One block per width w: values in [0, 2^w).
+        for w in 0..=64u32 {
+            let max = if w == 64 { u64::MAX } else { (1u64 << w) - 1 };
+            let vals: Vec<u64> = (0..200u64)
+                .map(|i| (i.wrapping_mul(0x9E3779B97F4A7C15)) & max)
+                .collect();
+            create_and_validate::<BlockForCodec>(&vals, "widths");
+        }
+    }
+
+    #[test]
+    fn test_block_for_datasets() {
+        let data_sets = crate::column_values::u64_based::tests::get_codec_test_datasets();
+        for (mut data, name) in data_sets {
+            create_and_validate::<BlockForCodec>(&data, name);
+            data.reverse();
+            create_and_validate::<BlockForCodec>(&data, name);
+        }
+    }
+
+    #[test]
+    fn test_block_for_wrapped_get_range() {
+        use common::OwnedBytes;
+
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+        let vals: Vec<u64> = (0..5000u64).map(|i| i * 3 + (i % 17)).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::BlockFor], &mut buffer).unwrap();
+        let col = load_u64_based_column_values::<u64>(OwnedBytes::new(buffer)).unwrap();
+        let mut out = vec![0u64; 3000];
+        col.get_range(137, &mut out);
+        assert_eq!(&vals[137..137 + 3000], &out[..]);
+        let mut out = vec![0u64; 5000];
+        col.get_range(0, &mut out);
+        assert_eq!(&vals[..], &out[..]);
+        // Small ranges go through the fused per-value path.
+        let mut out = vec![0u64; 5];
+        col.get_range(4990, &mut out);
+        assert_eq!(&vals[4990..4995], &out[..]);
+    }
+
+    #[test]
+    fn test_block_for_wrapped_get_range_f64() {
+        use common::OwnedBytes;
+
+        use crate::column_values::{
+            CodecType, load_u64_based_column_values, serialize_u64_based_column_values,
+        };
+        let vals: Vec<f64> = (0..3000u64).map(|i| (i as f64) * 0.25 - 100.0).collect();
+        let mut buffer = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[CodecType::BlockFor], &mut buffer).unwrap();
+        let col = load_u64_based_column_values::<f64>(OwnedBytes::new(buffer)).unwrap();
+        let mut out = vec![0f64; 2000];
+        col.get_range(11, &mut out);
+        assert_eq!(&vals[11..11 + 2000], &out[..]);
+    }
+
+    #[test]
+    #[should_panic(expected = "get_range out of bounds")]
+    fn test_block_for_get_range_rejects_padding() {
+        let vals = [42u64];
+        let mut buffer = Vec::new();
+        let stats = {
+            let mut collector = crate::column_values::u64_based::StatsCollector::default();
+            collector.collect(42);
+            collector.stats()
+        };
+        let estimator = BlockForEstimator::default();
+        estimator
+            .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+            .unwrap();
+        let reader = BlockForCodec::load(OwnedBytes::new(buffer)).unwrap();
+        let mut out = [0u64; 1];
+        reader.get_range(1, &mut out);
+    }
+
+    fn stats_of(vals: &[u64]) -> ColumnStats {
+        let mut collector = crate::column_values::u64_based::StatsCollector::default();
+        for &val in vals {
+            collector.collect(val);
+        }
+        collector.stats()
+    }
+
+    fn serialize_block_for(vals: &[u64]) -> (ColumnStats, Vec<u8>) {
+        let stats = stats_of(vals);
+        let mut buffer = Vec::new();
+        BlockForEstimator::default()
+            .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+            .unwrap();
+        (stats, buffer)
+    }
+
+    #[test]
+    fn test_block_for_footer_layout() {
+        let mut vals: Vec<u64> = (0..128u64).collect();
+        vals.extend(1000..1128u64);
+        vals.extend(5000..5044u64);
+        assert_eq!(vals.len(), 300);
+        let (stats, buffer) = serialize_block_for(&vals);
+        assert_eq!(stats.gcd.get(), 1);
+
+        let total_units = 7 + 7 + 6usize;
+        let offset_bits = compute_num_bits(total_units as u64);
+        let width_bits = compute_num_bits(7);
+        let min_bits = compute_num_bits(5000);
+        assert_eq!((offset_bits, width_bits, min_bits), (5, 3, 13));
+
+        // Head: 5 + 3 bits -> 1 byte. Minimum: 13 bits -> 2 bytes.
+        let stride = RecordLayout::new(offset_bits, width_bits, min_bits).stride;
+        assert_eq!(stride, 3);
+        let footer_len = 3 * stride + FOOTER_PAD + 3;
+        assert_eq!(
+            buffer.len(),
+            stats.num_bytes() as usize + 16 * total_units + footer_len + 4
+        );
+    }
+
+    /// `estimate` decides which codec wins, so it has to predict the footer
+    /// exactly, not approximately.
+    #[test]
+    fn test_block_for_estimate_matches_serialized_len() {
+        let mut cases: Vec<(Vec<u64>, &str)> = vec![
+            ((0..300u64).map(|i| i * 7 + (i % 5)).collect(), "ramp"),
+            (vec![42_000; 1000], "constant"),
+            ((0..128u64).collect(), "one block"),
+            (vec![7], "single value"),
+            (
+                (0..5000u64)
+                    .map(|i| i.wrapping_mul(2_654_435_761))
+                    .collect(),
+                "wide",
+            ),
+        ];
+
+        // An outlier in one block: the block widths, and so the offset array, stop being uniform.
+        let mut outliers = vec![42_000u64; 1000];
+        outliers[137] = u64::MAX / 2;
+        cases.push((outliers, "outliers"));
+
+        for (vals, name) in cases {
+            let stats = stats_of(&vals);
+            let mut estimator = BlockForEstimator::default();
+            for &val in &vals {
+                estimator.collect(val);
+            }
+            estimator.finalize();
+            let mut buffer = Vec::new();
+            estimator
+                .serialize(&stats, &mut vals.iter().copied(), &mut buffer)
+                .unwrap();
+            assert_eq!(
+                estimator.estimate(&stats),
+                Some(buffer.len() as u64),
+                "{name}: estimate must match the serialized length exactly"
+            );
+        }
+    }
+
+    /// Block minima are bitpacked at one column-wide width, so a column whose
+    /// minima need all 64 bits drives the `BitUnpacker` width that is legal but
+    /// skips the 8-byte fast path. Widths 57..=63 do not exist (`compute_num_bits`
+    /// rounds them to 64), which is what keeps `BitUnpacker::new` from panicking.
+    #[test]
+    fn test_block_for_full_width_block_minima() {
+        let vals: Vec<u64> = (0..1000u64)
+            .map(|i| (i.wrapping_mul(0x9E37_79B9_7F4A_7C15) & !0xFFu64) | (i % 251))
+            .collect();
+        let (_, buffer) = serialize_block_for(&vals);
+        let reader = BlockForCodec::load(OwnedBytes::new(buffer)).unwrap();
+        for (i, &expected) in vals.iter().enumerate() {
+            assert_eq!(reader.get_val(i as u32), expected, "row {i}");
+        }
+        let mut out = vec![0u64; vals.len()];
+        reader.get_range(0, &mut out);
+        assert_eq!(&out[..], &vals[..]);
+    }
+    #[test]
+    fn test_block_for_many_blocks() {
+        let vals: Vec<u64> = (0..200_000u64)
+            .map(|i| i * 64 + (i.wrapping_mul(2_654_435_761) % (1 << (i / 4096 % 20))))
+            .collect();
+        let (_, buffer) = serialize_block_for(&vals);
+        let reader = BlockForCodec::load(OwnedBytes::new(buffer)).unwrap();
+        for i in (0..vals.len()).step_by(97) {
+            assert_eq!(reader.get_val(i as u32), vals[i], "row {i}");
+        }
+        let mut out = vec![0u64; 4096];
+        reader.get_range(150_003, &mut out);
+        assert_eq!(&out[..], &vals[150_003..150_003 + 4096]);
+    }
+
+    #[test]
+    fn test_block_for_rand() {
+        for _ in 0..100 {
+            let mut data = (0..1 + rand::random::<u16>() as usize % 2000)
+                .map(|_| rand::random::<i64>() as u64 / 2)
+                .collect::<Vec<_>>();
+            create_and_validate::<BlockForCodec>(&data, "rand");
+            data.reverse();
+            create_and_validate::<BlockForCodec>(&data, "rand");
+        }
+    }
+}

--- a/columnar/src/column_values/u64_based/block_for.rs
+++ b/columnar/src/column_values/u64_based/block_for.rs
@@ -23,11 +23,10 @@ use std::io::{self, Write};
 
 use common::{BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes};
 use fastdivide::DividerU64;
+use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, compute_num_bits};
 
-use super::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
-};
+use super::block_decode::{BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows};
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 use crate::{ColumnValues, RowId};
 
@@ -140,15 +139,11 @@ impl BlockDecode for BlockForReader {
     }
 
     #[inline]
-    fn partial_min_rows(&self, block_idx: usize) -> usize {
-        partial_block_min_rows(self.block_meta(block_idx).bit_width)
-    }
-
-    #[inline]
-    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+    fn decode_block_range(&self, block_idx: usize, in_block: usize, out: &mut [u64]) {
         let meta = self.block_meta(block_idx);
-        decode_block(
+        decode_range(
             meta.bit_width,
+            in_block,
             &self.data[meta.start_byte_offset as usize..],
             out,
         );
@@ -231,7 +226,7 @@ impl ColumnValues for BlockForReader {
             if block_min > value_hi || block_max < value_lo {
                 continue;
             }
-            self.decode_block_mapped(block_idx, &mut buf);
+            self.decode_block_range(block_idx, 0, &mut buf);
             let row_base = (block_idx * BLOCK_LEN) as u32;
             let from = start.max(row_base) - row_base;
             let to = end.min(row_base + BLOCK_LEN as u32) - row_base;
@@ -249,7 +244,7 @@ impl ColumnValues for BlockForReader {
             start + output.len() as u64 <= u64::from(self.stats.num_rows),
             "get_range out of bounds"
         );
-        self.decode_range(start, output);
+        self.decode_range(start, output)
     }
 
     fn min_batch_rows(&self) -> usize {

--- a/columnar/src/column_values/u64_based/blockwise_linear.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear.rs
@@ -9,7 +9,7 @@ use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
 use crate::{MonotonicallyMappableToU64, RowId};
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
+    BLOCK_LEN, BatchThresholds, BlockDecode, DecodeCost, batch_thresholds,
 };
 use crate::column_values::u64_based::line::Line;
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
@@ -266,8 +266,8 @@ impl ColumnValues for BlockwiseLinearReader {
         super::get_row_ids_for_value_range_batched(self, value_range, row_id_range, row_id_hits)
     }
 
-    fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Blocked)
+    fn batch_thresholds(&self) -> BatchThresholds {
+        batch_thresholds(DecodeCost::BlockedInterpolated)
     }
 
     #[inline(always)]

--- a/columnar/src/column_values/u64_based/blockwise_linear.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear.rs
@@ -4,11 +4,12 @@ use std::{io, iter};
 
 use common::{BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes};
 use fastdivide::DividerU64;
+use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
 use crate::{MonotonicallyMappableToU64, RowId};
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
 };
 use crate::column_values::u64_based::line::Line;
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
@@ -210,22 +211,18 @@ impl BlockDecode for BlockwiseLinearReader {
         self.stats.num_rows as usize / BLOCK_LEN
     }
 
-    fn partial_min_rows(&self, group_idx: usize) -> usize {
-        let block = &self.blocks[group_idx * BLOCK_LEN / BLOCK_SIZE as usize];
-        partial_block_min_rows(block.bit_unpacker.bit_width())
-    }
-
     #[inline]
-    fn decode_block_mapped(&self, group_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+    fn decode_block_range(&self, group_idx: usize, in_block: usize, out: &mut [u64]) {
         let row = group_idx * BLOCK_LEN;
         let block = &self.blocks[row / BLOCK_SIZE as usize];
-        let idx_within_block = (row % BLOCK_SIZE as usize) as u32;
+        let group_start = (row % BLOCK_SIZE as usize) as u32;
         let bit_width = block.bit_unpacker.bit_width();
-        // `idx_within_block` is a multiple of 128, so this byte offset is
-        // exact and group-aligned within the block's stream.
-        let byte_offset =
-            block.data_start_offset + idx_within_block as usize * bit_width as usize / 8;
-        decode_block(bit_width, &self.data[byte_offset..], out);
+        // `group_start` is a multiple of 128, so this byte offset is exact and
+        // group-aligned within the block's stream; `in_block` then indexes the
+        // slots from there, which is what `decode_range` wants.
+        let byte_offset = block.data_start_offset + group_start as usize * bit_width as usize / 8;
+        decode_range(bit_width, in_block, &self.data[byte_offset..], out);
+        let idx_within_block = group_start + in_block as u32;
         let (min_value, gcd) = (self.stats.min_value, self.stats.gcd.get());
         for (i, o) in out.iter_mut().enumerate() {
             let interpolated_val = block.line.eval(idx_within_block + i as u32);
@@ -270,7 +267,7 @@ impl ColumnValues for BlockwiseLinearReader {
     }
 
     fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Flat)
+        min_batch_rows(DecodeCost::Blocked)
     }
 
     #[inline(always)]

--- a/columnar/src/column_values/u64_based/blockwise_linear.rs
+++ b/columnar/src/column_values/u64_based/blockwise_linear.rs
@@ -6,12 +6,18 @@ use common::{BinarySerializable, CountingWriter, DeserializeFrom, OwnedBytes};
 use fastdivide::DividerU64;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
-use crate::MonotonicallyMappableToU64;
+use crate::{MonotonicallyMappableToU64, RowId};
+use crate::column_values::u64_based::block_decode::{
+    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+};
 use crate::column_values::u64_based::line::Line;
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
-use crate::column_values::{ColumnValues, VecColumn};
+use crate::column_values::ColumnValues;
 
 const BLOCK_SIZE: u32 = 512u32;
+// A 512-value block is exactly 4 decode groups, so a group never straddles
+// two blocks (and their different bit widths / data offsets).
+const _: () = assert!((BLOCK_SIZE as usize).is_multiple_of(BLOCK_LEN));
 
 #[derive(Debug, Default)]
 struct Block {
@@ -63,9 +69,7 @@ impl BlockwiseLinearEstimator {
         if self.block.is_empty() {
             return;
         }
-        let column = VecColumn::from(std::mem::take(&mut self.block));
-        let line = Line::train(&column);
-        self.block = column.into();
+        let line = Line::train_slice(&self.block);
 
         let mut max_value = 0u64;
         for (i, buffer_val) in self.block.iter().enumerate() {
@@ -128,7 +132,7 @@ impl ColumnCodecEstimator for BlockwiseLinearEstimator {
                 *buffer_val = gcd_divider.divide(*buffer_val - stats.min_value);
             }
 
-            let line = Line::train(&VecColumn::from(buffer.to_vec()));
+            let line = Line::train_slice(&buffer);
 
             assert!(!buffer.is_empty());
 
@@ -201,6 +205,35 @@ pub struct BlockwiseLinearReader {
     stats: ColumnStats,
 }
 
+impl BlockDecode for BlockwiseLinearReader {
+    fn num_full_blocks(&self) -> usize {
+        self.stats.num_rows as usize / BLOCK_LEN
+    }
+
+    fn partial_min_rows(&self, group_idx: usize) -> usize {
+        let block = &self.blocks[group_idx * BLOCK_LEN / BLOCK_SIZE as usize];
+        partial_block_min_rows(block.bit_unpacker.bit_width())
+    }
+
+    #[inline]
+    fn decode_block_mapped(&self, group_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+        let row = group_idx * BLOCK_LEN;
+        let block = &self.blocks[row / BLOCK_SIZE as usize];
+        let idx_within_block = (row % BLOCK_SIZE as usize) as u32;
+        let bit_width = block.bit_unpacker.bit_width();
+        // `idx_within_block` is a multiple of 128, so this byte offset is
+        // exact and group-aligned within the block's stream.
+        let byte_offset =
+            block.data_start_offset + idx_within_block as usize * bit_width as usize / 8;
+        decode_block(bit_width, &self.data[byte_offset..], out);
+        let (min_value, gcd) = (self.stats.min_value, self.stats.gcd.get());
+        for (i, o) in out.iter_mut().enumerate() {
+            let interpolated_val = block.line.eval(idx_within_block + i as u32);
+            *o = min_value + gcd.wrapping_mul(interpolated_val.wrapping_add(*o));
+        }
+    }
+}
+
 impl ColumnValues for BlockwiseLinearReader {
     #[inline(always)]
     fn get_val(&self, idx: u32) -> u64 {
@@ -218,6 +251,26 @@ impl ColumnValues for BlockwiseLinearReader {
                 .gcd
                 .get()
                 .wrapping_mul(interpoled_val.wrapping_add(bitpacked_diff))
+    }
+
+    fn get_range(&self, start: u64, output: &mut [u64]) {
+        self.decode_range(start, output);
+    }
+
+    /// Decode-then-filter: the offset is a per-block line evaluated at the
+    /// row, so there is no fixed residual range a value range could be pushed
+    /// down to.
+    fn get_row_ids_for_value_range(
+        &self,
+        value_range: std::ops::RangeInclusive<u64>,
+        row_id_range: std::ops::Range<RowId>,
+        row_id_hits: &mut Vec<RowId>,
+    ) {
+        super::get_row_ids_for_value_range_batched(self, value_range, row_id_range, row_id_hits)
+    }
+
+    fn min_batch_rows(&self) -> usize {
+        min_batch_rows(DecodeCost::Flat)
     }
 
     #[inline(always)]

--- a/columnar/src/column_values/u64_based/line.rs
+++ b/columnar/src/column_values/u64_based/line.rs
@@ -122,6 +122,20 @@ impl Line {
         line
     }
 
+    /// Same as [`Line::train`], for values already materialized in a slice:
+    /// avoids the boxed iterator per pass the `&dyn ColumnValues` form pays.
+    pub fn train_slice(ys: &[u64]) -> Self {
+        let (Some(&first_val), Some(&last_val)) = (ys.first(), ys.last()) else {
+            return Line::default();
+        };
+        Self::train_from(
+            first_val,
+            last_val,
+            ys.len() as u32,
+            ys.iter().enumerate().map(|(pos, &val)| (pos as u64, val)),
+        )
+    }
+
     /// Returns a line that attempts to approximate a function
     /// f: i in 0..[ys.num_vals()) -> ys[i].
     ///

--- a/columnar/src/column_values/u64_based/linear.rs
+++ b/columnar/src/column_values/u64_based/linear.rs
@@ -9,7 +9,7 @@ use super::line::Line;
 use crate::RowId;
 use crate::column_values::VecColumn;
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
+    BLOCK_LEN, BatchThresholds, BlockDecode, DecodeCost, batch_thresholds,
 };
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 
@@ -61,8 +61,8 @@ impl ColumnValues for LinearReader {
     // stream, cheap enough that batching the filter measured slower.
 
     #[inline]
-    fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Interpolated)
+    fn batch_thresholds(&self) -> BatchThresholds {
+        batch_thresholds(DecodeCost::Interpolated)
     }
 
     #[inline(always)]

--- a/columnar/src/column_values/u64_based/linear.rs
+++ b/columnar/src/column_values/u64_based/linear.rs
@@ -1,6 +1,7 @@
 use std::io;
 
 use common::{BinarySerializable, OwnedBytes};
+use tantivy_bitpacker::block_decode::decode_range;
 use tantivy_bitpacker::{BitPacker, BitUnpacker, compute_num_bits};
 
 use super::ColumnValues;
@@ -8,7 +9,7 @@ use super::line::Line;
 use crate::RowId;
 use crate::column_values::VecColumn;
 use crate::column_values::u64_based::block_decode::{
-    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+    BLOCK_LEN, BlockDecode, DecodeCost, min_batch_rows,
 };
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 
@@ -22,8 +23,6 @@ pub struct LinearReader {
     data: OwnedBytes,
     linear_params: LinearParams,
     stats: ColumnStats,
-    /// See `BitpackedReader::partial_min_rows`: one stream-wide bit width.
-    partial_min_rows: usize,
 }
 
 impl BlockDecode for LinearReader {
@@ -32,16 +31,11 @@ impl BlockDecode for LinearReader {
     }
 
     #[inline]
-    fn partial_min_rows(&self, _block_idx: usize) -> usize {
-        self.partial_min_rows
-    }
-
-    #[inline]
-    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+    fn decode_block_range(&self, block_idx: usize, in_block: usize, out: &mut [u64]) {
         let bit_width = self.linear_params.bit_unpacker.bit_width();
         let byte_offset = block_idx * BLOCK_LEN * bit_width as usize / 8;
-        decode_block(bit_width, &self.data[byte_offset..], out);
-        let base = (block_idx * BLOCK_LEN) as u32;
+        decode_range(bit_width, in_block, &self.data[byte_offset..], out);
+        let base = (block_idx * BLOCK_LEN + in_block) as u32;
         let line = self.linear_params.line;
         for (i, o) in out.iter_mut().enumerate() {
             *o = line.eval(base + i as u32).wrapping_add(*o);
@@ -68,7 +62,7 @@ impl ColumnValues for LinearReader {
 
     #[inline]
     fn min_batch_rows(&self) -> usize {
-        min_batch_rows(DecodeCost::Flat)
+        min_batch_rows(DecodeCost::Interpolated)
     }
 
     #[inline(always)]
@@ -235,9 +229,7 @@ impl ColumnCodec for LinearCodec {
     fn load(mut data: OwnedBytes) -> io::Result<Self::ColumnValues> {
         let stats = ColumnStats::deserialize(&mut data)?;
         let linear_params = LinearParams::deserialize(&mut data)?;
-        let bit_width = linear_params.bit_unpacker.bit_width();
         Ok(LinearReader {
-            partial_min_rows: partial_block_min_rows(bit_width),
             stats,
             linear_params,
             data,

--- a/columnar/src/column_values/u64_based/linear.rs
+++ b/columnar/src/column_values/u64_based/linear.rs
@@ -7,6 +7,9 @@ use super::ColumnValues;
 use super::line::Line;
 use crate::RowId;
 use crate::column_values::VecColumn;
+use crate::column_values::u64_based::block_decode::{
+    BLOCK_LEN, BlockDecode, DecodeCost, decode_block, min_batch_rows, partial_block_min_rows,
+};
 use crate::column_values::u64_based::{ColumnCodec, ColumnCodecEstimator, ColumnStats};
 
 const HALF_SPACE: u64 = u64::MAX / 2;
@@ -19,6 +22,31 @@ pub struct LinearReader {
     data: OwnedBytes,
     linear_params: LinearParams,
     stats: ColumnStats,
+    /// See `BitpackedReader::partial_min_rows`: one stream-wide bit width.
+    partial_min_rows: usize,
+}
+
+impl BlockDecode for LinearReader {
+    fn num_full_blocks(&self) -> usize {
+        self.stats.num_rows as usize / BLOCK_LEN
+    }
+
+    #[inline]
+    fn partial_min_rows(&self, _block_idx: usize) -> usize {
+        self.partial_min_rows
+    }
+
+    #[inline]
+    fn decode_block_mapped(&self, block_idx: usize, out: &mut [u64; BLOCK_LEN]) {
+        let bit_width = self.linear_params.bit_unpacker.bit_width();
+        let byte_offset = block_idx * BLOCK_LEN * bit_width as usize / 8;
+        decode_block(bit_width, &self.data[byte_offset..], out);
+        let base = (block_idx * BLOCK_LEN) as u32;
+        let line = self.linear_params.line;
+        for (i, o) in out.iter_mut().enumerate() {
+            *o = line.eval(base + i as u32).wrapping_add(*o);
+        }
+    }
 }
 
 impl ColumnValues for LinearReader {
@@ -27,6 +55,20 @@ impl ColumnValues for LinearReader {
         let interpoled_val: u64 = self.linear_params.line.eval(doc);
         let bitpacked_diff = self.linear_params.bit_unpacker.get(doc, &self.data);
         interpoled_val.wrapping_add(bitpacked_diff)
+    }
+
+    #[inline]
+    fn get_range(&self, start: u64, output: &mut [u64]) {
+        self.decode_range(start, output);
+    }
+
+    // No `get_row_ids_for_value_range` override on purpose: this codec's
+    // `get_val` is a line eval plus one load/shift/mask on a single flat
+    // stream, cheap enough that batching the filter measured slower.
+
+    #[inline]
+    fn min_batch_rows(&self) -> usize {
+        min_batch_rows(DecodeCost::Flat)
     }
 
     #[inline(always)]
@@ -193,7 +235,9 @@ impl ColumnCodec for LinearCodec {
     fn load(mut data: OwnedBytes) -> io::Result<Self::ColumnValues> {
         let stats = ColumnStats::deserialize(&mut data)?;
         let linear_params = LinearParams::deserialize(&mut data)?;
+        let bit_width = linear_params.bit_unpacker.bit_width();
         Ok(LinearReader {
+            partial_min_rows: partial_block_min_rows(bit_width),
             stats,
             linear_params,
             data,

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -1,3 +1,7 @@
+/// Not wired into [`CodecType`] yet: needs more validation before production
+/// columns serialize with it.
+#[allow(dead_code)]
+mod alp;
 mod bitpacked;
 mod block_decode;
 mod block_for;

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -1,5 +1,6 @@
 mod bitpacked;
 mod block_decode;
+mod block_for;
 mod blockwise_linear;
 mod line;
 mod linear;
@@ -15,6 +16,7 @@ use crate::column_values::monotonic_mapping::{
     StrictlyMonotonicMappingInverter, StrictlyMonotonicMappingToInternal,
 };
 pub use crate::column_values::u64_based::bitpacked::BitpackedCodec;
+pub use crate::column_values::u64_based::block_for::BlockForCodec;
 pub use crate::column_values::u64_based::blockwise_linear::BlockwiseLinearCodec;
 pub use crate::column_values::u64_based::linear::LinearCodec;
 pub use crate::column_values::u64_based::stats_collector::StatsCollector;
@@ -23,7 +25,8 @@ use crate::iterable::Iterable;
 use crate::{ColumnValues, MonotonicallyMappableToU64, RowId};
 
 /// Batched `get_row_ids_for_value_range`: decode chunks via `get_range` and
-/// filter, instead of one `get_val` per row.
+/// filter, instead of one `get_val` per row. `BlockFor` has its own version
+/// that also prunes blocks by their metadata.
 pub(crate) fn get_row_ids_for_value_range_batched<C: ColumnValues<u64> + ?Sized>(
     column: &C,
     value_range: std::ops::RangeInclusive<u64>,
@@ -114,13 +117,17 @@ pub enum CodecType {
     Linear = 1u8,
     /// Same as [`CodecType::Linear`], but encodes in blocks of 512 elements.
     BlockwiseLinear = 2u8,
+    /// Per-block (128 values) frame-of-reference: each block stores its own
+    /// minimum and bit width.
+    BlockFor = 3u8,
 }
 
 /// List of all available u64-base codecs.
-pub const ALL_U64_CODEC_TYPES: [CodecType; 3] = [
+pub const ALL_U64_CODEC_TYPES: [CodecType; 4] = [
     CodecType::Bitpacked,
     CodecType::Linear,
     CodecType::BlockwiseLinear,
+    CodecType::BlockFor,
 ];
 
 impl std::fmt::Display for CodecType {
@@ -129,6 +136,7 @@ impl std::fmt::Display for CodecType {
             CodecType::Bitpacked => "bitpacked",
             CodecType::Linear => "linear",
             CodecType::BlockwiseLinear => "blockwise_linear",
+            CodecType::BlockFor => "block_for",
         };
         f.write_str(name)
     }
@@ -149,6 +157,7 @@ impl CodecType {
             0u8 => Some(CodecType::Bitpacked),
             1u8 => Some(CodecType::Linear),
             2u8 => Some(CodecType::BlockwiseLinear),
+            3u8 => Some(CodecType::BlockFor),
             _ => None,
         }
     }
@@ -161,6 +170,7 @@ impl CodecType {
             CodecType::Bitpacked => load_specific_codec::<BitpackedCodec, T>(bytes),
             CodecType::Linear => load_specific_codec::<LinearCodec, T>(bytes),
             CodecType::BlockwiseLinear => load_specific_codec::<BlockwiseLinearCodec, T>(bytes),
+            CodecType::BlockFor => load_specific_codec::<BlockForCodec, T>(bytes),
         }
     }
 }
@@ -183,7 +193,22 @@ impl CodecType {
             CodecType::Bitpacked => BitpackedCodec::boxed_estimator(),
             CodecType::Linear => LinearCodec::boxed_estimator(),
             CodecType::BlockwiseLinear => BlockwiseLinearCodec::boxed_estimator(),
+            CodecType::BlockFor => BlockForCodec::boxed_estimator(),
         }
+    }
+}
+
+/// Selection penalty for `BlockFor`: its random access is pricier (block-meta
+/// load on top of the unpack), so it must win on size by >= ~7.7%.
+const BLOCK_CODEC_PENALTY_NUM: u64 = 13;
+const BLOCK_CODEC_PENALTY_DEN: u64 = 12;
+
+fn selection_cost(codec_type: CodecType, estimated_num_bytes: u64) -> u64 {
+    match codec_type {
+        CodecType::BlockFor => {
+            estimated_num_bytes * BLOCK_CODEC_PENALTY_NUM / BLOCK_CODEC_PENALTY_DEN
+        }
+        _ => estimated_num_bytes,
     }
 }
 
@@ -214,9 +239,9 @@ pub fn serialize_u64_based_column_values<T: MonotonicallyMappableToU64>(
         .into_iter()
         .flat_map(|(codec_type, estimator)| {
             let num_bytes = estimator.estimate(&stats)?;
-            Some((num_bytes, codec_type, estimator))
+            Some((selection_cost(codec_type, num_bytes), codec_type, estimator))
         })
-        .min_by_key(|(num_bytes, _, _)| *num_bytes)
+        .min_by_key(|(selection_cost, _, _)| *selection_cost)
         .ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidData, "No available applicable codec.")
         })?;
@@ -260,6 +285,7 @@ pub fn load_u64_based_column_values_raw(
         CodecType::Bitpacked => Ok(Arc::new(BitpackedCodec::load(bytes)?)),
         CodecType::Linear => Ok(Arc::new(LinearCodec::load(bytes)?)),
         CodecType::BlockwiseLinear => Ok(Arc::new(BlockwiseLinearCodec::load(bytes)?)),
+        CodecType::BlockFor => Ok(Arc::new(BlockForCodec::load(bytes)?)),
     }
 }
 

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -1,4 +1,5 @@
 mod bitpacked;
+mod block_decode;
 mod blockwise_linear;
 mod line;
 mod linear;
@@ -19,7 +20,34 @@ pub use crate::column_values::u64_based::linear::LinearCodec;
 pub use crate::column_values::u64_based::stats_collector::StatsCollector;
 use crate::column_values::{ColumnStats, monotonic_map_column};
 use crate::iterable::Iterable;
-use crate::{ColumnValues, MonotonicallyMappableToU64};
+use crate::{ColumnValues, MonotonicallyMappableToU64, RowId};
+
+/// Batched `get_row_ids_for_value_range`: decode chunks via `get_range` and
+/// filter, instead of one `get_val` per row.
+pub(crate) fn get_row_ids_for_value_range_batched<C: ColumnValues<u64> + ?Sized>(
+    column: &C,
+    value_range: std::ops::RangeInclusive<u64>,
+    row_id_range: std::ops::Range<RowId>,
+    row_id_hits: &mut Vec<RowId>,
+) {
+    // Multiple of BLOCK_LEN (128) so that after the first (possibly
+    // unaligned) chunk, the codec decodes whole blocks.
+    const CHUNK: usize = 512;
+    let end = row_id_range.end.min(column.num_vals());
+    let mut start = row_id_range.start;
+    let mut buf = [0u64; CHUNK];
+    while start < end {
+        let chunk_end = (((start as usize / CHUNK) + 1) * CHUNK).min(end as usize) as u32;
+        let len = (chunk_end - start) as usize;
+        column.get_range(u64::from(start), &mut buf[..len]);
+        for (offset, &val) in buf[..len].iter().enumerate() {
+            if value_range.contains(&val) {
+                row_id_hits.push(start + offset as u32);
+            }
+        }
+        start = chunk_end;
+    }
+}
 
 /// A `ColumnCodecEstimator` is in charge of gathering all
 /// data required to serialize a column.
@@ -95,9 +123,25 @@ pub const ALL_U64_CODEC_TYPES: [CodecType; 3] = [
     CodecType::BlockwiseLinear,
 ];
 
+impl std::fmt::Display for CodecType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let name = match self {
+            CodecType::Bitpacked => "bitpacked",
+            CodecType::Linear => "linear",
+            CodecType::BlockwiseLinear => "blockwise_linear",
+        };
+        f.write_str(name)
+    }
+}
+
 impl CodecType {
     fn to_code(self) -> u8 {
         self as u8
+    }
+
+    /// Recovers the codec from the code byte a serialized column starts with.
+    pub fn from_code(code: u8) -> Option<CodecType> {
+        Self::try_from_code(code)
     }
 
     fn try_from_code(code: u8) -> Option<CodecType> {
@@ -198,6 +242,25 @@ pub fn load_u64_based_column_values<T: MonotonicallyMappableToU64>(
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Failed to read codec type"))?;
     bytes.advance(1);
     codec_type.load(bytes)
+}
+
+/// Loads u64 column values without the (identity) monotonic-mapping wrapper:
+/// same bytes as [`load_u64_based_column_values`], one less virtual hop.
+#[doc(hidden)]
+pub fn load_u64_based_column_values_raw(
+    mut bytes: OwnedBytes,
+) -> io::Result<Arc<dyn ColumnValues<u64>>> {
+    let codec_type: CodecType = bytes
+        .first()
+        .copied()
+        .and_then(CodecType::try_from_code)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Failed to read codec type"))?;
+    bytes.advance(1);
+    match codec_type {
+        CodecType::Bitpacked => Ok(Arc::new(BitpackedCodec::load(bytes)?)),
+        CodecType::Linear => Ok(Arc::new(LinearCodec::load(bytes)?)),
+        CodecType::BlockwiseLinear => Ok(Arc::new(BlockwiseLinearCodec::load(bytes)?)),
+    }
 }
 
 /// Helper function to serialize a column (autodetect from all codecs) and then open it

--- a/columnar/src/column_values/u64_based/mod.rs
+++ b/columnar/src/column_values/u64_based/mod.rs
@@ -19,6 +19,10 @@ use common::{BinarySerializable, OwnedBytes};
 use crate::column_values::monotonic_mapping::{
     StrictlyMonotonicMappingInverter, StrictlyMonotonicMappingToInternal,
 };
+/// `Alp` is deliberately not a [`CodecType`], so nothing in the library
+/// selects it and this re-export has no non-test consumer.
+#[cfg(test)]
+pub use crate::column_values::u64_based::alp::AlpCodec;
 pub use crate::column_values::u64_based::bitpacked::BitpackedCodec;
 pub use crate::column_values::u64_based::block_for::BlockForCodec;
 pub use crate::column_values::u64_based::blockwise_linear::BlockwiseLinearCodec;

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -677,7 +677,7 @@ fn timestamp_sizes() {
 /// notices if a width silently drops back to scalar.
 #[test]
 fn test_linear_batches_at_every_width() {
-    use crate::column_values::u64_based::block_decode::{DecodeCost, min_batch_rows};
+    use crate::column_values::u64_based::block_decode::{DecodeCost, batch_thresholds};
 
     // Residuals run several bits wider than the noise term, so these straddle
     // the narrow/wide kernel boundary with margin on both sides.
@@ -692,8 +692,8 @@ fn test_linear_batches_at_every_width() {
         }
         let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
         assert_eq!(
-            column.min_batch_rows(),
-            min_batch_rows(DecodeCost::Interpolated),
+            column.batch_thresholds(),
+            batch_thresholds(DecodeCost::Interpolated),
             "noise_bits={noise_bits} must report the Interpolated threshold"
         );
         let mut out = vec![0u64; 300];
@@ -705,8 +705,8 @@ fn test_linear_batches_at_every_width() {
 }
 
 #[test]
-fn test_min_batch_rows_per_codec() {
-    use crate::column_values::u64_based::block_decode::{DecodeCost, min_batch_rows};
+fn test_batch_thresholds_per_codec() {
+    use crate::column_values::u64_based::block_decode::{DecodeCost, batch_thresholds};
 
     let mut covered: Vec<String> = Vec::new();
     for (vals, _shape) in multi_block_datasets() {
@@ -717,16 +717,30 @@ fn test_min_batch_rows_per_codec() {
             }
             covered.push(format!("{codec:?}"));
             let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
-            let got = column.min_batch_rows();
-            let expected = min_batch_rows(match codec {
+            let got = column.batch_thresholds();
+            let expected = batch_thresholds(match codec {
                 CodecType::Bitpacked => DecodeCost::Flat,
                 CodecType::Linear => DecodeCost::Interpolated,
-                _ => DecodeCost::Blocked,
+                CodecType::BlockwiseLinear => DecodeCost::BlockedInterpolated,
+                CodecType::BlockFor => DecodeCost::Blocked,
             });
+            // Ordering of the families, cheapest `get_val` last: a codec that
+            // hoists per-block metadata crosses over soonest, and paying a
+            // line eval in *both* arms pushes it back out again.
             assert!(
-                min_batch_rows(DecodeCost::Interpolated) > min_batch_rows(DecodeCost::Flat)
-                    && min_batch_rows(DecodeCost::Flat) > min_batch_rows(DecodeCost::Blocked),
+                batch_thresholds(DecodeCost::Interpolated).forwarding
+                    > batch_thresholds(DecodeCost::Flat).forwarding
+                    && batch_thresholds(DecodeCost::Flat).forwarding
+                        > batch_thresholds(DecodeCost::BlockedInterpolated).forwarding
+                    && batch_thresholds(DecodeCost::BlockedInterpolated).forwarding
+                        > batch_thresholds(DecodeCost::Blocked).forwarding,
                 "DecodeCost families are out of order"
+            );
+            // The buffered arm is never cheaper to reach than the forwarding
+            // one: it does strictly more work per row.
+            assert!(
+                got.buffered >= got.forwarding,
+                "{codec:?} claims the buffered arm crosses over first"
             );
             assert_eq!(
                 got, expected,
@@ -743,7 +757,7 @@ fn test_min_batch_rows_per_codec() {
 /// the 128-value block grid, on every codec that can encode the data.
 /// `load_u64_based_column_values_raw` is deliberate: it skips the monotonic
 /// wrapper, so the codec's batch path is reached at every length rather than
-/// only above the wrapper's `min_batch_rows` gate.
+/// only above the wrapper's `batch_thresholds` gate.
 #[test]
 fn test_get_range_all_codecs_all_block_phases() {
     let mut covered: Vec<String> = Vec::new();

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -693,8 +693,8 @@ fn test_linear_batches_at_every_width() {
         let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
         assert_eq!(
             column.min_batch_rows(),
-            min_batch_rows(DecodeCost::Flat),
-            "noise_bits={noise_bits} must report the Flat threshold"
+            min_batch_rows(DecodeCost::Interpolated),
+            "noise_bits={noise_bits} must report the Interpolated threshold"
         );
         let mut out = vec![0u64; 300];
         column.get_range(137, &mut out);
@@ -704,9 +704,6 @@ fn test_linear_batches_at_every_width() {
     }
 }
 
-/// The per-codec `min_batch_rows` family assignment. Value-equality tests
-/// cannot see this: picking the wrong `DecodeCost` only changes *which* path
-/// produces a value, never the value.
 #[test]
 fn test_min_batch_rows_per_codec() {
     use crate::column_values::u64_based::block_decode::{DecodeCost, min_batch_rows};
@@ -721,14 +718,16 @@ fn test_min_batch_rows_per_codec() {
             covered.push(format!("{codec:?}"));
             let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
             let got = column.min_batch_rows();
-            let expect_flat = matches!(
-                codec,
-                CodecType::Bitpacked | CodecType::Linear | CodecType::BlockwiseLinear
+            let expected = min_batch_rows(match codec {
+                CodecType::Bitpacked => DecodeCost::Flat,
+                CodecType::Linear => DecodeCost::Interpolated,
+                _ => DecodeCost::Blocked,
+            });
+            assert!(
+                min_batch_rows(DecodeCost::Interpolated) > min_batch_rows(DecodeCost::Flat)
+                    && min_batch_rows(DecodeCost::Flat) > min_batch_rows(DecodeCost::Blocked),
+                "DecodeCost families are out of order"
             );
-            let flat = min_batch_rows(DecodeCost::Flat);
-            let blocked = min_batch_rows(DecodeCost::Blocked);
-            assert!(flat > blocked, "Flat must cross over later than Blocked");
-            let expected = if expect_flat { flat } else { blocked };
             assert_eq!(
                 got, expected,
                 "{codec:?} reports the wrong DecodeCost family"
@@ -758,8 +757,6 @@ fn test_get_range_all_codecs_all_block_phases() {
             let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer.clone())).unwrap();
             assert_eq!(column.num_vals() as usize, vals.len(), "{codec:?}/{shape}");
 
-            // Every phase of the block grid, and lengths straddling the block
-            // size, the partial-block floor, and the trailing partial block.
             for start in 0..140usize {
                 for len in [1usize, 2, 47, 48, 79, 80, 128, 129, 256, 400] {
                     if start + len > vals.len() {
@@ -788,8 +785,6 @@ fn test_get_range_all_codecs_all_block_phases() {
                 );
             }
 
-            // The same data through the wrapper, which gates short takes onto
-            // the per-value loop: both routes must agree.
             let wrapped: Arc<dyn ColumnValues<u64>> =
                 load_u64_based_column_values(OwnedBytes::new(buffer)).unwrap();
             for start in [0usize, 1, 63, 127, 128, 129] {
@@ -848,8 +843,6 @@ fn estimation_test_bad_interpolation_case_monotonically_increasing() {
     let mut data: Vec<u64> = (201..=20000_u64).collect();
     data.push(1_000_000);
 
-    // in this case the linear interpolation can't in fact not be worse than bitpacking,
-    // but the estimator adds some threshold, which leads to estimated worse behavior
     let linear_interpol_estimation = estimate::<LinearCodec>(&data[..]).unwrap();
     assert_le!(linear_interpol_estimation, 0.35);
 

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -294,6 +294,10 @@ fn test_codec_interpolation() {
 fn test_codec_multi_interpolation() {
     test_codec::<BlockwiseLinearCodec>();
 }
+#[test]
+fn test_codec_block_for() {
+    test_codec::<BlockForCodec>();
+}
 
 /// Data shapes long enough to span several 128-value blocks, including a
 /// trailing partial one.
@@ -383,6 +387,87 @@ fn date_precision_sizes() {
             format!("{:?}", CodecType::try_from_code(buf[0]).unwrap()),
             buf.len() as f64 * 8.0 / N as f64,
             buf.len() as f64 / 1e6,
+        );
+    }
+}
+
+/// Range-filter cost on a *sorted* column: `BlockFor` prunes blocks by their
+/// metadata, `BlockwiseLinear` decodes every block in range and filters --
+/// and on a sorted column the selection prefers `BlockwiseLinear` on size.
+///
+/// ```text
+/// cargo test --release -p tantivy-columnar --lib sorted_range_filter_ab \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn sorted_range_filter_ab() {
+    use std::hint::black_box;
+    use std::time::Instant;
+
+    use crate::column_values::u64_based::{BlockForCodec, BlockwiseLinearCodec};
+
+    const N: usize = 2_000_000;
+    // Timestamps in an index sorted by that timestamp.
+    let mut vals: Vec<u64> = (0..N as u64)
+        .map(|i| 1_700_000_000_000 + i * 250 + (i.wrapping_mul(2_654_435_761) % 4_000))
+        .collect();
+    vals.sort_unstable();
+    let (lo, hi) = (vals[0], *vals.last().unwrap());
+
+    fn bytes_of(vals: &[u64], codec: CodecType) -> Vec<u8> {
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &[codec], &mut buf).unwrap();
+        buf[1..].to_vec()
+    }
+    let mut chosen = Vec::new();
+    serialize_u64_based_column_values(&&vals[..], &ALL_U64_CODEC_TYPES, &mut chosen).unwrap();
+    println!(
+        "\nsorted column, {N} rows: selection picks {:?} at {:.2} b/val",
+        CodecType::try_from_code(chosen[0]).unwrap(),
+        chosen.len() as f64 * 8.0 / N as f64
+    );
+
+    let bwl =
+        BlockwiseLinearCodec::load(OwnedBytes::new(bytes_of(&vals, CodecType::BlockwiseLinear)))
+            .unwrap();
+    let bfor = BlockForCodec::load(OwnedBytes::new(bytes_of(&vals, CodecType::BlockFor))).unwrap();
+
+    println!(
+        "{:>12} {:>10} {:>12} {:>9} {:>10}",
+        "selectivity", "bwl_us", "blockfor_us", "ratio", "hits"
+    );
+    let mut hits: Vec<u32> = Vec::with_capacity(N);
+    for (label, frac) in [("0.1%", 1000u64), ("1%", 100), ("10%", 10), ("100%", 1)] {
+        let span = (hi - lo) / frac;
+        let start = (lo + (hi - lo) / 2).min(hi - span);
+        let range = start..=start + span;
+
+        let mut time = |run: &mut dyn FnMut(&mut Vec<u32>)| {
+            for _ in 0..2 {
+                hits.clear();
+                run(&mut hits);
+            }
+            const REPS: usize = 5;
+            let t0 = Instant::now();
+            for _ in 0..REPS {
+                hits.clear();
+                run(&mut hits);
+                black_box(hits.len());
+            }
+            (
+                t0.elapsed().as_nanos() as f64 / REPS as f64 / 1000.0,
+                hits.len(),
+            )
+        };
+        let (bwl_us, n_bwl) =
+            time(&mut |h| bwl.get_row_ids_for_value_range(range.clone(), 0..N as u32, h));
+        let (bf_us, n_bf) =
+            time(&mut |h| bfor.get_row_ids_for_value_range(range.clone(), 0..N as u32, h));
+        assert_eq!(n_bwl, n_bf, "{label}: codecs disagree on hit count");
+        println!(
+            "{label:>12} {bwl_us:>10.0} {bf_us:>12.0} {:>9.2} {n_bwl:>10}",
+            bwl_us / bf_us
         );
     }
 }
@@ -482,6 +567,106 @@ fn range_filter_ab() {
     ab::<BlockwiseLinearCodec>("BlockwiseLinear", buf[1..].to_vec(), vals[N - 1]);
 }
 
+/// Bits per value per codec on timestamp shapes, including gaps; answers what
+/// a delta codec would be worth over the existing set.
+///
+/// ```text
+/// cargo test --release -p tantivy-columnar --lib timestamp_sizes \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn timestamp_sizes() {
+    const N: usize = 100_000;
+    const DAY_MS: u64 = 86_400_000;
+
+    /// Bits/value if consecutive deltas were bitpacked per 128-value block at
+    /// each block's own width -- an upper bound on what a delta codec could
+    /// do, ignoring the per-block metadata it would also need.
+    fn delta_bound(vals: &[u64]) -> f64 {
+        let mut bits = 0u64;
+        for block in vals.chunks(128) {
+            let mut prev = block[0];
+            let mut max_delta = 0u64;
+            for &v in &block[1..] {
+                max_delta = max_delta.max(v.wrapping_sub(prev));
+                prev = v;
+            }
+            bits += 64 + tantivy_bitpacker::compute_num_bits(max_delta) as u64 * 128;
+        }
+        bits as f64 / vals.len() as f64
+    }
+
+    let dense: Vec<u64> = (0..N as u64)
+        .map(|i| 1_700_000_000_000 + i * 250 + (i.wrapping_mul(2_654_435_761) % 4_000))
+        .collect();
+    // One day of silence in the middle: the shape the question is about.
+    let one_gap: Vec<u64> = dense
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| if i >= N / 2 { v + DAY_MS } else { v })
+        .collect();
+    // A gap every 10k rows, e.g. a nightly batch job.
+    let many_gaps: Vec<u64> = dense
+        .iter()
+        .enumerate()
+        .map(|(i, &v)| v + DAY_MS * (i / 10_000) as u64)
+        .collect();
+    // Bursty arrivals: no steady rate for a line to fit.
+    let bursty: Vec<u64> = {
+        let mut t = 1_700_000_000_000u64;
+        (0..N as u64)
+            .map(|i| {
+                t += if i % 997 == 0 { DAY_MS } else { i % 40 };
+                t
+            })
+            .collect()
+    };
+
+    println!(
+        "{:>12} {:>10} {:>8} {:>8} {:>8} {:>8} {:>10}",
+        "shape", "codec", "Bitpckd", "Linear", "BWL", "BlockFor", "delta_bnd"
+    );
+    // Coarser granularities: what an index that stores seconds or minutes
+    // rather than milliseconds hands the codec.
+    let by_second: Vec<u64> = dense.iter().map(|v| v / 1_000 * 1_000).collect();
+    let by_minute: Vec<u64> = dense.iter().map(|v| v / 60_000 * 60_000).collect();
+
+    for (name, vals) in [
+        ("dense", &dense),
+        ("one day gap", &one_gap),
+        ("gap/10k", &many_gaps),
+        ("bursty", &bursty),
+        ("by second", &by_second),
+        ("by minute", &by_minute),
+    ] {
+        let mut bits = Vec::new();
+        for codec in [
+            CodecType::Bitpacked,
+            CodecType::Linear,
+            CodecType::BlockwiseLinear,
+            CodecType::BlockFor,
+        ] {
+            let mut buf = Vec::new();
+            serialize_u64_based_column_values(&&vals[..], &[codec], &mut buf).unwrap();
+            bits.push(buf.len() as f64 * 8.0 / vals.len() as f64);
+        }
+        // What the selection actually ships.
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&vals[..], &ALL_U64_CODEC_TYPES, &mut buf).unwrap();
+        let chosen = CodecType::try_from_code(buf[0]).unwrap();
+        println!(
+            "{name:>12} {:>10} {:>8.2} {:>8.2} {:>8.2} {:>8.2} {:>10.2}",
+            format!("{chosen:?}"),
+            bits[0],
+            bits[1],
+            bits[2],
+            bits[3],
+            delta_bound(vals)
+        );
+    }
+}
+
 /// Every packed residual width reaches a SIMD unpack kernel, so `Linear`
 /// reports the same threshold at all of them. Nothing about the *values*
 /// changes with the threshold, so only an assertion on the threshold itself
@@ -531,9 +716,17 @@ fn test_min_batch_rows_per_codec() {
             }
             covered.push(format!("{codec:?}"));
             let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
+            let got = column.min_batch_rows();
+            let expect_flat = matches!(
+                codec,
+                CodecType::Bitpacked | CodecType::Linear | CodecType::BlockwiseLinear
+            );
+            let flat = min_batch_rows(DecodeCost::Flat);
+            let blocked = min_batch_rows(DecodeCost::Blocked);
+            assert!(flat > blocked, "Flat must cross over later than Blocked");
+            let expected = if expect_flat { flat } else { blocked };
             assert_eq!(
-                column.min_batch_rows(),
-                min_batch_rows(DecodeCost::Flat),
+                got, expected,
                 "{codec:?} reports the wrong DecodeCost family"
             );
         }
@@ -670,7 +863,7 @@ fn test_fast_field_codec_type_to_code() {
             count_codec += 1;
         }
     }
-    assert_eq!(count_codec, 3);
+    assert_eq!(count_codec, 4);
 }
 
 fn test_fastfield_gcd_i64_with_codec(codec_type: CodecType, num_vals: usize) -> io::Result<()> {

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -127,14 +127,17 @@ pub(crate) fn create_and_validate<TColumnCodec: ColumnCodec>(
     reader.get_range(0, &mut buffer);
     assert_eq!(vals, buffer, "get_range (full) mismatch in data set {name}");
     if vals.len() >= 2 {
-        let start = 1usize;
-        buffer.resize(vals.len() - start, 0);
-        reader.get_range(start as u64, &mut buffer);
-        assert_eq!(
-            &vals[start..],
-            &buffer[..],
-            "get_range (sub-range) mismatch in data set {name}"
-        );
+        // Offset 1 exercises the entrance ramp of a batch decode; the
+        // mid-column offset lands on different alignments as lengths vary.
+        for start in [1usize, vals.len() / 2] {
+            buffer.resize(vals.len() - start, 0);
+            reader.get_range(start as u64, &mut buffer);
+            assert_eq!(
+                &vals[start..],
+                &buffer[..],
+                "get_range (start {start}) mismatch in data set {name}"
+            );
+        }
     }
 
     if !vals.is_empty() {
@@ -152,6 +155,24 @@ pub(crate) fn create_and_validate<TColumnCodec: ColumnCodec>(
             &mut positions,
         );
         assert_eq!(expected_positions, positions);
+    }
+    // Range filter on a sub row-range with a proper value range, against a
+    // naive filter.
+    if vals.len() >= 3 {
+        let lo = *vals.iter().min().unwrap();
+        let hi = *vals.iter().max().unwrap();
+        let value_lo = lo + (hi - lo) / 4;
+        let value_hi = lo + (hi - lo) / 4 * 3;
+        let row_range = 1u32..(vals.len() as u32 - 1);
+        let expected: Vec<u32> = (row_range.start..row_range.end)
+            .filter(|&row| (value_lo..=value_hi).contains(&vals[row as usize]))
+            .collect();
+        let mut positions = Vec::new();
+        reader.get_row_ids_for_value_range(value_lo..=value_hi, row_range, &mut positions);
+        assert_eq!(
+            expected, positions,
+            "get_row_ids_for_value_range mismatch in data set {name}"
+        );
     }
     if actual_compression > 1000 {
         assert!(relative_difference(estimation, actual_compression) < 0.10f32);
@@ -272,6 +293,324 @@ fn test_codec_interpolation() {
 #[test]
 fn test_codec_multi_interpolation() {
     test_codec::<BlockwiseLinearCodec>();
+}
+
+/// Data shapes long enough to span several 128-value blocks, including a
+/// trailing partial one.
+fn multi_block_datasets() -> Vec<(Vec<u64>, &'static str)> {
+    use rand::SeedableRng;
+    let mut rng = rand::rngs::StdRng::from_seed([9u8; 32]);
+    vec![
+        ((0..600u64).map(|i| i * 3 + 7).collect(), "monotonic"),
+        (
+            (0..600).map(|_| rng.random_range(0..1_000_000)).collect(),
+            "random",
+        ),
+        (vec![42u64; 600], "constant"),
+        (
+            (0..600u64)
+                .map(|i| if i % 97 == 0 { u64::MAX / 2 } else { i })
+                .collect(),
+            "outliers",
+        ),
+        (
+            (0..600u64).map(|i| 1_700_000_000_000 + i * 1_000).collect(),
+            "timestamps",
+        ),
+        // Decimal f64 values, stored as the u64 bit-mapping the codecs see.
+        (
+            (0..600u64)
+                .map(|i| f64::to_u64((i as f64) / 100.0))
+                .collect(),
+            "decimals",
+        ),
+    ]
+}
+
+/// Names of every codec, so a test can prove it actually exercised all of
+/// them rather than skipping some via a `continue`.
+fn all_codec_names() -> Vec<String> {
+    let mut names: Vec<String> = ALL_U64_CODEC_TYPES
+        .iter()
+        .map(|c| format!("{c:?}"))
+        .collect();
+    names.sort();
+    names
+}
+
+/// What `DateTimePrecision` is worth on a date fast field: truncation keeps
+/// values in nanoseconds, so the saving comes entirely from
+/// `ColumnStats::gcd` dividing the common factor out.
+///
+/// ```text
+/// cargo test --release -p tantivy-columnar --lib date_precision_sizes \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn date_precision_sizes() {
+    const N: usize = 500_000;
+    // Millisecond-resolution timestamps, as they arrive.
+    let ms: Vec<u64> = (0..N as u64)
+        .map(|i| 1_700_000_000_000 + i * 250 + (i.wrapping_mul(2_654_435_761) % 4_000))
+        .collect();
+
+    println!(
+        "\n{:>14} {:>10} {:>16} {:>8} {:>9}",
+        "precision", "gcd", "chosen", "b/val", "MB"
+    );
+    for (label, unit_ns) in [
+        ("nanoseconds", 1u64),
+        ("microseconds", 1_000),
+        ("milliseconds", 1_000_000),
+        ("seconds", 1_000_000_000),
+    ] {
+        // to_u64 is nanos; truncate() zeroes below the precision, so every
+        // value stays in nanos and becomes a multiple of `unit_ns`.
+        let nanos: Vec<u64> = ms
+            .iter()
+            .map(|&v| (v * 1_000_000 / unit_ns) * unit_ns)
+            .collect();
+        let mut collector = StatsCollector::default();
+        for &v in &nanos {
+            collector.collect(v);
+        }
+        let gcd = collector.stats().gcd.get();
+        let mut buf = Vec::new();
+        serialize_u64_based_column_values(&&nanos[..], &ALL_U64_CODEC_TYPES, &mut buf).unwrap();
+        println!(
+            "{label:>14} {gcd:>10} {:>16} {:>8.2} {:>9.2}",
+            format!("{:?}", CodecType::try_from_code(buf[0]).unwrap()),
+            buf.len() as f64 * 8.0 / N as f64,
+            buf.len() as f64 / 1e6,
+        );
+    }
+}
+
+/// Calibration harness for the `get_row_ids_for_value_range` overrides:
+/// batched decode-then-filter vs the `ColumnValues` per-value default. Run
+/// this before adding or removing an override -- which codecs win is not
+/// obvious and does not generalize.
+///
+/// ```text
+/// cargo test --release -p tantivy-columnar --lib range_filter_ab \
+///     -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore]
+fn range_filter_ab() {
+    use std::time::Instant;
+
+    use crate::column_values::u64_based::{BlockwiseLinearCodec, LinearCodec};
+
+    const N: usize = 1 << 16;
+
+    /// The `ColumnValues::get_row_ids_for_value_range` default, verbatim.
+    fn per_value<C: ColumnValues<u64>>(
+        col: &C,
+        value_range: std::ops::RangeInclusive<u64>,
+        row_id_range: std::ops::Range<u32>,
+        hits: &mut Vec<u32>,
+    ) {
+        let row_id_range = row_id_range.start..row_id_range.end.min(col.num_vals());
+        for idx in row_id_range {
+            if value_range.contains(&col.get_val(idx)) {
+                hits.push(idx);
+            }
+        }
+    }
+
+    fn ab<C: ColumnCodec<u64>>(label: &str, bytes: Vec<u8>, spread: u64) {
+        let col = C::load(OwnedBytes::new(bytes)).unwrap();
+        println!("\n=== {label} ===");
+        println!(
+            "{:>12} {:>10} {:>12} {:>8}",
+            "selectivity", "batch_ns", "pervalue_ns", "ratio"
+        );
+        for (sel, frac) in [("1%", 100u64), ("25%", 4), ("50%", 2), ("100%", 1)] {
+            let hi = spread / frac;
+            let mut batched = Vec::with_capacity(N);
+            let mut naive = Vec::with_capacity(N);
+            // Correctness guard: an A/B that measures two different answers is
+            // measuring nothing.
+            batched.clear();
+            naive.clear();
+            col.get_row_ids_for_value_range(0..=hi, 0..N as u32, &mut batched);
+            per_value(&col, 0..=hi, 0..N as u32, &mut naive);
+            assert_eq!(batched, naive, "{label} {sel}: arms disagree");
+
+            const REPS: usize = 60;
+            for _ in 0..8 {
+                batched.clear();
+                col.get_row_ids_for_value_range(0..=hi, 0..N as u32, &mut batched);
+                naive.clear();
+                per_value(&col, 0..=hi, 0..N as u32, &mut naive);
+            }
+            let t0 = Instant::now();
+            for _ in 0..REPS {
+                batched.clear();
+                col.get_row_ids_for_value_range(0..=hi, 0..N as u32, &mut batched);
+                std::hint::black_box(batched.len());
+            }
+            let batch_ns = t0.elapsed().as_nanos() as f64 / (REPS * N) as f64;
+            let t1 = Instant::now();
+            for _ in 0..REPS {
+                naive.clear();
+                per_value(&col, 0..=hi, 0..N as u32, &mut naive);
+                std::hint::black_box(naive.len());
+            }
+            let pv_ns = t1.elapsed().as_nanos() as f64 / (REPS * N) as f64;
+            println!(
+                "{sel:>12} {batch_ns:>10.4} {pv_ns:>12.4} {:>8.2}",
+                pv_ns / batch_ns
+            );
+        }
+    }
+
+    // A noisy ramp: what Linear is actually chosen for.
+    const SPREAD: u64 = 1 << 20;
+    let vals: Vec<u64> = (0..N as u64)
+        .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % SPREAD))
+        .collect();
+
+    let mut buf = Vec::new();
+    serialize_u64_based_column_values(&&vals[..], &[CodecType::Linear], &mut buf).unwrap();
+    ab::<LinearCodec>("Linear", buf[1..].to_vec(), vals[N - 1]);
+
+    let mut buf = Vec::new();
+    serialize_u64_based_column_values(&&vals[..], &[CodecType::BlockwiseLinear], &mut buf).unwrap();
+    ab::<BlockwiseLinearCodec>("BlockwiseLinear", buf[1..].to_vec(), vals[N - 1]);
+}
+
+/// Every packed residual width reaches a SIMD unpack kernel, so `Linear`
+/// reports the same threshold at all of them. Nothing about the *values*
+/// changes with the threshold, so only an assertion on the threshold itself
+/// notices if a width silently drops back to scalar.
+#[test]
+fn test_linear_batches_at_every_width() {
+    use crate::column_values::u64_based::block_decode::{DecodeCost, min_batch_rows};
+
+    // Residuals run several bits wider than the noise term, so these straddle
+    // the narrow/wide kernel boundary with margin on both sides.
+    for noise_bits in [4u32, 12, 30, 48] {
+        let vals: Vec<u64> = (0..2_000u64)
+            .map(|i| i * 16 + (i.wrapping_mul(2_654_435_761) % (1u64 << noise_bits)))
+            .collect();
+        let mut buffer = Vec::new();
+        if serialize_u64_based_column_values(&&vals[..], &[CodecType::Linear], &mut buffer).is_err()
+        {
+            continue;
+        }
+        let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
+        assert_eq!(
+            column.min_batch_rows(),
+            min_batch_rows(DecodeCost::Flat),
+            "noise_bits={noise_bits} must report the Flat threshold"
+        );
+        let mut out = vec![0u64; 300];
+        column.get_range(137, &mut out);
+        for (i, o) in out.iter().enumerate() {
+            assert_eq!(*o, vals[137 + i], "noise_bits={noise_bits} i={i}");
+        }
+    }
+}
+
+/// The per-codec `min_batch_rows` family assignment. Value-equality tests
+/// cannot see this: picking the wrong `DecodeCost` only changes *which* path
+/// produces a value, never the value.
+#[test]
+fn test_min_batch_rows_per_codec() {
+    use crate::column_values::u64_based::block_decode::{DecodeCost, min_batch_rows};
+
+    let mut covered: Vec<String> = Vec::new();
+    for (vals, _shape) in multi_block_datasets() {
+        for codec in ALL_U64_CODEC_TYPES {
+            let mut buffer = Vec::new();
+            if serialize_u64_based_column_values(&&vals[..], &[codec], &mut buffer).is_err() {
+                continue;
+            }
+            covered.push(format!("{codec:?}"));
+            let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer)).unwrap();
+            assert_eq!(
+                column.min_batch_rows(),
+                min_batch_rows(DecodeCost::Flat),
+                "{codec:?} reports the wrong DecodeCost family"
+            );
+        }
+    }
+    covered.sort();
+    covered.dedup();
+    assert_eq!(covered, all_codec_names(), "a codec was skipped");
+}
+
+/// `get_range` must agree with the source values at every phase relative to
+/// the 128-value block grid, on every codec that can encode the data.
+/// `load_u64_based_column_values_raw` is deliberate: it skips the monotonic
+/// wrapper, so the codec's batch path is reached at every length rather than
+/// only above the wrapper's `min_batch_rows` gate.
+#[test]
+fn test_get_range_all_codecs_all_block_phases() {
+    let mut covered: Vec<String> = Vec::new();
+    for (vals, shape) in multi_block_datasets() {
+        for codec in ALL_U64_CODEC_TYPES {
+            let mut buffer = Vec::new();
+            if serialize_u64_based_column_values(&&vals[..], &[codec], &mut buffer).is_err() {
+                continue;
+            }
+            covered.push(format!("{codec:?}"));
+            let column = load_u64_based_column_values_raw(OwnedBytes::new(buffer.clone())).unwrap();
+            assert_eq!(column.num_vals() as usize, vals.len(), "{codec:?}/{shape}");
+
+            // Every phase of the block grid, and lengths straddling the block
+            // size, the partial-block floor, and the trailing partial block.
+            for start in 0..140usize {
+                for len in [1usize, 2, 47, 48, 79, 80, 128, 129, 256, 400] {
+                    if start + len > vals.len() {
+                        continue;
+                    }
+                    let mut output = vec![0u64; len];
+                    column.get_range(start as u64, &mut output);
+                    assert_eq!(
+                        output,
+                        vals[start..start + len],
+                        "{codec:?}/{shape}: get_range(start={start}, len={len})"
+                    );
+                }
+            }
+
+            // Ranges that end exactly at the column end, i.e. run through the
+            // trailing partial block.
+            for len in [1usize, 64, 128, 200, 600] {
+                let start = vals.len() - len;
+                let mut output = vec![0u64; len];
+                column.get_range(start as u64, &mut output);
+                assert_eq!(
+                    output,
+                    vals[start..],
+                    "{codec:?}/{shape}: tail get_range(start={start}, len={len})"
+                );
+            }
+
+            // The same data through the wrapper, which gates short takes onto
+            // the per-value loop: both routes must agree.
+            let wrapped: Arc<dyn ColumnValues<u64>> =
+                load_u64_based_column_values(OwnedBytes::new(buffer)).unwrap();
+            for start in [0usize, 1, 63, 127, 128, 129] {
+                for len in [1usize, 47, 96, 128, 300] {
+                    if start + len > vals.len() {
+                        continue;
+                    }
+                    let mut output = vec![0u64; len];
+                    wrapped.get_range(start as u64, &mut output);
+                    assert_eq!(
+                        output,
+                        vals[start..start + len],
+                        "{codec:?}/{shape}: wrapped get_range(start={start}, len={len})"
+                    );
+                }
+            }
+        }
+    }
 }
 
 use super::*;

--- a/columnar/src/column_values/u64_based/tests.rs
+++ b/columnar/src/column_values/u64_based/tests.rs
@@ -298,6 +298,10 @@ fn test_codec_multi_interpolation() {
 fn test_codec_block_for() {
     test_codec::<BlockForCodec>();
 }
+#[test]
+fn test_codec_alp() {
+    test_codec::<alp::AlpCodec>();
+}
 
 /// Data shapes long enough to span several 128-value blocks, including a
 /// trailing partial one.

--- a/columnar/src/column_values/vec_column.rs
+++ b/columnar/src/column_values/vec_column.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use tantivy_bitpacker::minmax;
 
 use crate::ColumnValues;
+use crate::column_values::BatchThresholds;
 
 /// VecColumn provides `Column` over a `Vec<T>`.
 pub struct VecColumn<T = u64> {
@@ -36,8 +37,13 @@ impl<T: Copy + PartialOrd + Send + Sync + Debug + 'static> ColumnValues<T> for V
         output.copy_from_slice(&self.values[start as usize..][..output.len()])
     }
 
-    fn min_batch_rows(&self) -> usize {
-        1
+    fn batch_thresholds(&self) -> BatchThresholds {
+        // A memcpy; the buffered arm's own crossover is unmeasured, so this
+        // keeps the value the 4/3 derivation used to produce.
+        BatchThresholds {
+            forwarding: 1,
+            buffered: 2,
+        }
     }
 }
 

--- a/columnar/src/column_values/vec_column.rs
+++ b/columnar/src/column_values/vec_column.rs
@@ -35,6 +35,10 @@ impl<T: Copy + PartialOrd + Send + Sync + Debug + 'static> ColumnValues<T> for V
     fn get_range(&self, start: u64, output: &mut [T]) {
         output.copy_from_slice(&self.values[start as usize..][..output.len()])
     }
+
+    fn min_batch_rows(&self) -> usize {
+        1
+    }
 }
 
 impl<T: Copy + PartialOrd + Default> From<Vec<T>> for VecColumn<T> {


### PR DESCRIPTION
> **Update:** this PR now carries the whole series as five self-contained commits — the
> batch-decode work from #3043 is commits 1–2 (rewritten), the codecs follow. If you have
> reviewed #3043, start at `feat(columnar): BlockFor per-block frame-of-reference codec`.
> The ALP codec is no longer wired into the format (details below).

## Motivation

The u64 codec roster has a structural gap: every codec prices the whole column
at once. `Bitpacked` uses one bit width for all values, so a handful of
outliers inflates every row — a million 42_000s with 0.1% random 48-bit
outliers pack at 48 bits/value.

This PR first routes `ColumnValues::get_range` through SIMD kernels that
unpack 128 fixed-width values per call (NEON on aarch64, AVX2 on x86_64), then
adds a codec that prices each 128-value block independently on top of the same
kernels:

- **BlockFor (code 3)** — per-block frame of reference: each block stores its
  own minimum and bit width, so outliers only inflate the block they live in.
  Block metadata is bitpacked into fixed-width records read in place off the
  mapped bytes (O(1) load, zero resident metadata), and the range filter
  prunes whole blocks by their metadata before decoding.

An **ALP-style pseudo-decimal codec for f64 columns** (following Afroozeh et
al.) ships as code but is deliberately **not wired into `CodecType`**: it
needs more validation before production columns serialize with it. `alp.rs`
is compiled and fully tested through its estimator/loader; no code byte is
reserved, and wiring it up later is a small change.

## Commits

1. `perf(bitpacker): SIMD block decode kernels for bitpacked values` — narrow
   u32-lane kernel for widths 1..=25, wide u64-lane kernel for 26..=56, scalar
   fallback; drops the external `bitpacking` dependency.
2. `perf(columnar): batch get_range through whole-block decode` — a shared
   `BlockDecode` trait drives Bitpacked/Linear/BlockwiseLinear; the monotonic
   wrapper gains a three-way `get_range` (per-value below the codec-reported
   `min_batch_rows` crossover, in-place forward when `Input == Output`,
   block-buffered otherwise); `ColumnBlockAccessor` serves 1-doc fetches with
   a direct `get_val`.
3. `feat(columnar): BlockFor per-block frame-of-reference codec` — joins the
   default selection with a ~7.7% size penalty against its pricier random
   access.
4. `feat(columnar): experimental ALP pseudo-decimal codec for f64 columns` —
   not in `CodecType`.
5. `test(columnar): extend codec benchmarks for batch decode paths`

## Numbers

Measured on Apple M4 (NEON) and a 32-core x86_64 host (AVX2, native — not
Rosetta). In-process A/B where possible; `TANTIVY_BITPACKER_SCALAR=1` forces
the scalar decode path.

### Kernels (`kernel_sweep`, one 128-value block, vs scalar unpack)

| kernel | widths | M4 / NEON | x86 / AVX2 |
|---|---|---|---|
| narrow (u32 lanes) | 1..=25 | 3.16–3.28× | 3.48–3.56× |
| wide (u64 lanes) | 26..=56 | 2.79–2.96× | 3.99–4.29× |

Every packed width reaches a kernel (pinned by a test); widths 0/64 are
served by fill/plain loads.

### Batch `get_range` vs the per-value default it replaces (`bench_bitpacked_batch`, medians)

| shape | M4 | x86 |
|---|---|---|
| full scan, widths 8..64 | 4.0–4.5× | 5.8–7.1× |
| scattered 64-row takes | 2.0× | 2.2× |
| scattered 16-row takes | 1.9× | 2.2× |
| f64 column, 128-row chunks (buffered wrapper path) | 1.6–1.9× | 2.5× |

1-row takes deliberately fall back to the per-value loop; the production
1-doc path (`ColumnBlockAccessor`) short-circuits to `get_val`.

### BlockFor (2M-row shapes, `bench_column_values_get`, medians, M4)

The selection still picks BlockwiseLinear on these shapes on size; BlockFor's
win is the metadata-pruned range filter and whole-block decode:

| timestamps shape | BlockwiseLinear | BlockFor |
|---|---|---|
| `filter_1pct_span` | 1543 µs | **57 µs (27×)** |
| `filter_walk_only` (no hits) | 1539 µs | **32 µs (49×)** |
| `get_range_seq128` | 919 µs | 492 µs (1.9×) |
| `get_val_random` (100k gets) | 288 µs | 569 µs (0.5×) |

Random single-value access is where BlockFor pays (block-meta load per get) —
hence the 13/12 selection penalty: it must win on size by ≥ ~7.7%, so a
near-tie never trades a 55–80% random-get cost for a noise-level size win.
Write side: BlockFor serializes at ~ BlockwiseLinear speed (502 vs 515 µs on
the 130k-value bench input).

### End-to-end regression check (this branch vs its merge-base, same machine)

- `agg_bench` (1M-doc indices built by the *base* binary, so both sides read
  identical bytes): median delta −1.9% across the metrics/cardinality group,
  everything inside the cross-binary noise band.
- `range_query`, `str_search_and_get`, `merge_segments` and the columnar
  `bench_values_u64` / `bench_access` / `bench_merge`: medians flat (−0.3% to
  +2.6% per suite); the fast-field range-filter cells improve ~15%.
- Index size, `agg_bench` corpus rebuilt by each side: **77.2 MB vs 80.3 MB
  (−3.9%)** with BlockFor in the selection; `.fast` files 33.0 vs 33.5 MB.

## Format impact

Codec code 3 (BlockFor) is new: columns written after this PR may not be
readable by older readers. Everything previously written stays readable — the
existing codecs and their code bytes are untouched. ALP reserves no code.

## Verification

- `tantivy-bitpacker` 25 tests, `tantivy-columnar` 233 tests: pass on
  aarch64/NEON **and natively on x86_64/AVX2**, each also with
  `TANTIVY_BITPACKER_SCALAR=1` forcing the scalar path.
- Each of the five commits compiles warning-free and passes the crate suites
  individually.
- New tests: proptests for `get_batch`/`get_batch_u32s` across all widths and
  block phases; per-width kernel-vs-scalar equality plus a gate test proving
  no packed width silently falls back to scalar; every codec × every block
  phase `get_range` equality (raw + wrapped); wrapper-forwarding pin tests
  (`min_batch_rows`, `specializations_survive_arc`); BlockFor
  footer-layout/estimate-exactness tests; ALP round-trip incl. NaN/±0/inf,
  full-exception blocks, and opt-out on non-decimal / full-precision data.
- Threshold calibration is reproducible via the ignored `gate_sweep` /
  `kernel_sweep` tests (commands in their doc comments); the x86 sweep
  confirms the shipped `min_batch_rows` values hold there too.
