### PR TITLE
Disable child scoring in ConstScoreQuery

### DIFF
--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -5,10 +5,12 @@ use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::{DocId, DocSet, Score, SegmentReader, TantivyError, Term};
 
 /// `ConstScoreQuery` is a wrapper over a query to provide a constant score.
-/// It can avoid unnecessary score computation on the wrapped query.
+/// The wrapped query is evaluated with scoring disabled and only determines which documents
+/// match, avoiding unnecessary score computation.
 ///
 /// The document set matched by the `ConstScoreQuery` is strictly the same as the underlying query.
-/// The configured score is used for each document.
+/// The configured score is used for each document. Score explanations only report this constant
+/// score and omit scoring details from the wrapped query.
 pub struct ConstScoreQuery {
     query: Box<dyn Query>,
     score: Score,
@@ -38,8 +40,9 @@ impl fmt::Debug for ConstScoreQuery {
 
 impl Query for ConstScoreQuery {
     fn weight(&self, enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
-        let inner_weight = self.query.weight(enable_scoring)?;
-        Ok(if enable_scoring.is_scoring_enabled() {
+        let scoring_enabled = enable_scoring.is_scoring_enabled();
+        let inner_weight = self.query.weight(enable_scoring.scoring_disabled())?;
+        Ok(if scoring_enabled {
             Box::new(ConstWeight::new(inner_weight, self.score))
         } else {
             inner_weight
@@ -70,15 +73,14 @@ impl Weight for ConstWeight {
 
     fn explain(&self, reader: &SegmentReader, doc: u32) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
-        if scorer.seek(doc) != doc {
+        if scorer.doc() > doc || scorer.seek(doc) != doc {
             return Err(TantivyError::InvalidArgument(format!(
                 "Document #({doc}) does not match"
             )));
         }
-        let mut explanation = Explanation::new("Const", self.score);
-        let underlying_explanation = self.weight.explain(reader, doc)?;
-        explanation.add_detail(underlying_explanation);
-        Ok(explanation)
+        // The child query only determines whether the document matches. Its score does not
+        // contribute to the constant score and is intentionally omitted from the explanation.
+        Ok(Explanation::new("Const", self.score))
     }
 
     fn count(&self, reader: &SegmentReader) -> crate::Result<u32> {
@@ -150,34 +152,168 @@ impl<TDocSet: DocSet + 'static> Scorer for ConstScorer<TDocSet> {
 #[cfg(test)]
 mod tests {
     use super::ConstScoreQuery;
-    use crate::query::{AllQuery, Query};
-    use crate::schema::Schema;
-    use crate::{DocAddress, Index, IndexWriter, TantivyDocument};
+    use crate::collector::TopDocs;
+    use crate::query::{
+        Bm25StatisticsProvider, BoostQuery, EnableScoring, Query, Scorer, TermQuery,
+    };
+    use crate::schema::{Field, IndexRecordOption, Schema, FAST, TEXT};
+    use crate::{DocAddress, Index, IndexWriter, TantivyDocument, TantivyError, Term, TERMINATED};
+
+    struct PanickingStatistics;
+
+    impl Bm25StatisticsProvider for PanickingStatistics {
+        fn total_num_tokens(&self, _field: Field) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested total_num_tokens")
+        }
+
+        fn total_num_docs(&self) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested total_num_docs")
+        }
+
+        fn doc_freq(&self, _term: &Term) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested doc_freq")
+        }
+    }
 
     #[test]
-    fn test_const_score_query_explain() -> crate::Result<()> {
-        let schema = Schema::builder().build();
+    fn test_const_score_query_disables_child_scoring() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer: IndexWriter = index.writer_for_tests()?;
-        index_writer.add_document(TantivyDocument::new())?;
+        let mut document = TantivyDocument::new();
+        document.add_text(text_field, "rust");
+        index_writer.add_document(document)?;
+        let mut non_matching_document = TantivyDocument::new();
+        non_matching_document.add_text(text_field, "search");
+        index_writer.add_document(non_matching_document)?;
         index_writer.commit()?;
         let reader = index.reader()?;
         let searcher = reader.searcher();
-        let query = ConstScoreQuery::new(Box::new(AllQuery), 0.42);
-        let explanation = query.explain(&searcher, DocAddress::new(0, 0u32)).unwrap();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_text(text_field, "rust"),
+                IndexRecordOption::WithFreqs,
+            )),
+            0.42,
+        );
+
+        let weight = query.weight(EnableScoring::enabled_from_statistics_provider(
+            &PanickingStatistics,
+            &searcher,
+        ))?;
+        let mut scorer = weight.scorer(searcher.segment_reader(0), 1.0)?;
+        assert_eq!(scorer.doc(), 0);
+        assert_eq!(scorer.score(), 0.42);
+        assert_eq!(scorer.advance(), TERMINATED);
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_supports_term_query_on_fast_only_field() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let number_field = schema_builder.add_u64_field("number", FAST);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(number_field => 42u64))?;
+        index_writer.add_document(doc!(number_field => 7u64))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_u64(number_field, 42u64),
+                IndexRecordOption::Basic,
+            )),
+            1.5,
+        );
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(10).order_by_score())?;
+        assert_eq!(top_docs, vec![(1.5, DocAddress::new(0, 0))]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_explain_omits_child_scoring_details() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(text_field => "rust rust rust other"))?;
+        index_writer.add_document(doc!(text_field => "rust search"))?;
+        index_writer.add_document(doc!(text_field => "search only"))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let term = Term::from_field_text(text_field, "rust");
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(term.clone(), IndexRecordOption::WithFreqs)),
+            0.42,
+        );
+
+        let explanation = query.explain(&searcher, DocAddress::new(0, 0))?;
         assert_eq!(
             explanation.to_pretty_json(),
             r#"{
   "value": 0.42,
-  "description": "Const",
+  "description": "Const"
+}"#
+        );
+
+        let nested_query = BoostQuery::new(
+            Box::new(ConstScoreQuery::new(
+                Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs)),
+                0.42,
+            )),
+            2.0,
+        );
+        let nested_explanation = nested_query.explain(&searcher, DocAddress::new(0, 0))?;
+        assert_eq!(
+            nested_explanation.to_pretty_json(),
+            r#"{
+  "value": 0.84,
+  "description": "Boost x2 of ...",
   "details": [
     {
-      "value": 1.0,
-      "description": "AllQuery"
+      "value": 0.42,
+      "description": "Const"
     }
   ]
 }"#
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_explain_before_first_match_returns_error() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(text_field => "alpha"))?;
+        index_writer.add_document(doc!(text_field => "beta"))?;
+        index_writer.add_document(doc!(text_field => "beta"))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_text(text_field, "beta"),
+                IndexRecordOption::Basic,
+            )),
+            0.42,
+        );
+
+        let error = query.explain(&searcher, DocAddress::new(0, 0)).unwrap_err();
+        assert!(matches!(
+            error,
+            TantivyError::InvalidArgument(message)
+                if message == "Document #(0) does not match"
+        ));
         Ok(())
     }
 }

