### PR TITLE
Fix RamDirectory::atomic_write not waiting for reload watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Tantivy 0.26 (Unreleased)
 ================================
 
 ## Bugfixes
+- Fix `RamDirectory::atomic_write` not waiting for `OnCommitWithDelay` watchers (e.g. `IndexReader::reload()`), so a search right after `commit()` on an in-memory index could miss documents from that commit [#1824](https://github.com/quickwit-oss/tantivy/issues/1824)(@Divyesh-k)
 - Align float query coercion during search with the columnar coercion rules [#2692](https://github.com/quickwit-oss/tantivy/pull/2692)(@fulmicoton)
 - Fix lenient elastic range queries with trailing closing parentheses [#2816](https://github.com/quickwit-oss/tantivy/pull/2816)(@evance-br)
 - Fix intersection `seek()` advancing below current doc id [#2812](https://github.com/quickwit-oss/tantivy/pull/2812)(@fulmicoton)

--- a/src/core/tests.rs
+++ b/src/core/tests.rs
@@ -130,6 +130,33 @@ fn test_index_on_commit_reload_policy() -> crate::Result<()> {
     test_index_on_commit_reload_policy_aux(field, &index, &reader)
 }
 
+// Regression test for https://github.com/quickwit-oss/tantivy/issues/1824
+//
+// On a `RamDirectory`, `commit()` used to notify `OnCommitWithDelay` watchers
+// (including the `IndexReader`) on a detached thread without waiting for them, so a
+// search performed right after `commit()` returns could still see the pre-commit state.
+#[test]
+fn test_index_on_commit_reload_policy_ram_directory_is_synchronous() -> crate::Result<()> {
+    let schema = throw_away_schema();
+    let field = schema.get_field("num_likes").unwrap();
+    let index = Index::create_in_ram(schema);
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::OnCommitWithDelay)
+        .try_into()?;
+    let mut writer: IndexWriter = index.writer_for_tests()?;
+    for i in 0..100 {
+        writer.add_document(doc!(field=>i as u64))?;
+        writer.commit()?;
+        assert_eq!(
+            reader.searcher().num_docs(),
+            i + 1,
+            "reader was not synchronously reloaded after commit() returned"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(feature = "mmap")]
 mod mmap_specific {
 

--- a/src/directory/ram_directory.rs
+++ b/src/directory/ram_directory.rs
@@ -225,7 +225,12 @@ impl Directory for RamDirectory {
         let path_buf = PathBuf::from(path);
         self.fs.write().unwrap().write(path_buf, data);
         if path == *META_FILEPATH {
-            drop(self.fs.write().unwrap().watch_router.broadcast());
+            // Wait for watchers (e.g. `IndexReader::reload()`) so that a `commit()` on a
+            // `RamDirectory` is synchronously visible once it returns. `broadcast()` and
+            // `wait()` must stay in separate statements: callbacks read from `self.fs`, so the
+            // write guard has to be dropped before we block on them, or we deadlock.
+            let broadcast_result = self.fs.write().unwrap().watch_router.broadcast();
+            let _ = broadcast_result.wait();
         }
         Ok(())
     }


### PR DESCRIPTION
commit() on a RamDirectory broadcast the meta.json watch callbacks (including IndexReader::reload() under ReloadPolicy::OnCommitWithDelay) on a detached thread and dropped the result without waiting, so a search performed immediately after commit() returned could still miss documents from that commit. Wait for the broadcast to finish before atomic_write() returns.

Fixes #1824