### PR TITLE
Faster exists queries on columns (up to 500x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,6 +195,10 @@ name = "exists_json"
 harness = false
 
 [[bench]]
+name = "exists_query"
+harness = false
+
+[[bench]]
 name = "range_query"
 harness = false
 

--- a/benches/exists_query.rs
+++ b/benches/exists_query.rs
@@ -1,0 +1,228 @@
+use binggan::{black_box, BenchRunner};
+use rand::prelude::*;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use serde_json::json;
+use tantivy::collector::Count;
+use tantivy::query::{BooleanQuery, ExistsQuery, Query, TermQuery};
+use tantivy::schema::{Field, IndexRecordOption, Schema, FAST, TEXT};
+use tantivy::{Index, ReloadPolicy, Searcher, TantivyDocument, Term};
+
+const NUM_DOCS: usize = 5_000_000;
+const EXISTS_SELECTIVITIES: &[f64] = &[0.001, 0.1, 0.9];
+const TERM_SELECTIVITIES: &[f64] = &[0.0001, 0.01, 0.5];
+
+struct ColumnFields {
+    optional: Field,
+    multivalued: Field,
+    multiple_columns: Field,
+}
+
+struct BenchIndex {
+    #[allow(dead_code)]
+    index: Index,
+    searcher: Searcher,
+    selector: Field,
+}
+
+fn field_suffix(selectivity: f64) -> String {
+    format_pct(selectivity)
+        .replace('.', "d")
+        .replace('%', "pct")
+}
+
+fn format_pct(selectivity: f64) -> String {
+    let pct = selectivity * 100.0;
+    if pct >= 1.0 {
+        format!("{pct:.0}%")
+    } else if pct >= 0.1 {
+        format!("{pct:.1}%")
+    } else {
+        format!("{pct:.2}%")
+    }
+}
+
+fn selector_term(selectivity: f64) -> String {
+    format!("selector{}", field_suffix(selectivity))
+}
+
+fn column_encoding(selectivity: f64) -> &'static str {
+    if selectivity < 0.1 {
+        "sparse blocks"
+    } else {
+        "dense blocks"
+    }
+}
+
+fn build_index() -> BenchIndex {
+    let mut schema_builder = Schema::builder();
+    let selector = schema_builder.add_text_field("selector", TEXT);
+    let columns: Vec<ColumnFields> = EXISTS_SELECTIVITIES
+        .iter()
+        .map(|&selectivity| {
+            let suffix = field_suffix(selectivity);
+            let optional_name = format!("optional_{suffix}");
+            let multivalued_name = format!("multivalued_{suffix}");
+            let multiple_columns_name = format!("multiple_columns_{suffix}");
+            ColumnFields {
+                optional: schema_builder.add_u64_field(&optional_name, FAST),
+                multivalued: schema_builder.add_u64_field(&multivalued_name, FAST),
+                multiple_columns: schema_builder
+                    .add_json_field(&multiple_columns_name, TEXT | FAST),
+            }
+        })
+        .collect();
+    let index = Index::create_in_ram(schema_builder.build());
+    let mut rng = StdRng::from_seed([7u8; 32]);
+
+    {
+        let mut writer = index.writer_with_num_threads(1, 4_000_000_000).unwrap();
+        for doc_id in 0..NUM_DOCS {
+            let mut doc = TantivyDocument::default();
+
+            for (&selectivity, fields) in EXISTS_SELECTIVITIES.iter().zip(&columns) {
+                if rng.random_bool(selectivity) {
+                    doc.add_u64(fields.optional, doc_id as u64);
+                    // Two values force this column to use MultiValueIndex while preserving the
+                    // same set of matching documents as the optional column.
+                    doc.add_u64(fields.multivalued, doc_id as u64);
+                    doc.add_u64(fields.multivalued, doc_id as u64 + 1);
+                    let multiple_columns_value = if doc_id % 2 == 0 {
+                        json!({"optional": doc_id as u64})
+                    } else {
+                        json!({"multivalued": [doc_id as u64, doc_id as u64 + 1]})
+                    };
+                    doc.add_field_value(fields.multiple_columns, &multiple_columns_value);
+                }
+            }
+
+            for &selectivity in TERM_SELECTIVITIES {
+                if rng.random_bool(selectivity) {
+                    doc.add_text(selector, selector_term(selectivity));
+                }
+            }
+
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+    }
+
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()
+        .unwrap();
+    let searcher = reader.searcher();
+
+    BenchIndex {
+        index,
+        searcher,
+        selector,
+    }
+}
+
+fn exists_query(column_kind: &str, selectivity: f64) -> Box<dyn Query> {
+    Box::new(ExistsQuery::new(
+        format!("{column_kind}_{}", field_suffix(selectivity)),
+        column_kind == "multiple_columns",
+    ))
+}
+
+fn intersection_query(
+    bench_index: &BenchIndex,
+    column_kind: &str,
+    exists_selectivity: f64,
+    term_selectivity: f64,
+) -> Box<dyn Query> {
+    let term = Term::from_field_text(bench_index.selector, &selector_term(term_selectivity));
+    let term_query = TermQuery::new(term, IndexRecordOption::Basic);
+    Box::new(BooleanQuery::intersection(vec![
+        Box::new(term_query),
+        exists_query(column_kind, exists_selectivity),
+    ]))
+}
+
+fn register_query(
+    group: &mut binggan::BenchGroup,
+    bench_index: &BenchIndex,
+    name: &str,
+    query: Box<dyn Query>,
+) {
+    let task = SearchTask {
+        searcher: bench_index.searcher.clone(),
+        query,
+    };
+    group.register(name.to_string(), move |_| black_box(task.run()));
+}
+
+fn main() {
+    let bench_index = build_index();
+
+    let mut exists_runner = BenchRunner::with_name("exists");
+    for &exists_selectivity in EXISTS_SELECTIVITIES {
+        let mut group = exists_runner.new_group();
+        group.set_name(format!(
+            "column populated in {} of docs ({})",
+            format_pct(exists_selectivity),
+            column_encoding(exists_selectivity)
+        ));
+        register_query(
+            &mut group,
+            &bench_index,
+            "optional",
+            exists_query("optional", exists_selectivity),
+        );
+        register_query(
+            &mut group,
+            &bench_index,
+            "multivalued",
+            exists_query("multivalued", exists_selectivity),
+        );
+        register_query(
+            &mut group,
+            &bench_index,
+            "multiple_columns",
+            exists_query("multiple_columns", exists_selectivity),
+        );
+        group.run();
+    }
+
+    let mut intersection_runner = BenchRunner::with_name("term_AND_exists");
+    for &exists_selectivity in EXISTS_SELECTIVITIES {
+        for &term_selectivity in TERM_SELECTIVITIES {
+            let mut group = intersection_runner.new_group();
+            group.set_name(format!(
+                "term matches {} of docs, column populated in {} ({})",
+                format_pct(term_selectivity),
+                format_pct(exists_selectivity),
+                column_encoding(exists_selectivity)
+            ));
+            for column_kind in ["optional", "multivalued", "multiple_columns"] {
+                register_query(
+                    &mut group,
+                    &bench_index,
+                    column_kind,
+                    intersection_query(
+                        &bench_index,
+                        column_kind,
+                        exists_selectivity,
+                        term_selectivity,
+                    ),
+                );
+            }
+            group.run();
+        }
+    }
+}
+
+struct SearchTask {
+    searcher: Searcher,
+    query: Box<dyn Query>,
+}
+
+impl SearchTask {
+    #[inline(never)]
+    fn run(&self) -> usize {
+        self.searcher.search(&self.query, &Count).unwrap()
+    }
+}

--- a/columnar/src/column/dictionary_encoded.rs
+++ b/columnar/src/column/dictionary_encoded.rs
@@ -4,8 +4,8 @@ use std::{fmt, io};
 
 use sstable::{Dictionary, VoidSSTable};
 
-use crate::RowId;
 use crate::column::Column;
+use crate::{ColumnIndex, RowId};
 
 /// Dictionary encoded column.
 ///
@@ -59,6 +59,10 @@ impl BytesColumn {
         &self.term_ord_column
     }
 
+    pub(crate) fn into_column_index(self) -> ColumnIndex {
+        self.term_ord_column.index
+    }
+
     pub fn num_terms(&self) -> usize {
         self.dictionary.num_terms()
     }
@@ -84,6 +88,10 @@ impl From<StrColumn> for BytesColumn {
 }
 
 impl StrColumn {
+    pub(crate) fn into_column_index(self) -> ColumnIndex {
+        self.0.into_column_index()
+    }
+
     pub fn wrap(bytes_column: BytesColumn) -> StrColumn {
         StrColumn(bytes_column)
     }

--- a/columnar/src/column_index/mod.rs
+++ b/columnar/src/column_index/mod.rs
@@ -11,13 +11,13 @@ mod serialize;
 use std::ops::Range;
 
 pub use merge::merge_column_index;
+pub use multivalued_index::MultiValueIndex;
 pub(crate) use multivalued_index::SerializableMultivalueIndex;
 pub use optional_index::{OptionalIndex, Set};
 pub use serialize::{
     SerializableColumnIndex, SerializableOptionalIndex, open_column_index, serialize_column_index,
 };
 
-use crate::column_index::multivalued_index::MultiValueIndex;
 use crate::{Cardinality, DocId, RowId};
 
 #[derive(Clone, Debug)]

--- a/columnar/src/column_index/multivalued_index.rs
+++ b/columnar/src/column_index/multivalued_index.rs
@@ -215,6 +215,22 @@ impl MultiValueIndex {
         }
     }
 
+    /// Returns true if the document has at least one value.
+    #[inline]
+    pub fn has_value(&self, doc_id: DocId) -> bool {
+        !self.range(doc_id).is_empty()
+    }
+
+    /// Returns the first document with values at or after `target`.
+    pub fn next_non_null_doc(&self, target: DocId) -> Option<DocId> {
+        match self {
+            MultiValueIndex::MultiValueIndexV1(idx) => {
+                (target..idx.num_docs()).find(|&doc| !idx.range(doc).is_empty())
+            }
+            MultiValueIndex::MultiValueIndexV2(idx) => idx.optional_index.next_non_null_doc(target),
+        }
+    }
+
     /// Returns an iterator over document ids that have at least one value.
     pub fn iter_non_null_docs(&self) -> Box<dyn Iterator<Item = DocId> + '_> {
         match self {

--- a/columnar/src/column_index/optional_index/mod.rs
+++ b/columnar/src/column_index/optional_index/mod.rs
@@ -280,6 +280,45 @@ impl OptionalIndex {
         self.num_non_null_docs
     }
 
+    /// Returns the first populated document at or after `target`.
+    pub fn next_non_null_doc(&self, target: DocId) -> Option<DocId> {
+        if target >= self.num_docs {
+            return None;
+        }
+        let first_block = row_addr_from_row_id(target).block_id;
+        for block_id in first_block..self.block_metas.len() as u16 {
+            let block_start = block_id as u32 * ELEMENTS_PER_BLOCK;
+            let in_block_start = if block_id == first_block {
+                (target - block_start) as u16
+            } else {
+                0
+            };
+            let block_meta = self.block_metas[block_id as usize];
+            match self.block(block_meta) {
+                Block::Sparse(block) => {
+                    let rank = block.rank(in_block_start);
+                    let block_end_rank = self
+                        .block_metas
+                        .get(block_id as usize + 1)
+                        .map(|meta| meta.non_null_rows_before_block)
+                        .unwrap_or(self.num_non_null_docs);
+                    if block_meta.non_null_rows_before_block + (rank as u32) < block_end_rank {
+                        return Some(block_start + block.select(rank) as u32);
+                    }
+                }
+                Block::Dense(block) => {
+                    let block_num_docs = (self.num_docs - block_start).min(ELEMENTS_PER_BLOCK);
+                    for in_block_doc in in_block_start as u32..block_num_docs {
+                        if block.contains(in_block_doc as u16) {
+                            return Some(block_start + in_block_doc);
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Appends the queried doc ids that exist in this index and their corresponding ranks.
     ///
     /// Sorted input is processed one encoded block at a time. Unsorted input is supported too,

--- a/columnar/src/column_index/optional_index/tests.rs
+++ b/columnar/src/column_index/optional_index/tests.rs
@@ -32,6 +32,25 @@ fn test_dense_block_threshold() {
     assert_eq!(super::DENSE_BLOCK_THRESHOLD, 5_120);
 }
 
+#[test]
+fn test_next_non_null_doc_across_sparse_and_dense_blocks() {
+    let mut populated_docs = vec![1, 4, ELEMENTS_PER_BLOCK - 1];
+    populated_docs.extend((0..6_000).map(|doc| ELEMENTS_PER_BLOCK + doc));
+    let index = OptionalIndex::for_test(ELEMENTS_PER_BLOCK * 2, &populated_docs);
+
+    assert_eq!(index.next_non_null_doc(0), Some(1));
+    assert_eq!(index.next_non_null_doc(3), Some(4));
+    assert_eq!(
+        index.next_non_null_doc(ELEMENTS_PER_BLOCK),
+        Some(ELEMENTS_PER_BLOCK)
+    );
+    assert_eq!(
+        index.next_non_null_doc(ELEMENTS_PER_BLOCK + 100),
+        Some(ELEMENTS_PER_BLOCK + 100)
+    );
+    assert_eq!(index.next_non_null_doc(ELEMENTS_PER_BLOCK + 6_000), None);
+}
+
 fn random_bitvec() -> BoxedStrategy<Vec<bool>> {
     prop_oneof![
         1 => prop::collection::vec(proptest::bool::weighted(1.0), 0..100),

--- a/columnar/src/dynamic_column.rs
+++ b/columnar/src/dynamic_column.rs
@@ -54,6 +54,20 @@ impl DynamicColumn {
         }
     }
 
+    /// Consumes the dynamic column and returns its underlying column index.
+    pub fn into_column_index(self) -> ColumnIndex {
+        match self {
+            DynamicColumn::Bool(c) => c.index,
+            DynamicColumn::I64(c) => c.index,
+            DynamicColumn::U64(c) => c.index,
+            DynamicColumn::F64(c) => c.index,
+            DynamicColumn::IpAddr(c) => c.index,
+            DynamicColumn::DateTime(c) => c.index,
+            DynamicColumn::Bytes(c) => c.into_column_index(),
+            DynamicColumn::Str(c) => c.into_column_index(),
+        }
+    }
+
     pub fn get_cardinality(&self) -> Cardinality {
         self.column_index().get_cardinality()
     }

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1896,7 +1896,8 @@ mod tests {
             res["my_texts"]["buckets"][1]["key"],
             serde_json::Value::Null
         );
-        assert_eq!(res["my_texts"]["sum_other_doc_count"], 0); // TODO sum_other_doc_count with min_doc_count
+        assert_eq!(res["my_texts"]["sum_other_doc_count"], 0); // TODO sum_other_doc_count with
+                                                               // min_doc_count
         Ok(())
     }
 

--- a/src/query/exist_query.rs
+++ b/src/query/exist_query.rs
@@ -83,7 +83,7 @@ impl Query for ExistsQuery {
                 self.field_name
             )));
         }
-        Ok(Box::new(ExistsWeight {
+        Ok(Box::new(FastFieldExistsWeight {
             field_name: self.field_name.clone(),
             field_type: field_type.value_type(),
             json_subpaths: self.json_subpaths,
@@ -91,14 +91,14 @@ impl Query for ExistsQuery {
     }
 }
 
-/// Weight associated with the `ExistsQuery` query.
-pub struct ExistsWeight {
+/// Fast-field weight associated with the `ExistsQuery` query.
+pub struct FastFieldExistsWeight {
     field_name: String,
     field_type: Type,
     json_subpaths: bool,
 }
 
-impl Weight for ExistsWeight {
+impl Weight for FastFieldExistsWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         let fast_field_reader = reader.fast_fields();
         let mut column_handles = fast_field_reader.dynamic_column_handles(&self.field_name)?;

--- a/src/query/exist_query.rs
+++ b/src/query/exist_query.rs
@@ -1,10 +1,11 @@
 use core::fmt::Debug;
 
-use columnar::{ColumnIndex, DynamicColumn};
+use columnar::column_index::{MultiValueIndex, OptionalIndex, Set};
+use columnar::ColumnIndex;
 use common::BitSet;
 
 use super::{ConstScorer, EmptyScorer};
-use crate::docset::{DocSet, TERMINATED};
+use crate::docset::{DocSet, SeekDangerResult, TERMINATED};
 use crate::index::SegmentReader;
 use crate::query::all_query::AllScorer;
 use crate::query::boost_query::BoostScorer;
@@ -106,25 +107,30 @@ impl Weight for ExistsWeight {
                 fast_field_reader.dynamic_subpath_column_handles(&self.field_name)?;
             column_handles.append(&mut sub_columns);
         }
-        let dynamic_columns: crate::Result<Vec<DynamicColumn>> = column_handles
+        // An exists query only needs the column indexes. Drop the values so that the docset below
+        // operates directly on the specialized optional or multivalued index.
+        let column_indexes: crate::Result<Vec<ColumnIndex>> = column_handles
             .into_iter()
-            .map(|handle| handle.open().map_err(|io_error| io_error.into()))
+            .map(|handle| {
+                handle
+                    .open()
+                    .map(|column| column.into_column_index())
+                    .map_err(|io_error| io_error.into())
+            })
             .collect();
-        let mut non_empty_columns = Vec::new();
-        for column in dynamic_columns? {
-            if !matches!(column.column_index(), ColumnIndex::Empty { .. }) {
-                non_empty_columns.push(column)
-            }
-        }
-        if non_empty_columns.is_empty() {
+        let mut non_empty_column_indexes: Vec<ColumnIndex> = column_indexes?
+            .into_iter()
+            .filter(|column_index| !matches!(column_index, ColumnIndex::Empty { .. }))
+            .collect();
+        if non_empty_column_indexes.is_empty() {
             return Ok(Box::new(EmptyScorer));
         }
 
         // If any column is full, all docs match.
         let max_doc = reader.max_doc();
-        if non_empty_columns
+        if non_empty_column_indexes
             .iter()
-            .any(|col| matches!(col.column_index(), ColumnIndex::Full))
+            .any(|column_index| matches!(column_index, ColumnIndex::Full))
         {
             let all_scorer = AllScorer::new(max_doc);
             if boost != 1.0f32 {
@@ -134,21 +140,30 @@ impl Weight for ExistsWeight {
             }
         }
 
-        // If we have a single dynamic column, use ExistsDocSet
-        // NOTE: A lower number may be better for very sparse columns
-        if non_empty_columns.len() < 4 {
-            let docset = ExistsDocSet::new(non_empty_columns, reader.max_doc());
-            return Ok(Box::new(ConstScorer::new(docset, boost)));
+        // Starting here we are guaranteed that there is no full or empty column left.
+
+        if non_empty_column_indexes.len() == 1 {
+            return match non_empty_column_indexes.pop().unwrap() {
+                ColumnIndex::Optional(optional_index) => {
+                    Ok(exists_scorer(optional_index, max_doc, boost))
+                }
+                ColumnIndex::Multivalued(multivalued_index) => {
+                    Ok(exists_scorer(multivalued_index, max_doc, boost))
+                }
+                ColumnIndex::Empty { .. } | ColumnIndex::Full => unreachable!(),
+            };
+        }
+
+        // NOTE: A lower number may be better for very sparse columns.
+        if non_empty_column_indexes.len() < 4 {
+            return Ok(exists_scorer(non_empty_column_indexes, max_doc, boost));
         }
 
         // If we have many dynamic columns, precompute a bitset of matching docs
         let mut doc_bitset = BitSet::with_max_value(max_doc);
-        for column in &non_empty_columns {
-            match column.column_index() {
-                ColumnIndex::Empty { .. } => {}
-                ColumnIndex::Full => {
-                    // Handled by AllScorer return above.
-                }
+        for column_index in &non_empty_column_indexes {
+            match column_index {
+                ColumnIndex::Empty { .. } | ColumnIndex::Full => unreachable!(),
                 ColumnIndex::Optional(optional_index) => {
                     for doc in optional_index.iter_non_null_docs() {
                         doc_bitset.insert(doc);
@@ -174,42 +189,82 @@ impl Weight for ExistsWeight {
     }
 }
 
-pub(crate) struct ExistsDocSet {
-    columns: Vec<DynamicColumn>,
+pub(crate) trait ExistsIndex: Send {
+    fn next_doc(&self, target: DocId, max_doc: DocId) -> DocId;
+    fn has_value(&self, doc: DocId) -> bool;
+}
+
+impl ExistsIndex for OptionalIndex {
+    fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
+        self.next_non_null_doc(target).unwrap_or(TERMINATED)
+    }
+
+    fn has_value(&self, doc: DocId) -> bool {
+        doc < self.num_docs() && self.contains(doc)
+    }
+}
+
+impl ExistsIndex for MultiValueIndex {
+    fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
+        self.next_non_null_doc(target).unwrap_or(TERMINATED)
+    }
+
+    fn has_value(&self, doc: DocId) -> bool {
+        MultiValueIndex::has_value(self, doc)
+    }
+}
+
+impl ExistsIndex for Vec<ColumnIndex> {
+    fn next_doc(&self, mut target: DocId, max_doc: DocId) -> DocId {
+        while target < max_doc {
+            if self
+                .iter()
+                .any(|column_index| column_index.has_value(target))
+            {
+                return target;
+            }
+            target += 1;
+        }
+        TERMINATED
+    }
+
+    fn has_value(&self, doc: DocId) -> bool {
+        self.iter().any(|column_index| column_index.has_value(doc))
+    }
+}
+
+fn exists_scorer<T: ExistsIndex + 'static>(
+    column_index: T,
+    max_doc: DocId,
+    boost: Score,
+) -> Box<dyn Scorer> {
+    let docset = ExistsDocSet::new(column_index, max_doc);
+    Box::new(ConstScorer::new(docset, boost))
+}
+
+pub(crate) struct ExistsDocSet<T: ExistsIndex> {
+    column_index: T,
     doc: DocId,
     max_doc: DocId,
 }
 
-impl ExistsDocSet {
-    pub(crate) fn new(columns: Vec<DynamicColumn>, max_doc: DocId) -> Self {
-        let mut set = Self {
-            columns,
-            doc: 0u32,
+impl<T: ExistsIndex> ExistsDocSet<T> {
+    pub(crate) fn new(column_index: T, max_doc: DocId) -> Self {
+        let doc = column_index.next_doc(0, max_doc);
+        Self {
+            column_index,
+            doc,
             max_doc,
-        };
-        set.find_next();
-        set
-    }
-
-    fn find_next(&mut self) -> DocId {
-        while self.doc < self.max_doc {
-            if self
-                .columns
-                .iter()
-                .any(|col| col.column_index().has_value(self.doc))
-            {
-                return self.doc;
-            }
-            self.doc += 1;
         }
-        self.doc = TERMINATED;
-        TERMINATED
     }
 }
 
-impl DocSet for ExistsDocSet {
+impl<T: ExistsIndex> DocSet for ExistsDocSet<T> {
     fn advance(&mut self) -> DocId {
-        self.seek(self.doc + 1)
+        if self.doc != TERMINATED {
+            self.doc = self.column_index.next_doc(self.doc + 1, self.max_doc);
+        }
+        self.doc
     }
 
     fn size_hint(&self) -> u32 {
@@ -222,8 +277,22 @@ impl DocSet for ExistsDocSet {
 
     #[inline(always)]
     fn seek(&mut self, target: DocId) -> DocId {
-        self.doc = target;
-        self.find_next()
+        self.doc = self.column_index.next_doc(target, self.max_doc);
+        self.doc
+    }
+
+    fn seek_danger(&mut self, target: DocId) -> SeekDangerResult {
+        if target >= self.max_doc {
+            return SeekDangerResult::SeekLowerBound(TERMINATED);
+        }
+        if self.column_index.has_value(target) {
+            self.doc = target;
+            SeekDangerResult::Found
+        } else {
+            // We only need to return a lower bound here. Avoid scanning for the next populated
+            // document; intersections can continue with a cheap point lookup instead.
+            SeekDangerResult::SeekLowerBound(target + 1)
+        }
     }
 }
 
@@ -232,14 +301,32 @@ mod tests {
     use std::net::Ipv6Addr;
     use std::ops::Bound;
 
+    use columnar::column_index::OptionalIndex;
     use common::DateTime;
     use time::OffsetDateTime;
 
     use crate::collector::Count;
-    use crate::query::exist_query::ExistsQuery;
+    use crate::docset::{DocSet, SeekDangerResult, TERMINATED};
+    use crate::query::exist_query::{ExistsDocSet, ExistsQuery};
     use crate::query::{BooleanQuery, RangeQuery};
     use crate::schema::{Facet, FacetOptions, Schema, FAST, INDEXED, STRING, TEXT};
     use crate::{Index, Searcher, Term};
+
+    #[test]
+    fn test_exists_docset_seek_danger() {
+        let optional_index = OptionalIndex::for_test(8, &[1, 4, 7]);
+        let mut docset = ExistsDocSet::new(optional_index, 8);
+
+        assert_eq!(docset.doc(), 1);
+        assert_eq!(docset.seek_danger(2), SeekDangerResult::SeekLowerBound(3));
+        assert_eq!(docset.seek_danger(4), SeekDangerResult::Found);
+        assert_eq!(docset.doc(), 4);
+        assert_eq!(docset.advance(), 7);
+        assert_eq!(
+            docset.seek_danger(TERMINATED),
+            SeekDangerResult::SeekLowerBound(TERMINATED)
+        );
+    }
 
     #[test]
     fn test_exists_query_simple() -> crate::Result<()> {

--- a/src/query/exist_query.rs
+++ b/src/query/exist_query.rs
@@ -1,11 +1,11 @@
 use core::fmt::Debug;
 
-use columnar::column_index::{MultiValueIndex, OptionalIndex, Set};
+use columnar::column_index::{MultiValueIndex, OptionalIndex};
 use columnar::ColumnIndex;
 use common::BitSet;
 
 use super::{ConstScorer, EmptyScorer};
-use crate::docset::{DocSet, SeekDangerResult, TERMINATED};
+use crate::docset::{DocSet, TERMINATED};
 use crate::index::SegmentReader;
 use crate::query::all_query::AllScorer;
 use crate::query::boost_query::BoostScorer;
@@ -190,26 +190,17 @@ impl Weight for FastFieldExistsWeight {
 
 pub(crate) trait ExistsIndex: Send {
     fn next_doc(&self, target: DocId, max_doc: DocId) -> DocId;
-    fn has_value(&self, doc: DocId) -> bool;
 }
 
 impl ExistsIndex for OptionalIndex {
     fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
         self.next_non_null_doc(target).unwrap_or(TERMINATED)
     }
-
-    fn has_value(&self, doc: DocId) -> bool {
-        doc < self.num_docs() && self.contains(doc)
-    }
 }
 
 impl ExistsIndex for MultiValueIndex {
     fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
         self.next_non_null_doc(target).unwrap_or(TERMINATED)
-    }
-
-    fn has_value(&self, doc: DocId) -> bool {
-        MultiValueIndex::has_value(self, doc)
     }
 }
 
@@ -225,10 +216,6 @@ impl ExistsIndex for Vec<ColumnIndex> {
             target += 1;
         }
         TERMINATED
-    }
-
-    fn has_value(&self, doc: DocId) -> bool {
-        self.iter().any(|column_index| column_index.has_value(doc))
     }
 }
 
@@ -279,20 +266,6 @@ impl<T: ExistsIndex> DocSet for ExistsDocSet<T> {
         self.doc = self.column_index.next_doc(target, self.max_doc);
         self.doc
     }
-
-    fn seek_danger(&mut self, target: DocId) -> SeekDangerResult {
-        if target >= self.max_doc {
-            return SeekDangerResult::SeekLowerBound(TERMINATED);
-        }
-        if self.column_index.has_value(target) {
-            self.doc = target;
-            SeekDangerResult::Found
-        } else {
-            // We only need to return a lower bound here. Avoid scanning for the next populated
-            // document; intersections can continue with a cheap point lookup instead.
-            SeekDangerResult::SeekLowerBound(target + 1)
-        }
-    }
 }
 
 #[cfg(test)]
@@ -317,7 +290,7 @@ mod tests {
         let mut docset = ExistsDocSet::new(optional_index, 8);
 
         assert_eq!(docset.doc(), 1);
-        assert_eq!(docset.seek_danger(2), SeekDangerResult::SeekLowerBound(3));
+        assert_eq!(docset.seek_danger(2), SeekDangerResult::SeekLowerBound(4));
         assert_eq!(docset.seek_danger(4), SeekDangerResult::Found);
         assert_eq!(docset.doc(), 4);
         assert_eq!(docset.advance(), 7);

--- a/src/query/exist_query.rs
+++ b/src/query/exist_query.rs
@@ -109,16 +109,15 @@ impl Weight for FastFieldExistsWeight {
         }
         // An exists query only needs the column indexes. Drop the values so that the docset below
         // operates directly on the specialized optional or multivalued index.
-        let column_indexes: crate::Result<Vec<ColumnIndex>> = column_handles
+        let column_indexes: Vec<ColumnIndex> = column_handles
             .into_iter()
             .map(|handle| {
                 handle
                     .open()
                     .map(|column| column.into_column_index())
-                    .map_err(|io_error| io_error.into())
             })
-            .collect();
-        let mut non_empty_column_indexes: Vec<ColumnIndex> = column_indexes?
+            .collect::<Result<_, _>>()?;
+        let mut non_empty_column_indexes: Vec<ColumnIndex> = column_indexes
             .into_iter()
             .filter(|column_index| !matches!(column_index, ColumnIndex::Empty { .. }))
             .collect();

--- a/src/query/exist_query.rs
+++ b/src/query/exist_query.rs
@@ -111,23 +111,11 @@ impl Weight for FastFieldExistsWeight {
         // operates directly on the specialized optional or multivalued index.
         let column_indexes: Vec<ColumnIndex> = column_handles
             .into_iter()
-            .map(|handle| {
-                handle
-                    .open()
-                    .map(|column| column.into_column_index())
-            })
+            .map(|handle| handle.open().map(|column| column.into_column_index()))
             .collect::<Result<_, _>>()?;
-        let mut non_empty_column_indexes: Vec<ColumnIndex> = column_indexes
-            .into_iter()
-            .filter(|column_index| !matches!(column_index, ColumnIndex::Empty { .. }))
-            .collect();
-        if non_empty_column_indexes.is_empty() {
-            return Ok(Box::new(EmptyScorer));
-        }
-
         // If any column is full, all docs match.
         let max_doc = reader.max_doc();
-        if non_empty_column_indexes
+        if column_indexes
             .iter()
             .any(|column_index| matches!(column_index, ColumnIndex::Full))
         {
@@ -139,36 +127,42 @@ impl Weight for FastFieldExistsWeight {
             }
         }
 
-        // Starting here we are guaranteed that there is no full or empty column left.
-
-        if non_empty_column_indexes.len() == 1 {
-            return match non_empty_column_indexes.pop().unwrap() {
+        let mut column_indexes: Vec<ExistsColumnIndex> = column_indexes
+            .into_iter()
+            .filter_map(|column_index| match column_index {
+                ColumnIndex::Empty { .. } => None,
                 ColumnIndex::Optional(optional_index) => {
-                    Ok(exists_scorer(optional_index, max_doc, boost))
+                    Some(ExistsColumnIndex::Optional(optional_index))
                 }
                 ColumnIndex::Multivalued(multivalued_index) => {
-                    Ok(exists_scorer(multivalued_index, max_doc, boost))
+                    Some(ExistsColumnIndex::Multivalued(multivalued_index))
                 }
-                ColumnIndex::Empty { .. } | ColumnIndex::Full => unreachable!(),
-            };
+                ColumnIndex::Full => unreachable!(),
+            })
+            .collect();
+        if column_indexes.is_empty() {
+            return Ok(Box::new(EmptyScorer));
+        }
+
+        if column_indexes.len() == 1 {
+            return Ok(exists_scorer(column_indexes.pop().unwrap(), boost));
         }
 
         // NOTE: A lower number may be better for very sparse columns.
-        if non_empty_column_indexes.len() < 4 {
-            return Ok(exists_scorer(non_empty_column_indexes, max_doc, boost));
+        if column_indexes.len() < 4 {
+            return Ok(exists_scorer(column_indexes, boost));
         }
 
         // If we have many dynamic columns, precompute a bitset of matching docs
         let mut doc_bitset = BitSet::with_max_value(max_doc);
-        for column_index in &non_empty_column_indexes {
+        for column_index in &column_indexes {
             match column_index {
-                ColumnIndex::Empty { .. } | ColumnIndex::Full => unreachable!(),
-                ColumnIndex::Optional(optional_index) => {
+                ExistsColumnIndex::Optional(optional_index) => {
                     for doc in optional_index.iter_non_null_docs() {
                         doc_bitset.insert(doc);
                     }
                 }
-                ColumnIndex::Multivalued(multi_idx) => {
+                ExistsColumnIndex::Multivalued(multi_idx) => {
                     for doc in multi_idx.iter_non_null_docs() {
                         doc_bitset.insert(doc);
                     }
@@ -188,73 +182,78 @@ impl Weight for FastFieldExistsWeight {
     }
 }
 
+enum ExistsColumnIndex {
+    Optional(OptionalIndex),
+    Multivalued(MultiValueIndex),
+}
+
 pub(crate) trait ExistsIndex: Send {
-    fn next_doc(&self, target: DocId, max_doc: DocId) -> DocId;
+    fn next_doc(&self, target: DocId) -> DocId;
+    fn size_hint(&self) -> u32;
 }
 
-impl ExistsIndex for OptionalIndex {
-    fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
-        self.next_non_null_doc(target).unwrap_or(TERMINATED)
-    }
-}
-
-impl ExistsIndex for MultiValueIndex {
-    fn next_doc(&self, target: DocId, _max_doc: DocId) -> DocId {
-        self.next_non_null_doc(target).unwrap_or(TERMINATED)
-    }
-}
-
-impl ExistsIndex for Vec<ColumnIndex> {
-    fn next_doc(&self, mut target: DocId, max_doc: DocId) -> DocId {
-        while target < max_doc {
-            if self
-                .iter()
-                .any(|column_index| column_index.has_value(target))
-            {
-                return target;
+impl ExistsIndex for ExistsColumnIndex {
+    fn next_doc(&self, target: DocId) -> DocId {
+        match self {
+            ExistsColumnIndex::Optional(optional_index) => optional_index.next_non_null_doc(target),
+            ExistsColumnIndex::Multivalued(multivalued_index) => {
+                multivalued_index.next_non_null_doc(target)
             }
-            target += 1;
         }
-        TERMINATED
+        .unwrap_or(TERMINATED)
+    }
+
+    fn size_hint(&self) -> u32 {
+        match self {
+            ExistsColumnIndex::Optional(optional_index) => optional_index.num_non_nulls(),
+            ExistsColumnIndex::Multivalued(MultiValueIndex::MultiValueIndexV1(index)) => {
+                index.num_docs()
+            }
+            ExistsColumnIndex::Multivalued(MultiValueIndex::MultiValueIndexV2(index)) => {
+                index.optional_index.num_non_nulls()
+            }
+        }
     }
 }
 
-fn exists_scorer<T: ExistsIndex + 'static>(
-    column_index: T,
-    max_doc: DocId,
-    boost: Score,
-) -> Box<dyn Scorer> {
-    let docset = ExistsDocSet::new(column_index, max_doc);
+impl ExistsIndex for Vec<ExistsColumnIndex> {
+    fn next_doc(&self, target: DocId) -> DocId {
+        self.iter()
+            .map(|column_index| column_index.next_doc(target))
+            .min()
+            .unwrap_or(TERMINATED)
+    }
+
+    fn size_hint(&self) -> u32 {
+        self.iter().map(ExistsIndex::size_hint).sum()
+    }
+}
+
+fn exists_scorer<T: ExistsIndex + 'static>(column_index: T, boost: Score) -> Box<dyn Scorer> {
+    let docset = ExistsDocSet::new(column_index);
     Box::new(ConstScorer::new(docset, boost))
 }
 
 pub(crate) struct ExistsDocSet<T: ExistsIndex> {
     column_index: T,
     doc: DocId,
-    max_doc: DocId,
 }
 
 impl<T: ExistsIndex> ExistsDocSet<T> {
-    pub(crate) fn new(column_index: T, max_doc: DocId) -> Self {
-        let doc = column_index.next_doc(0, max_doc);
-        Self {
-            column_index,
-            doc,
-            max_doc,
-        }
+    pub(crate) fn new(column_index: T) -> Self {
+        let doc = column_index.next_doc(0);
+        Self { column_index, doc }
     }
 }
 
 impl<T: ExistsIndex> DocSet for ExistsDocSet<T> {
     fn advance(&mut self) -> DocId {
-        if self.doc != TERMINATED {
-            self.doc = self.column_index.next_doc(self.doc + 1, self.max_doc);
-        }
+        self.doc = self.column_index.next_doc(self.doc + 1);
         self.doc
     }
 
     fn size_hint(&self) -> u32 {
-        0
+        self.column_index.size_hint()
     }
 
     fn doc(&self) -> DocId {
@@ -263,7 +262,8 @@ impl<T: ExistsIndex> DocSet for ExistsDocSet<T> {
 
     #[inline(always)]
     fn seek(&mut self, target: DocId) -> DocId {
-        self.doc = self.column_index.next_doc(target, self.max_doc);
+        debug_assert!(self.doc <= target);
+        self.doc = self.column_index.next_doc(target);
         self.doc
     }
 }
@@ -279,7 +279,7 @@ mod tests {
 
     use crate::collector::Count;
     use crate::docset::{DocSet, SeekDangerResult, TERMINATED};
-    use crate::query::exist_query::{ExistsDocSet, ExistsQuery};
+    use crate::query::exist_query::{ExistsColumnIndex, ExistsDocSet, ExistsQuery};
     use crate::query::{BooleanQuery, RangeQuery};
     use crate::schema::{Facet, FacetOptions, Schema, FAST, INDEXED, STRING, TEXT};
     use crate::{Index, Searcher, Term};
@@ -287,8 +287,9 @@ mod tests {
     #[test]
     fn test_exists_docset_seek_danger() {
         let optional_index = OptionalIndex::for_test(8, &[1, 4, 7]);
-        let mut docset = ExistsDocSet::new(optional_index, 8);
+        let mut docset = ExistsDocSet::new(ExistsColumnIndex::Optional(optional_index));
 
+        assert_eq!(docset.size_hint(), 3);
         assert_eq!(docset.doc(), 1);
         assert_eq!(docset.seek_danger(2), SeekDangerResult::SeekLowerBound(4));
         assert_eq!(docset.seek_danger(4), SeekDangerResult::Found);

--- a/src/store/reader.rs
+++ b/src/store/reader.rs
@@ -304,7 +304,9 @@ impl StoreReader {
         let mut curr_checkpoint = checkpoint_block_iter.next();
         let mut curr_block = curr_checkpoint
             .as_ref()
-            .map(|checkpoint| self.read_block(checkpoint).map_err(|e| e.kind())); // map error in order to enable cloning
+            .map(|checkpoint| self.read_block(checkpoint).map_err(|e| e.kind())); // map error in
+                                                                                  // order to enable
+                                                                                  // cloning
         let mut doc_pos = 0;
         (0..last_doc_id)
             .filter_map(move |doc_id| {


### PR DESCRIPTION
Up to 500x faster exists queries by advancing directly on the column index instead of scanning documents.

Adds benchmark for exist queries
Fix `size_hint` for exist queries. It was 0 before, but often it's better for the term to be the leader in an intersection.

```
exists
column populated in 0.1% of docs (sparse blocks)
optional                Avg: 0.0428ms (-99.82%)    Median: 0.0406ms (-99.83%)    [0.0373ms .. 0.0485ms]    Output: 4_836
multivalued             Avg: 0.0404ms (-99.87%)    Median: 0.0405ms (-99.86%)    [0.0394ms .. 0.0421ms]    Output: 4_836
multiple_columns        Avg: 0.0762ms (-99.85%)    Median: 0.0761ms (-99.85%)    [0.0751ms .. 0.0780ms]    Output: 4_836
column populated in 10% of docs (dense blocks)
optional                Avg: 6.0727ms (-52.27%)     Median: 6.0048ms (-51.54%)     [5.8567ms .. 6.7305ms]      Output: 499_966
multivalued             Avg: 6.2980ms (-64.96%)     Median: 6.2846ms (-64.57%)     [6.1856ms .. 6.6087ms]      Output: 499_966
multiple_columns        Avg: 33.3504ms (-72.36%)    Median: 33.2882ms (-72.37%)    [33.0809ms .. 33.9911ms]    Output: 499_966
column populated in 90% of docs (dense blocks)
optional                Avg: 12.6584ms (+12.12%)    Median: 12.6360ms (+12.79%)    [12.5785ms .. 13.1334ms]    Output: 4_498_850
multivalued             Avg: 15.5358ms (-40.23%)    Median: 15.4799ms (-39.41%)    [15.4306ms .. 16.3949ms]    Output: 4_498_850
multiple_columns        Avg: 28.3890ms (+14.00%)    Median: 28.3283ms (+13.84%)    [28.2405ms .. 29.0357ms]    Output: 4_498_850
term_AND_exists
term matches 0.01% of docs, column populated in 0.1% (sparse blocks)
optional                Avg: 6463ns (-99.72%)      Median: 6458ns (-99.72%)      [6382ns .. 6569ns]        Output: 1
multivalued             Avg: 6740ns (-99.77%)      Median: 6726ns (-99.77%)      [6686ns .. 6868ns]        Output: 1
multiple_columns        Avg: 0.0103ms (-99.79%)    Median: 0.0103ms (-99.79%)    [0.0102ms .. 0.0106ms]    Output: 1
term matches 1% of docs, column populated in 0.1% (sparse blocks)
optional                Avg: 0.1057ms (-99.49%)    Median: 0.1055ms (-99.48%)    [0.1045ms .. 0.1106ms]    Output: 51
multivalued             Avg: 0.1077ms (-99.60%)    Median: 0.1074ms (-99.60%)    [0.1066ms .. 0.1102ms]    Output: 51
multiple_columns        Avg: 0.1380ms (-99.70%)    Median: 0.1372ms (-99.70%)    [0.1275ms .. 0.1529ms]    Output: 51
term matches 50% of docs, column populated in 0.1% (sparse blocks)
optional                Avg: 0.3027ms (-98.72%)    Median: 0.2949ms (-98.75%)    [0.2744ms .. 0.3393ms]    Output: 2_405
multivalued             Avg: 0.3088ms (-98.97%)    Median: 0.3099ms (-98.98%)    [0.2790ms .. 0.3369ms]    Output: 2_405
multiple_columns        Avg: 0.3719ms (-99.26%)    Median: 0.3704ms (-99.25%)    [0.3362ms .. 0.4114ms]    Output: 2_405
term matches 0.01% of docs, column populated in 10% (dense blocks)
optional                Avg: 0.0153ms (-44.43%)    Median: 0.0153ms (-44.42%)    [0.0151ms .. 0.0156ms]    Output: 50
multivalued             Avg: 0.0234ms (-44.47%)    Median: 0.0234ms (-44.64%)    [0.0232ms .. 0.0240ms]    Output: 50
multiple_columns        Avg: 0.0313ms (-74.66%)    Median: 0.0312ms (-74.65%)    [0.0309ms .. 0.0321ms]    Output: 50
term matches 1% of docs, column populated in 10% (dense blocks)
optional                Avg: 0.7648ms (-48.81%)    Median: 0.7611ms (-48.98%)    [0.7511ms .. 0.7922ms]    Output: 5_023
multivalued             Avg: 0.7920ms (-62.34%)    Median: 0.7888ms (-61.65%)    [0.7789ms .. 0.8276ms]    Output: 5_023
multiple_columns        Avg: 4.4917ms (-70.95%)    Median: 4.4724ms (-71.00%)    [4.4450ms .. 4.5834ms]    Output: 5_023
term matches 50% of docs, column populated in 10% (dense blocks)
optional                Avg: 10.3595ms (-43.49%)    Median: 10.3215ms (-43.00%)    [10.1375ms .. 10.8415ms]    Output: 249_853
multivalued             Avg: 10.6857ms (-55.68%)    Median: 10.6551ms (-55.44%)    [10.4806ms .. 11.2511ms]    Output: 249_853
multiple_columns        Avg: 37.8456ms (-69.13%)    Median: 37.7711ms (-69.13%)    [37.4558ms .. 39.0351ms]    Output: 249_853
term matches 0.01% of docs, column populated in 90% (dense blocks)
optional                Avg: 0.0845ms (-4.32%)    Median: 0.0845ms (-4.42%)    [0.0838ms .. 0.0851ms]    Output: 439
multivalued             Avg: 0.1640ms (-4.79%)    Median: 0.1641ms (-4.53%)    [0.1622ms .. 0.1663ms]    Output: 439
multiple_columns        Avg: 0.1280ms (-6.36%)    Median: 0.1280ms (-6.07%)    [0.1267ms .. 0.1309ms]    Output: 439
term matches 1% of docs, column populated in 90% (dense blocks)
optional                Avg: 0.3717ms (-36.70%)    Median: 0.3707ms (-36.13%)    [0.3690ms .. 0.3807ms]    Output: 45_342
multivalued             Avg: 0.4760ms (-50.03%)    Median: 0.4752ms (-50.08%)    [0.4733ms .. 0.4856ms]    Output: 45_342
multiple_columns        Avg: 0.8229ms (-29.50%)    Median: 0.8196ms (-29.50%)    [0.8163ms .. 0.8703ms]    Output: 45_342
term matches 50% of docs, column populated in 90% (dense blocks)
optional                Avg: 18.0280ms (-37.79%)    Median: 17.9460ms (-37.41%)    [17.8901ms .. 18.4567ms]    Output: 2_249_485
multivalued             Avg: 21.0466ms (-47.01%)    Median: 20.9365ms (-47.15%)    [20.8675ms .. 21.8006ms]    Output: 2_249_485
multiple_columns        Avg: 33.7600ms (-23.99%)    Median: 33.6401ms (-24.11%)    [33.4742ms .. 34.4603ms]    Output: 2_249_485
```