### PR TITLE
Add read-only directory support

### DIFF
--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -100,10 +100,12 @@ fn retry_policy(is_blocking: bool) -> RetryPolicy {
 /// Write-once read many (WORM) abstraction for where
 /// tantivy's data should be stored.
 ///
-/// There are currently two implementations of `Directory`
+/// There are currently three implementations of `Directory`
 ///
 /// - The [`MMapDirectory`][crate::directory::MmapDirectory], this should be your default choice.
 /// - The [`RamDirectory`][crate::directory::RamDirectory], which should be used mostly for tests.
+/// - The [`ReadOnlyDirectory`][crate::directory::ReadOnlyDirectory], which wraps another directory
+///   containing an immutable index.
 pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// Opens a file and returns a boxed `FileHandle`.
     ///

--- a/src/directory/directory.rs
+++ b/src/directory/directory.rs
@@ -104,7 +104,7 @@ fn retry_policy(is_blocking: bool) -> RetryPolicy {
 ///
 /// - The [`MMapDirectory`][crate::directory::MmapDirectory], this should be your default choice.
 /// - The [`RamDirectory`][crate::directory::RamDirectory], which should be used mostly for tests.
-/// - The [`ReadOnlyDirectory`][crate::directory::ReadOnlyDirectory], which wraps another directory
+/// - The [`ImmutableDirectory`][crate::directory::ImmutableDirectory], which wraps another directory
 ///   containing an immutable index.
 pub trait Directory: DirectoryClone + fmt::Debug + Send + Sync + 'static {
     /// Opens a file and returns a boxed `FileHandle`.

--- a/src/directory/immutable_directory.rs
+++ b/src/directory/immutable_directory.rs
@@ -7,18 +7,22 @@ use crate::directory::{
     Directory, DirectoryLock, FileHandle, Lock, WatchCallback, WatchHandle, WritePtr, META_LOCK,
 };
 
-/// A read-only view over a [`Directory`].
+/// A [`Directory`] wrapper for an immutable index.
 ///
-/// Read operations are forwarded to the underlying directory, while write operations are rejected.
-/// [`META_LOCK`] is not acquired, so the underlying index must remain unchanged while this
-/// directory is in use.
+/// Read operations are forwarded to the underlying directory, while operations that could mutate
+/// it are rejected. Requests for [`META_LOCK`] are satisfied without touching the underlying
+/// directory, and filesystem watching is disabled.
+///
+/// The underlying index must not be modified or garbage-collected by any process while this
+/// directory is in use. This wrapper is intended for indexes stored on read-only filesystems, not
+/// for read-only access to an index that another process may update.
 #[derive(Clone)]
-pub struct ReadOnlyDirectory {
+pub struct ImmutableDirectory {
     directory: Box<dyn Directory>,
 }
 
-impl ReadOnlyDirectory {
-    /// Wraps a directory containing an immutable index.
+impl ImmutableDirectory {
+    /// Wraps a directory whose contents will remain unchanged for the lifetime of this wrapper.
     pub fn new(directory: impl Into<Box<dyn Directory>>) -> Self {
         Self {
             directory: directory.into(),
@@ -26,20 +30,20 @@ impl ReadOnlyDirectory {
     }
 }
 
-impl fmt::Debug for ReadOnlyDirectory {
+impl fmt::Debug for ImmutableDirectory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ReadOnlyDirectory({:?})", self.directory)
+        write!(f, "ImmutableDirectory({:?})", self.directory)
     }
 }
 
-impl Directory for ReadOnlyDirectory {
+impl Directory for ImmutableDirectory {
     fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
         self.directory.get_file_handle(path)
     }
 
     fn delete(&self, path: &Path) -> Result<(), DeleteError> {
         Err(DeleteError::IoError {
-            io_error: Arc::new(read_only_error()),
+            io_error: Arc::new(immutable_error()),
             filepath: path.to_path_buf(),
         })
     }
@@ -50,7 +54,7 @@ impl Directory for ReadOnlyDirectory {
 
     fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {
         Err(OpenWriteError::wrap_io_error(
-            read_only_error(),
+            immutable_error(),
             path.to_path_buf(),
         ))
     }
@@ -60,7 +64,7 @@ impl Directory for ReadOnlyDirectory {
     }
 
     fn atomic_write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
-        Err(read_only_error())
+        Err(immutable_error())
     }
 
     fn sync_directory(&self) -> io::Result<()> {
@@ -69,18 +73,22 @@ impl Directory for ReadOnlyDirectory {
 
     fn acquire_lock(&self, lock: &Lock) -> Result<DirectoryLock, LockError> {
         if lock.filepath == META_LOCK.filepath {
+            // Reading index metadata normally requires `META_LOCK`. The caller guarantees that the
+            // index cannot change, so a no-op guard provides the same protection without creating a
+            // lock file in the underlying directory.
             return Ok(DirectoryLock::from(Box::new(())));
         }
-        Err(LockError::wrap_io_error(read_only_error()))
+        Err(LockError::wrap_io_error(immutable_error()))
     }
 
     fn watch(&self, _watch_callback: WatchCallback) -> crate::Result<WatchHandle> {
+        // An immutable index cannot receive commits, so there are no changes to watch for.
         Ok(WatchHandle::empty())
     }
 }
 
-fn read_only_error() -> io::Error {
-    io::Error::new(io::ErrorKind::PermissionDenied, "directory is read-only")
+fn immutable_error() -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, "directory is immutable")
 }
 
 #[cfg(test)]
@@ -90,43 +98,43 @@ mod tests {
     use crate::collector::Count;
     use crate::directory::error::LockError;
     use crate::directory::{
-        Directory, RamDirectory, ReadOnlyDirectory, INDEX_WRITER_LOCK, META_LOCK,
+        Directory, ImmutableDirectory, RamDirectory, INDEX_WRITER_LOCK, META_LOCK,
     };
     use crate::query::AllQuery;
     use crate::schema::{Schema, TEXT};
     use crate::{Index, TantivyDocument, TantivyError};
 
     #[test]
-    fn test_read_only_directory_rejects_writes() {
+    fn test_immutable_directory_rejects_writes() {
         let directory = RamDirectory::create();
         directory
             .atomic_write(Path::new("file"), b"original")
             .unwrap();
-        let read_only_directory = ReadOnlyDirectory::new(directory);
+        let immutable_directory = ImmutableDirectory::new(directory);
 
         assert_eq!(
-            read_only_directory.atomic_read(Path::new("file")).unwrap(),
+            immutable_directory.atomic_read(Path::new("file")).unwrap(),
             b"original"
         );
-        assert!(read_only_directory
+        assert!(immutable_directory
             .open_write(Path::new("new-file"))
             .is_err());
-        assert!(read_only_directory
+        assert!(immutable_directory
             .atomic_write(Path::new("file"), b"changed")
             .is_err());
-        assert!(read_only_directory.delete(Path::new("file")).is_err());
+        assert!(immutable_directory.delete(Path::new("file")).is_err());
         assert_eq!(
-            read_only_directory.atomic_read(Path::new("file")).unwrap(),
+            immutable_directory.atomic_read(Path::new("file")).unwrap(),
             b"original"
         );
     }
 
     #[test]
-    fn test_read_only_directory_only_allows_meta_lock() {
-        let read_only_directory = ReadOnlyDirectory::new(RamDirectory::create());
+    fn test_immutable_directory_uses_noop_meta_lock() {
+        let immutable_directory = ImmutableDirectory::new(RamDirectory::create());
 
-        assert!(read_only_directory.acquire_lock(&META_LOCK).is_ok());
-        let lock_error = read_only_directory
+        assert!(immutable_directory.acquire_lock(&META_LOCK).is_ok());
+        let lock_error = immutable_directory
             .acquire_lock(&INDEX_WRITER_LOCK)
             .err()
             .unwrap();
@@ -137,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn test_read_only_index_can_search_and_reload() {
+    fn test_immutable_index_can_search_and_reload() {
         let mut schema_builder = Schema::builder();
         let text = schema_builder.add_text_field("text", TEXT);
         let schema = schema_builder.build();
@@ -148,13 +156,13 @@ mod tests {
         writer.commit().unwrap();
         drop(writer);
 
-        let read_only_index = Index::open_read_only(directory).unwrap();
-        let reader = read_only_index.reader().unwrap();
+        let immutable_index = Index::open_immutable(directory).unwrap();
+        let reader = immutable_index.reader().unwrap();
         assert_eq!(reader.searcher().search(&AllQuery, &Count).unwrap(), 1);
         reader.reload().unwrap();
         assert_eq!(reader.searcher().search(&AllQuery, &Count).unwrap(), 1);
 
-        let writer_error = read_only_index
+        let writer_error = immutable_index
             .writer_for_tests::<TantivyDocument>()
             .err()
             .unwrap();
@@ -166,7 +174,7 @@ mod tests {
 
     #[cfg(all(feature = "mmap", unix))]
     #[test]
-    fn test_open_read_only_filesystem_index_without_lock_file() {
+    fn test_open_immutable_filesystem_index_without_lock_file() {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
         use std::path::PathBuf;
@@ -197,11 +205,11 @@ mod tests {
         fs::set_permissions(temp_directory.path(), fs::Permissions::from_mode(0o555)).unwrap();
         let _restore_permissions = RestoreDirectoryPermissions(temp_directory.path().to_path_buf());
 
-        let read_only_index = Index::open_read_only_in_dir(temp_directory.path()).unwrap();
-        let reader = read_only_index.reader().unwrap();
+        let immutable_index = Index::open_immutable_in_dir(temp_directory.path()).unwrap();
+        let reader = immutable_index.reader().unwrap();
         assert_eq!(reader.searcher().num_docs(), 1);
 
-        let second_index = Index::open_read_only_in_dir(temp_directory.path()).unwrap();
+        let second_index = Index::open_immutable_in_dir(temp_directory.path()).unwrap();
         let second_reader = second_index.reader().unwrap();
         assert_eq!(second_reader.searcher().num_docs(), 1);
         assert!(!meta_lock_path.try_exists().unwrap());

--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -6,9 +6,9 @@ mod mmap_directory;
 mod directory;
 mod directory_lock;
 pub mod footer;
+mod immutable_directory;
 mod managed_directory;
 mod ram_directory;
-mod read_only_directory;
 mod watch_event_router;
 
 /// Errors specific to the directory module.
@@ -25,8 +25,8 @@ pub use common::{AntiCallToken, OwnedBytes, TerminatingWrite};
 pub use self::composite_file::{CompositeFile, CompositeWrite};
 pub use self::directory::{Directory, DirectoryClone, DirectoryLock};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
+pub use self::immutable_directory::ImmutableDirectory;
 pub use self::ram_directory::RamDirectory;
-pub use self::read_only_directory::ReadOnlyDirectory;
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};
 
 /// Outcome of the Garbage collection

--- a/src/directory/mod.rs
+++ b/src/directory/mod.rs
@@ -8,6 +8,7 @@ mod directory_lock;
 pub mod footer;
 mod managed_directory;
 mod ram_directory;
+mod read_only_directory;
 mod watch_event_router;
 
 /// Errors specific to the directory module.
@@ -25,6 +26,7 @@ pub use self::composite_file::{CompositeFile, CompositeWrite};
 pub use self::directory::{Directory, DirectoryClone, DirectoryLock};
 pub use self::directory_lock::{Lock, INDEX_WRITER_LOCK, META_LOCK};
 pub use self::ram_directory::RamDirectory;
+pub use self::read_only_directory::ReadOnlyDirectory;
 pub use self::watch_event_router::{WatchCallback, WatchCallbackList, WatchHandle};
 
 /// Outcome of the Garbage collection

--- a/src/directory/read_only_directory.rs
+++ b/src/directory/read_only_directory.rs
@@ -1,0 +1,209 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::{fmt, io};
+
+use crate::directory::error::{DeleteError, LockError, OpenReadError, OpenWriteError};
+use crate::directory::{
+    Directory, DirectoryLock, FileHandle, Lock, WatchCallback, WatchHandle, WritePtr, META_LOCK,
+};
+
+/// A read-only view over a [`Directory`].
+///
+/// Read operations are forwarded to the underlying directory, while write operations are rejected.
+/// [`META_LOCK`] is not acquired, so the underlying index must remain unchanged while this
+/// directory is in use.
+#[derive(Clone)]
+pub struct ReadOnlyDirectory {
+    directory: Box<dyn Directory>,
+}
+
+impl ReadOnlyDirectory {
+    /// Wraps a directory containing an immutable index.
+    pub fn new(directory: impl Into<Box<dyn Directory>>) -> Self {
+        Self {
+            directory: directory.into(),
+        }
+    }
+}
+
+impl fmt::Debug for ReadOnlyDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ReadOnlyDirectory({:?})", self.directory)
+    }
+}
+
+impl Directory for ReadOnlyDirectory {
+    fn get_file_handle(&self, path: &Path) -> Result<Arc<dyn FileHandle>, OpenReadError> {
+        self.directory.get_file_handle(path)
+    }
+
+    fn delete(&self, path: &Path) -> Result<(), DeleteError> {
+        Err(DeleteError::IoError {
+            io_error: Arc::new(read_only_error()),
+            filepath: path.to_path_buf(),
+        })
+    }
+
+    fn exists(&self, path: &Path) -> Result<bool, OpenReadError> {
+        self.directory.exists(path)
+    }
+
+    fn open_write(&self, path: &Path) -> Result<WritePtr, OpenWriteError> {
+        Err(OpenWriteError::wrap_io_error(
+            read_only_error(),
+            path.to_path_buf(),
+        ))
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        self.directory.atomic_read(path)
+    }
+
+    fn atomic_write(&self, _path: &Path, _data: &[u8]) -> io::Result<()> {
+        Err(read_only_error())
+    }
+
+    fn sync_directory(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn acquire_lock(&self, lock: &Lock) -> Result<DirectoryLock, LockError> {
+        if lock.filepath == META_LOCK.filepath {
+            return Ok(DirectoryLock::from(Box::new(())));
+        }
+        Err(LockError::wrap_io_error(read_only_error()))
+    }
+
+    fn watch(&self, _watch_callback: WatchCallback) -> crate::Result<WatchHandle> {
+        Ok(WatchHandle::empty())
+    }
+}
+
+fn read_only_error() -> io::Error {
+    io::Error::new(io::ErrorKind::PermissionDenied, "directory is read-only")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::collector::Count;
+    use crate::directory::error::LockError;
+    use crate::directory::{
+        Directory, RamDirectory, ReadOnlyDirectory, INDEX_WRITER_LOCK, META_LOCK,
+    };
+    use crate::query::AllQuery;
+    use crate::schema::{Schema, TEXT};
+    use crate::{Index, TantivyDocument, TantivyError};
+
+    #[test]
+    fn test_read_only_directory_rejects_writes() {
+        let directory = RamDirectory::create();
+        directory
+            .atomic_write(Path::new("file"), b"original")
+            .unwrap();
+        let read_only_directory = ReadOnlyDirectory::new(directory);
+
+        assert_eq!(
+            read_only_directory.atomic_read(Path::new("file")).unwrap(),
+            b"original"
+        );
+        assert!(read_only_directory
+            .open_write(Path::new("new-file"))
+            .is_err());
+        assert!(read_only_directory
+            .atomic_write(Path::new("file"), b"changed")
+            .is_err());
+        assert!(read_only_directory.delete(Path::new("file")).is_err());
+        assert_eq!(
+            read_only_directory.atomic_read(Path::new("file")).unwrap(),
+            b"original"
+        );
+    }
+
+    #[test]
+    fn test_read_only_directory_only_allows_meta_lock() {
+        let read_only_directory = ReadOnlyDirectory::new(RamDirectory::create());
+
+        assert!(read_only_directory.acquire_lock(&META_LOCK).is_ok());
+        let lock_error = read_only_directory
+            .acquire_lock(&INDEX_WRITER_LOCK)
+            .err()
+            .unwrap();
+        let LockError::IoError(io_error) = lock_error else {
+            panic!("expected an IO error");
+        };
+        assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn test_read_only_index_can_search_and_reload() {
+        let mut schema_builder = Schema::builder();
+        let text = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let directory = RamDirectory::create();
+        let index = Index::create(directory.clone(), schema, Default::default()).unwrap();
+        let mut writer = index.writer_for_tests::<TantivyDocument>().unwrap();
+        writer.add_document(crate::doc!(text => "hello")).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+
+        let read_only_index = Index::open_read_only(directory).unwrap();
+        let reader = read_only_index.reader().unwrap();
+        assert_eq!(reader.searcher().search(&AllQuery, &Count).unwrap(), 1);
+        reader.reload().unwrap();
+        assert_eq!(reader.searcher().search(&AllQuery, &Count).unwrap(), 1);
+
+        let writer_error = read_only_index
+            .writer_for_tests::<TantivyDocument>()
+            .err()
+            .unwrap();
+        let TantivyError::LockFailure(LockError::IoError(io_error), _) = writer_error else {
+            panic!("expected a lock failure");
+        };
+        assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(all(feature = "mmap", unix))]
+    #[test]
+    fn test_open_read_only_filesystem_index_without_lock_file() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+        use std::path::PathBuf;
+
+        struct RestoreDirectoryPermissions(PathBuf);
+
+        impl Drop for RestoreDirectoryPermissions {
+            fn drop(&mut self) {
+                let _ = fs::set_permissions(&self.0, fs::Permissions::from_mode(0o755));
+            }
+        }
+
+        let mut schema_builder = Schema::builder();
+        let text = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let temp_directory = tempfile::tempdir().unwrap();
+        let index = Index::create_in_dir(temp_directory.path(), schema).unwrap();
+        let mut writer = index.writer_for_tests::<TantivyDocument>().unwrap();
+        writer.add_document(crate::doc!(text => "hello")).unwrap();
+        writer.commit().unwrap();
+        drop(writer);
+        drop(index);
+
+        let meta_lock_path = temp_directory.path().join(&META_LOCK.filepath);
+        if meta_lock_path.try_exists().unwrap() {
+            fs::remove_file(&meta_lock_path).unwrap();
+        }
+        fs::set_permissions(temp_directory.path(), fs::Permissions::from_mode(0o555)).unwrap();
+        let _restore_permissions = RestoreDirectoryPermissions(temp_directory.path().to_path_buf());
+
+        let read_only_index = Index::open_read_only_in_dir(temp_directory.path()).unwrap();
+        let reader = read_only_index.reader().unwrap();
+        assert_eq!(reader.searcher().num_docs(), 1);
+
+        let second_index = Index::open_read_only_in_dir(temp_directory.path()).unwrap();
+        let second_reader = second_index.reader().unwrap();
+        assert_eq!(second_reader.searcher().num_docs(), 1);
+        assert!(!meta_lock_path.try_exists().unwrap());
+    }
+}

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -596,8 +596,7 @@ impl Index {
 
     /// Opens an immutable index from a filesystem path.
     ///
-    /// See [`ReadOnlyDirectory`] for the safety requirements of opening an index without the
-    /// metadata lock.
+    /// The index must remain unchanged while it is open.
     #[cfg(feature = "mmap")]
     pub fn open_read_only_in_dir<P: AsRef<Path>>(directory_path: P) -> crate::Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
@@ -656,8 +655,7 @@ impl Index {
 
     /// Opens an immutable index using the provided directory.
     ///
-    /// See [`ReadOnlyDirectory`] for the safety requirements of opening an index without the
-    /// metadata lock.
+    /// The index must remain unchanged while it is open.
     pub fn open_read_only<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
         Index::open(ReadOnlyDirectory::new(directory))
     }

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -14,7 +14,7 @@ use crate::directory::error::OpenReadError;
 #[cfg(feature = "mmap")]
 use crate::directory::MmapDirectory;
 use crate::directory::{
-    Directory, ManagedDirectory, RamDirectory, ReadOnlyDirectory, INDEX_WRITER_LOCK,
+    Directory, ImmutableDirectory, ManagedDirectory, RamDirectory, INDEX_WRITER_LOCK,
 };
 use crate::error::{DataCorruption, TantivyError};
 use crate::fastfield::FastFieldsPlugin;
@@ -596,11 +596,13 @@ impl Index {
 
     /// Opens an immutable index from a filesystem path.
     ///
-    /// The index must remain unchanged while it is open.
+    /// This method does not write a metadata lock file or watch the directory for changes, making
+    /// it suitable for indexes stored on read-only filesystems. The index must not be modified or
+    /// garbage-collected by any process while it is open.
     #[cfg(feature = "mmap")]
-    pub fn open_read_only_in_dir<P: AsRef<Path>>(directory_path: P) -> crate::Result<Index> {
+    pub fn open_immutable_in_dir<P: AsRef<Path>>(directory_path: P) -> crate::Result<Index> {
         let mmap_directory = MmapDirectory::open(directory_path)?;
-        Index::open_read_only(mmap_directory)
+        Index::open_immutable(mmap_directory)
     }
 
     /// Returns the list of the segment metas tracked by the index.
@@ -655,9 +657,11 @@ impl Index {
 
     /// Opens an immutable index using the provided directory.
     ///
-    /// The index must remain unchanged while it is open.
-    pub fn open_read_only<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
-        Index::open(ReadOnlyDirectory::new(directory))
+    /// This method wraps the directory in an [`ImmutableDirectory`]. It does not write a metadata
+    /// lock file or watch the directory for changes. The index must not be modified or
+    /// garbage-collected by any process while it is open.
+    pub fn open_immutable<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
+        Index::open(ImmutableDirectory::new(directory))
     }
 
     /// Reads the index meta file from the directory.

--- a/src/index/index.rs
+++ b/src/index/index.rs
@@ -13,7 +13,9 @@ use crate::core::{Executor, META_FILEPATH};
 use crate::directory::error::OpenReadError;
 #[cfg(feature = "mmap")]
 use crate::directory::MmapDirectory;
-use crate::directory::{Directory, ManagedDirectory, RamDirectory, INDEX_WRITER_LOCK};
+use crate::directory::{
+    Directory, ManagedDirectory, RamDirectory, ReadOnlyDirectory, INDEX_WRITER_LOCK,
+};
 use crate::error::{DataCorruption, TantivyError};
 use crate::fastfield::FastFieldsPlugin;
 use crate::index::{
@@ -592,6 +594,16 @@ impl Index {
         Index::open(mmap_directory)
     }
 
+    /// Opens an immutable index from a filesystem path.
+    ///
+    /// See [`ReadOnlyDirectory`] for the safety requirements of opening an index without the
+    /// metadata lock.
+    #[cfg(feature = "mmap")]
+    pub fn open_read_only_in_dir<P: AsRef<Path>>(directory_path: P) -> crate::Result<Index> {
+        let mmap_directory = MmapDirectory::open(directory_path)?;
+        Index::open_read_only(mmap_directory)
+    }
+
     /// Returns the list of the segment metas tracked by the index.
     ///
     /// Such segments can of course be part of the index,
@@ -640,6 +652,14 @@ impl Index {
         let metas = load_metas(&directory, &inventory)?;
         let index = Index::open_from_metas(directory, &metas, inventory);
         Ok(index)
+    }
+
+    /// Opens an immutable index using the provided directory.
+    ///
+    /// See [`ReadOnlyDirectory`] for the safety requirements of opening an index without the
+    /// metadata lock.
+    pub fn open_read_only<T: Into<Box<dyn Directory>>>(directory: T) -> crate::Result<Index> {
+        Index::open(ReadOnlyDirectory::new(directory))
     }
 
     /// Reads the index meta file from the directory.


### PR DESCRIPTION
## Summary

Adds `ReadOnlyDirectory` for opening an immutable index without requiring write access to its directory.

- Passes read operations to the underlying directory.
- Rejects write and delete operations.
- Skips `META_LOCK`.
- Rejects other locks, including the writer lock.
- Disables filesystem watching.

Two convenience methods are included:

```rust
Index::open_read_only(directory)
Index::open_read_only_in_dir(path)
```

## Motivation

`IndexReader` acquires `META_LOCK` while loading segment readers. This requires write access to the index directory, even when the index is immutable and used only for searching.

`ReadOnlyDirectory` skips this lock so an index can be used from a read-only filesystem.

A custom `Directory` wrapper can provide similar behaviour in Rust, but this workaround is not available to users of bindings such as `tantivy-py`, because the `Directory` interface is not exposed to Python. Providing `ReadOnlyDirectory` in Tantivy allows bindings to expose the same behaviour without maintaining their own implementation.

The underlying index must remain unchanged while it is open. This mode must not be used while another process is writing to or garbage-collecting the same index.

Addresses #557 https://github.com/quickwit-oss/tantivy/issues/557#issuecomment-5430243628

## Testing

Tests cover:

- Reading from the wrapped directory.
- Rejection of writes and deletes.
- Metadata and writer lock behaviour.
- Searching and manually reloading an index.
- Opening a real read-only filesystem directory.
- Opening the same index with multiple readers.
- Verifying that `.tantivy-meta.lock` is not created.

Built with GPT-5.6 Sol in the Codex desktop harness.