--- a/src/query/more_like_this/query.rs
+++ b/src/query/more_like_this/query.rs
@@ -45,13 +45,10 @@ impl MoreLikeThisQuery {
 
 impl Query for MoreLikeThisQuery {
     fn weight(&self, enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
-        let searcher = match enable_scoring {
-            EnableScoring::Enabled { searcher, .. } => searcher,
-            EnableScoring::Disabled { .. } => {
-                let err = "MoreLikeThisQuery requires to enable scoring.".to_string();
-                return Err(crate::TantivyError::InvalidArgument(err));
-            }
-        };
+        let searcher = enable_scoring.searcher().ok_or_else(|| {
+            let err = "MoreLikeThisQuery requires a searcher.".to_string();
+            crate::TantivyError::InvalidArgument(err)
+        })?;
         match &self.target {
             TargetDocument::DocumentAddress(doc_address) => self
                 .mlt
@@ -190,8 +187,9 @@ impl MoreLikeThisQueryBuilder {
 mod tests {
     use super::{MoreLikeThisQuery, TargetDocument};
     use crate::collector::TopDocs;
+    use crate::query::{ConstScoreQuery, EnableScoring, Query};
     use crate::schema::{Schema, STORED, TEXT};
-    use crate::{DocAddress, Index, IndexWriter};
+    use crate::{DocAddress, Index, IndexWriter, TantivyError};
 
     fn create_test_index() -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
@@ -290,5 +288,59 @@ mod tests {
         assert_eq!(doc_ids.len(), 2);
         assert_eq!(doc_ids, vec![3, 4]);
         Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_as_const_score_child() -> crate::Result<()> {
+        let index = create_test_index()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let more_like_this_query = MoreLikeThisQuery::builder()
+            .with_min_doc_frequency(1)
+            .with_max_doc_frequency(10)
+            .with_min_term_frequency(1)
+            .with_min_word_length(2)
+            .with_max_word_length(5)
+            .with_stop_words(vec!["old".to_string()])
+            .with_document(DocAddress::new(0, 0));
+        let query = ConstScoreQuery::new(Box::new(more_like_this_query), 2.0);
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(5).order_by_score())?;
+        assert_eq!(top_docs.len(), 3);
+        assert!(top_docs.iter().all(|(score, _)| *score == 2.0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_count_without_scoring() -> crate::Result<()> {
+        let index = create_test_index()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = MoreLikeThisQuery::builder()
+            .with_min_doc_frequency(1)
+            .with_max_doc_frequency(10)
+            .with_min_term_frequency(1)
+            .with_min_word_length(2)
+            .with_max_word_length(5)
+            .with_stop_words(vec!["old".to_string()])
+            .with_document(DocAddress::new(0, 0));
+
+        assert_eq!(query.count(&searcher)?, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_without_searcher_errors() {
+        let schema = Schema::builder().build();
+        let query = MoreLikeThisQuery::builder().with_document(DocAddress::new(0, 0));
+
+        let Err(error) = query.weight(EnableScoring::disabled_from_schema(&schema)) else {
+            panic!("MoreLikeThisQuery should require a searcher");
+        };
+        assert!(matches!(
+            error,
+            TantivyError::InvalidArgument(message)
+                if message == "MoreLikeThisQuery requires a searcher."
+        ));
     }
 }

--- a/src/query/query.rs
+++ b/src/query/query.rs
@@ -89,6 +89,14 @@ impl<'a> EnableScoring<'a> {
     pub fn is_scoring_enabled(&self) -> bool {
         matches!(self, EnableScoring::Enabled { .. })
     }
+
+    /// Returns an equivalent context with scoring disabled.
+    pub(crate) fn scoring_disabled(self) -> Self {
+        match self {
+            EnableScoring::Enabled { searcher, .. } => Self::disabled_from_searcher(searcher),
+            disabled @ EnableScoring::Disabled { .. } => disabled,
+        }
+    }
 }
 
 /// The `Query` trait defines a set of documents and a scoring method


### PR DESCRIPTION
## Summary

- Compile wrapped queries with scoring disabled so `ConstScoreQuery` does not compute scores that it discards.
- Keep constant-score explanations accurate by omitting wrapped-query scoring details.
- Allow `MoreLikeThisQuery` to build in non-scoring contexts when a `Searcher` is available.

Fixes #3021.

## File-by-file changes

### `src/query/query.rs`

- Add the crate-private `EnableScoring::scoring_disabled` helper.
- Convert enabled contexts to `Disabled` while retaining the schema and available `Searcher`, and leave already-disabled contexts unchanged.

### `src/query/const_score_query.rs`

- Build the wrapped query weight with scoring disabled while preserving whether the outer query needs a constant scorer.
- Document that the wrapped query only determines matches and that explanations report only the configured constant score.
- Stop attaching misleading wrapped-query score details to `ConstWeight::explain`.
- Guard the `DocSet::seek` precondition when explaining a document before the first match.
- Add regression coverage for avoiding BM25 statistics, using real term postings, FAST-only term queries, constant-only explanations, nested boosts, and non-matching documents before the first hit.

### `src/query/more_like_this/query.rs`

- Require an available `Searcher` rather than requiring scoring to be enabled, allowing query rewriting in non-scoring contexts.
- Keep returning an error when only a schema is available.
- Add coverage for use under `ConstScoreQuery`, non-scoring `count`, and the missing-Searcher error path.

## Testing

- `cargo test --locked -p tantivy --lib` — 1,224 passed, 8 ignored.
- `cargo clippy --locked -p tantivy --lib --tests -- -D warnings`.
- Nightly rustfmt check for all modified Rust files.