### PR TITLE
Clarify that OnCommitWithDelay reload is not synchronized with commit()

### DIFF
--- a/examples/reload_after_commit.rs
+++ b/examples/reload_after_commit.rs
@@ -1,0 +1,58 @@
+// # Reload after commit
+//
+// `IndexWriter::commit()` only guarantees that your documents are durably
+// persisted to the `Directory`. It does **not** guarantee that an already-open
+// `IndexReader` can see them right away: with the default
+// `ReloadPolicy::OnCommitWithDelay`, the reader reloads on a background thread
+// that is not synchronized with `commit()`'s return, on any `Directory`
+// implementation (including an in-memory `RamDirectory`). A search performed
+// immediately after `commit()` can therefore still miss the documents you
+// just added.
+//
+// If you need a search right after a commit to deterministically reflect that
+// commit, build the reader with `ReloadPolicy::Manual` and call
+// `reader.reload()` yourself, as shown below.
+
+use tantivy::collector::TopDocs;
+use tantivy::query::QueryParser;
+use tantivy::schema::*;
+use tantivy::{doc, Index, IndexWriter, ReloadPolicy};
+
+fn main() -> tantivy::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let title = schema_builder.add_text_field("title", TEXT | STORED);
+    let schema = schema_builder.build();
+
+    let index = Index::create_in_ram(schema);
+
+    // `ReloadPolicy::Manual` puts us in control of exactly when the reader
+    // sees new commits, instead of racing against the background reload.
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
+
+    let mut index_writer: IndexWriter = index.writer(15_000_000)?;
+    index_writer.add_document(doc!(
+        title => "The Old Man and the Sea"
+    ))?;
+    index_writer.commit()?;
+
+    // Without this explicit reload, the searcher below could still be
+    // looking at the pre-commit (empty) version of the index.
+    reader.reload()?;
+
+    let query_parser = QueryParser::for_index(&index, vec![title]);
+    let query = query_parser.parse_query("sea")?;
+
+    let searcher = reader.searcher();
+    let top_docs = searcher.search(&query, &TopDocs::with_limit(10).order_by_score())?;
+
+    assert!(!top_docs.is_empty());
+    println!(
+        "Found {} matching document(s) right after commit.",
+        top_docs.len()
+    );
+
+    Ok(())
+}

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -663,6 +663,18 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// Commit returns the `opstamp` of the last document
     /// that made it in the commit.
+    ///
+    /// Note that "published" here only means committed to the [`Directory`](crate::Directory).
+    /// Any already-open [`IndexReader`](crate::IndexReader) only picks up the change according
+    /// to its [`ReloadPolicy`](crate::ReloadPolicy): with the default
+    /// [`ReloadPolicy::OnCommitWithDelay`](crate::ReloadPolicy::OnCommitWithDelay), the reload
+    /// happens asynchronously and is not guaranteed to be done by the time `commit()` returns,
+    /// so a search right after `commit()` can still miss the documents just committed. Use
+    /// [`ReloadPolicy::Manual`](crate::ReloadPolicy::Manual) with an explicit
+    /// [`IndexReader::reload()`](crate::IndexReader::reload) call if you need the search to
+    /// deterministically reflect this commit (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     pub fn commit(&mut self) -> crate::Result<Opstamp> {
         self.prepare_commit()?.commit()
     }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -27,6 +27,16 @@ pub enum ReloadPolicy {
     Manual,
     /// The index is reloaded within milliseconds after a new commit is available.
     /// This is made possible by watching changes in the `meta.json` file.
+    ///
+    /// This reload happens on a background thread and is **not** guaranteed to have
+    /// completed by the time [`IndexWriter::commit()`](crate::IndexWriter::commit) returns,
+    /// on any [`Directory`] implementation, including [`RamDirectory`](crate::directory::RamDirectory).
+    /// A search performed immediately after `commit()` can therefore still observe the
+    /// pre-commit state. If you need a search to deterministically reflect a commit you just
+    /// made, use [`ReloadPolicy::Manual`] and call [`IndexReader::reload()`] yourself right
+    /// after `commit()` (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     OnCommitWithDelay, // TODO add NEAR_REAL_TIME(target_ms)
 }
 
@@ -282,8 +292,15 @@ impl IndexReader {
     /// every commit should be rapidly reflected on your `IndexReader` and you should
     /// not need to call `reload()` at all.
     ///
-    /// This automatic reload can take 10s of milliseconds to kick in however, and in unit tests
-    /// it can be nice to deterministically force the reload of searchers.
+    /// This automatic reload can take 10s of milliseconds to kick in however, and it is not
+    /// synchronized with the return of [`IndexWriter::commit()`](crate::IndexWriter::commit) —
+    /// this holds for every [`Directory`] implementation, including an in-memory
+    /// [`RamDirectory`](crate::directory::RamDirectory). If your code (or a test) needs to
+    /// search immediately after a commit and deterministically see its results, build the
+    /// reader with [`ReloadPolicy::Manual`] and call `reload()` explicitly after `commit()`
+    /// instead of relying on the automatic reload's timing (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     pub fn reload(&self) -> crate::Result<()> {
         self.inner.reload()
     }


### PR DESCRIPTION
commit() only guarantees documents are persisted to the Directory; an already-open IndexReader only picks up the change according to its ReloadPolicy. With the default OnCommitWithDelay, the reload happens asynchronously on a background thread and is not guaranteed to be done by the time commit() returns, on any Directory implementation (including RamDirectory), so a search immediately after commit() can still miss the documents just committed.

Document this explicitly on ReloadPolicy::OnCommitWithDelay, IndexReader::reload(), and IndexWriter::commit(), and add a runnable example showing the ReloadPolicy::Manual + explicit reader.reload() pattern for deterministic read-your-writes.

See #1824