### PR TITLE
Refactoring to introduce calculated fields.

### DIFF
--- a/columnar/src/lib.rs
+++ b/columnar/src/lib.rs
@@ -24,7 +24,6 @@ extern crate more_asserts;
 use std::fmt::Display;
 use std::io;
 
-mod block_accessor;
 mod column;
 pub mod column_index;
 pub mod column_values;
@@ -35,7 +34,6 @@ mod iterable;
 pub(crate) mod utils;
 mod value;
 
-pub use block_accessor::ColumnBlockAccessor;
 pub use column::{BytesColumn, Column, StrColumn};
 pub use column_index::ColumnIndex;
 pub use column_values::{

--- a/examples/reload_after_commit.rs
+++ b/examples/reload_after_commit.rs
@@ -1,0 +1,58 @@
+// # Reload after commit
+//
+// `IndexWriter::commit()` only guarantees that your documents are durably
+// persisted to the `Directory`. It does **not** guarantee that an already-open
+// `IndexReader` can see them right away: with the default
+// `ReloadPolicy::OnCommitWithDelay`, the reader reloads on a background thread
+// that is not synchronized with `commit()`'s return, on any `Directory`
+// implementation (including an in-memory `RamDirectory`). A search performed
+// immediately after `commit()` can therefore still miss the documents you
+// just added.
+//
+// If you need a search right after a commit to deterministically reflect that
+// commit, build the reader with `ReloadPolicy::Manual` and call
+// `reader.reload()` yourself, as shown below.
+
+use tantivy::collector::TopDocs;
+use tantivy::query::QueryParser;
+use tantivy::schema::*;
+use tantivy::{doc, Index, IndexWriter, ReloadPolicy};
+
+fn main() -> tantivy::Result<()> {
+    let mut schema_builder = Schema::builder();
+    let title = schema_builder.add_text_field("title", TEXT | STORED);
+    let schema = schema_builder.build();
+
+    let index = Index::create_in_ram(schema);
+
+    // `ReloadPolicy::Manual` puts us in control of exactly when the reader
+    // sees new commits, instead of racing against the background reload.
+    let reader = index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()?;
+
+    let mut index_writer: IndexWriter = index.writer(15_000_000)?;
+    index_writer.add_document(doc!(
+        title => "The Old Man and the Sea"
+    ))?;
+    index_writer.commit()?;
+
+    // Without this explicit reload, the searcher below could still be
+    // looking at the pre-commit (empty) version of the index.
+    reader.reload()?;
+
+    let query_parser = QueryParser::for_index(&index, vec![title]);
+    let query = query_parser.parse_query("sea")?;
+
+    let searcher = reader.searcher();
+    let top_docs = searcher.search(&query, &TopDocs::with_limit(10).order_by_score())?;
+
+    assert!(!top_docs.is_empty());
+    println!(
+        "Found {} matching document(s) right after commit.",
+        top_docs.len()
+    );
+
+    Ok(())
+}

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -39,7 +39,7 @@ pub struct AggregationsSegmentCtx {
     /// Request data for each aggregation type.
     pub per_request: PerRequestAggSegCtx,
     pub context: AggContextParams,
-    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
+    pub(crate) column_block_accessor: ColumnBlockAccessor,
 }
 
 impl AggregationsSegmentCtx {

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use columnar::{Column, ColumnBlockAccessor, ColumnType, StrColumn};
+use columnar::{Column, ColumnType, StrColumn};
 use common::BitSet;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -29,7 +29,7 @@ use crate::aggregation::metric::{
 use crate::aggregation::segment_agg_result::{
     GenericSegmentAggregationResultsCollector, SegmentAggregationCollector,
 };
-use crate::aggregation::{f64_to_fastfield_u64, AggContextParams, Key};
+use crate::aggregation::{f64_to_fastfield_u64, AggContextParams, ColumnBlockAccessor, Key};
 use crate::{SegmentOrdinal, SegmentReader};
 
 #[derive(Default)]
@@ -39,7 +39,7 @@ pub struct AggregationsSegmentCtx {
     /// Request data for each aggregation type.
     pub per_request: PerRequestAggSegCtx,
     pub context: AggContextParams,
-    pub column_block_accessor: ColumnBlockAccessor<u64>,
+    pub(crate) column_block_accessor: ColumnBlockAccessor<u64>,
 }
 
 impl AggregationsSegmentCtx {

--- a/src/aggregation/block_accessor.rs
+++ b/src/aggregation/block_accessor.rs
@@ -1,73 +1,108 @@
 use std::cmp::Ordering;
 
-use columnar::{Column, RowId};
+use columnar::{Cardinality, Column, RowId};
 
 use crate::DocId;
 
-#[derive(Debug, Default, Clone)]
-pub(crate) struct ColumnBlockAccessor<T> {
-    val_cache: Vec<T>,
-    docid_cache: Vec<DocId>,
-    missing_docids_cache: Vec<DocId>,
-    row_id_cache: Vec<RowId>,
+/// A source of values for a block of documents.
+///
+/// Implementations replace the contents of `values` and, for non-full sources, `docids`. The
+/// returned cardinality describes how the two buffers are aligned. Full sources must return one
+/// value per input document in the same order. Optional and multivalued sources must populate
+/// `docids` with one document id per value.
+pub(crate) trait BlockValueSource {
+    fn load_block(
+        &self,
+        docs: &[DocId],
+        values: &mut Vec<u64>,
+        docids: &mut Vec<DocId>,
+        row_ids: &mut Vec<RowId>,
+    ) -> Cardinality;
 }
 
-impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
-    ColumnBlockAccessor<T>
-{
+/// Buffers the values associated with a block of documents loaded from a [`BlockValueSource`].
+///
+/// Regardless of their original types, values are loaded in their `u64` representation using the
+/// associated monotonic mapping.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ColumnBlockAccessor {
+    /// Values loaded for the latest document block, in monotonic `u64` representation.
+    val_cache: Vec<u64>,
+    /// Document ID corresponding to each value in `val_cache` for a non-full source.
+    ///
+    /// A document can occur more than once for a multivalued source. For a full source this buffer
+    /// is ignored because `val_cache` is aligned directly with the requested document block.
+    docid_cache: Vec<DocId>,
+    /// Scratch buffer used to identify documents for which a missing value must be inserted.
+    missing_docids_cache: Vec<DocId>,
+    /// Scratch buffer available to sources for translating document IDs into value row IDs.
+    row_id_cache: Vec<RowId>,
+    /// Cardinality reported by the source that loaded the latest block.
+    /// For the moment this is reporting the cardinality of the full column, not
+    /// something specific to the block.
+    cardinality: Cardinality,
+}
+
+impl BlockValueSource for Column<u64> {
     #[inline]
-    pub(crate) fn fetch_block<'a>(&'a mut self, docs: &'a [u32], accessor: &Column<T>) {
-        self.fetch_block_with_is_full(docs, accessor, accessor.index.get_cardinality().is_full());
+    fn load_block(
+        &self,
+        docs: &[DocId],
+        values: &mut Vec<u64>,
+        docids: &mut Vec<DocId>,
+        row_ids: &mut Vec<RowId>,
+    ) -> Cardinality {
+        let cardinality = self.index.get_cardinality();
+        if cardinality.is_full() {
+            load_full_column_values(docs, self, values);
+        } else if docs.len() == 1 {
+            values.clear();
+            values.extend(self.values_for_doc(docs[0]));
+            docids.clear();
+            docids.resize(values.len(), docs[0]);
+            row_ids.clear();
+        } else {
+            docids.clear();
+            row_ids.clear();
+            self.row_ids_for_docs(docs, docids, row_ids);
+            values.resize(row_ids.len(), 0u64);
+            self.values.get_vals(row_ids, values);
+        }
+        cardinality
+    }
+}
+
+impl ColumnBlockAccessor {
+    #[inline]
+    pub(crate) fn fetch_block(&mut self, docs: &[DocId], source: &impl BlockValueSource) {
+        self.cardinality = source.load_block(
+            docs,
+            &mut self.val_cache,
+            &mut self.docid_cache,
+            &mut self.row_id_cache,
+        );
     }
 
-    /// Like [`Self::fetch_block`] but takes the column's fullness instead of querying
-    /// `accessor.index.get_cardinality()` each call — for callers that know it up front (e.g.
-    /// checked once at construction). `is_full` must equal
-    /// `accessor.index.get_cardinality().is_full()`.
+    /// Fetches a physical column known to be full without querying its cardinality.
+    ///
+    /// This direct-column-only entry point is reserved for specialized collectors whose
+    /// construction already proved the column is full.
     #[inline]
-    pub(crate) fn fetch_block_with_is_full<'a>(
-        &'a mut self,
-        docs: &'a [u32],
-        accessor: &Column<T>,
-        is_full: bool,
-    ) {
-        if is_full {
-            // Skip the resize when already the right length (common case: fixed-size blocks).
-            if self.val_cache.len() != docs.len() {
-                self.val_cache.resize(docs.len(), T::default());
-            }
-            // When the docs form a contiguous ascending run we can fetch the values
-            // as a single range. This lets codecs (e.g. bitpacked) bulk-decode the
-            // slice instead of gathering value-by-value, and avoids per-value dynamic
-            // dispatch. `docs` is always sorted ascending and free of duplicates here,
-            // so comparing the endpoints is enough to detect contiguity.
-            if is_contiguous(docs) {
-                accessor
-                    .values
-                    .get_range(docs[0] as u64, &mut self.val_cache);
-            } else {
-                accessor.values.get_vals(docs, &mut self.val_cache);
-            }
-        } else {
-            self.docid_cache.clear();
-            self.row_id_cache.clear();
-            accessor.row_ids_for_docs(docs, &mut self.docid_cache, &mut self.row_id_cache);
-            self.val_cache.resize(self.row_id_cache.len(), T::default());
-            accessor
-                .values
-                .get_vals(&self.row_id_cache, &mut self.val_cache);
-        }
+    pub(crate) fn fetch_full_column_block(&mut self, docs: &[DocId], accessor: &Column<u64>) {
+        debug_assert!(accessor.index.get_cardinality().is_full());
+        load_full_column_values(docs, accessor, &mut self.val_cache);
+        self.cardinality = Cardinality::Full;
     }
 
     /// Fetches a block and appends `missing_opt` for documents without a value.
     #[inline]
     pub(crate) fn fetch_block_with_missing(
         &mut self,
-        docs: &[u32],
-        accessor: &Column<T>,
-        missing_opt: Option<T>,
+        docs: &[DocId],
+        source: &impl BlockValueSource,
+        missing_opt: Option<u64>,
     ) {
-        self.fetch_block_with_missing_ordered(docs, accessor, missing_opt, false);
+        self.fetch_block_with_missing_ordered(docs, source, missing_opt, false)
     }
 
     /// Fetches a block and adds `missing_opt` for documents without a value. When `ordered` is
@@ -76,13 +111,13 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     #[inline]
     pub(crate) fn fetch_block_with_missing_ordered(
         &mut self,
-        docs: &[u32],
-        accessor: &Column<T>,
-        missing_opt: Option<T>,
+        docs: &[DocId],
+        source: &impl BlockValueSource,
+        missing_opt: Option<u64>,
         ordered: bool,
     ) {
-        self.fetch_block(docs, accessor);
-        let cardinality = accessor.index.get_cardinality();
+        self.fetch_block(docs, source);
+        let cardinality = self.cardinality;
         // no missing values
         if cardinality.is_full() {
             return;
@@ -146,15 +181,13 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     #[inline]
     pub(crate) fn fetch_block_with_missing_unique_per_doc(
         &mut self,
-        docs: &[u32],
-        accessor: &Column<T>,
-        missing: Option<T>,
+        docs: &[DocId],
+        source: &impl BlockValueSource,
+        missing: Option<u64>,
         ordered: bool,
-    ) where
-        T: Ord,
-    {
-        self.fetch_block_with_missing_ordered(docs, accessor, missing, ordered);
-        if accessor.index.get_cardinality().is_multivalue() {
+    ) {
+        self.fetch_block_with_missing_ordered(docs, source, missing, ordered);
+        if self.cardinality.is_multivalue() {
             self.dedup_docid_val_pairs();
         }
     }
@@ -167,8 +200,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     /// if it has more than 2 elements, then deduplicate adjacent pairs.
     ///
     /// Skips entirely if no doc_id appears more than once in the block.
-    fn dedup_docid_val_pairs(&mut self)
-    where T: Ord {
+    fn dedup_docid_val_pairs(&mut self) {
         if self.docid_cache.len() <= 1 {
             return;
         }
@@ -213,7 +245,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
 
     /// Returns the values fetched by the last `fetch_block*` call.
     #[inline]
-    pub(crate) fn values(&self) -> &[T] {
+    pub(crate) fn values(&self) -> &[u64] {
         &self.val_cache
     }
 
@@ -223,8 +255,20 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
         &self.docid_cache
     }
 
+    /// Returns whether the last fetched block contains exactly one aligned value per input doc.
     #[inline]
-    pub(crate) fn iter_vals(&self) -> impl ExactSizeIterator<Item = T> + '_ {
+    pub(crate) fn has_one_value_per_doc(&self, docs: &[DocId]) -> bool {
+        self.val_cache.len() == docs.len()
+            && (self.cardinality.is_full() || self.docid_cache == docs)
+    }
+
+    #[inline]
+    pub(crate) fn is_multivalued(&self) -> bool {
+        self.cardinality.is_multivalue()
+    }
+
+    #[inline]
+    pub(crate) fn iter_vals(&self) -> impl ExactSizeIterator<Item = u64> + '_ {
         self.val_cache.iter().cloned()
     }
 
@@ -233,14 +277,13 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     /// The passed in `docs` slice needs to be the same slice that was passed to `fetch_block` or
     /// `fetch_block_with_missing`.
     ///
-    /// The docs is used if the column is full (each docs has exactly one value), otherwise the
-    /// internal docid vec is used for the iterator, which e.g. may contain duplicate docs.
+    /// The docs are used if the source is full (each doc has exactly one value); otherwise the
+    /// internal docid vec is used and may contain duplicate docs.
     pub(crate) fn iter_docid_vals<'a>(
         &'a self,
-        docs: &'a [u32],
-        accessor: &Column<T>,
-    ) -> impl Iterator<Item = (DocId, T)> + 'a + use<'a, T> {
-        if accessor.index.get_cardinality().is_full() {
+        docs: &'a [DocId],
+    ) -> impl Iterator<Item = (DocId, u64)> + 'a {
+        if self.cardinality.is_full() {
             docs.iter().cloned().zip(self.val_cache.iter().cloned())
         } else {
             self.docid_cache
@@ -248,6 +291,21 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
                 .cloned()
                 .zip(self.val_cache.iter().cloned())
         }
+    }
+}
+
+#[inline]
+fn load_full_column_values(docs: &[DocId], accessor: &Column<u64>, values: &mut Vec<u64>) {
+    // Skip the resize when already the right length (common case: fixed-size blocks).
+    if values.len() != docs.len() {
+        values.resize(docs.len(), 0u64);
+    }
+    // When the docs form a contiguous ascending run we can fetch the values as a single range.
+    // This lets codecs (e.g. bitpacked) bulk-decode the slice instead of gathering value-by-value.
+    if is_contiguous(docs) {
+        accessor.values.get_range(docs[0] as u64, values);
+    } else {
+        accessor.values.get_vals(docs, values);
     }
 }
 
@@ -306,6 +364,33 @@ fn find_missing_docs(docs: &[u32], hits: &[u32], output: &mut Vec<u32>) {
 mod tests {
     use super::*;
 
+    struct TestValueSource {
+        cardinality: Cardinality,
+        entries: Vec<(DocId, u64)>,
+    }
+
+    impl BlockValueSource for TestValueSource {
+        fn load_block(
+            &self,
+            docs: &[DocId],
+            values: &mut Vec<u64>,
+            docids: &mut Vec<DocId>,
+            row_ids: &mut Vec<RowId>,
+        ) -> Cardinality {
+            values.clear();
+            docids.clear();
+            row_ids.clear();
+            if self.cardinality.is_full() {
+                assert_eq!(self.entries.len(), docs.len());
+                values.extend(self.entries.iter().map(|(_, value)| *value));
+            } else {
+                docids.extend(self.entries.iter().map(|(doc, _)| *doc));
+                values.extend(self.entries.iter().map(|(_, value)| *value));
+            }
+            self.cardinality
+        }
+    }
+
     #[test]
     fn test_find_missing_docs() {
         let docs: Vec<u32> = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -340,6 +425,60 @@ mod tests {
     }
 
     #[test]
+    fn test_source_neutral_full_block_alignment() {
+        let docs = [2, 4, 8];
+        let source = TestValueSource {
+            cardinality: Cardinality::Full,
+            entries: vec![(2, 20), (4, 40), (8, 80)],
+        };
+        let mut accessor = ColumnBlockAccessor::default();
+
+        accessor.fetch_block(&docs, &source);
+
+        assert!(accessor.has_one_value_per_doc(&docs));
+        assert_eq!(
+            accessor.iter_docid_vals(&docs).collect::<Vec<_>>(),
+            vec![(2, 20), (4, 40), (8, 80)]
+        );
+    }
+
+    #[test]
+    fn test_source_neutral_optional_block_with_missing() {
+        let docs = [0, 1, 2, 4];
+        let source = TestValueSource {
+            cardinality: Cardinality::Optional,
+            entries: vec![(1, 10), (4, 40)],
+        };
+        let mut accessor = ColumnBlockAccessor::default();
+
+        accessor.fetch_block_with_missing_ordered(&docs, &source, Some(99), true);
+
+        assert!(accessor.has_one_value_per_doc(&docs));
+        assert_eq!(
+            accessor.iter_docid_vals(&docs).collect::<Vec<_>>(),
+            vec![(0, 99), (1, 10), (2, 99), (4, 40)]
+        );
+    }
+
+    #[test]
+    fn test_source_neutral_multivalue_block_deduplication() {
+        let docs = [0, 1];
+        let source = TestValueSource {
+            cardinality: Cardinality::Multivalued,
+            entries: vec![(0, 3), (0, 1), (0, 3), (1, 5), (1, 5)],
+        };
+        let mut accessor = ColumnBlockAccessor::default();
+
+        accessor.fetch_block_with_missing_unique_per_doc(&docs, &source, None, false);
+
+        assert!(!accessor.has_one_value_per_doc(&docs));
+        assert_eq!(
+            accessor.iter_docid_vals(&docs).collect::<Vec<_>>(),
+            vec![(0, 1), (0, 3), (1, 5)]
+        );
+    }
+
+    #[test]
     fn test_fetch_block_with_missing_ordered() {
         use columnar::column_index::{ColumnIndex, OptionalIndex};
         use columnar::column_values::{
@@ -354,7 +493,7 @@ mod tests {
             values,
         };
         let docs = [0, 1, 2, 4, 7, 8];
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
 
         accessor.fetch_block_with_missing_ordered(&docs, &column, Some(99), true);
 
@@ -363,14 +502,14 @@ mod tests {
             vec![99, 10, 99, 40, 70, 99]
         );
         assert_eq!(
-            accessor.iter_docid_vals(&docs, &column).collect::<Vec<_>>(),
+            accessor.iter_docid_vals(&docs).collect::<Vec<_>>(),
             vec![(0, 99), (1, 10), (2, 99), (4, 40), (7, 70), (8, 99)]
         );
     }
 
     #[test]
     fn test_dedup_docid_val_pairs_consecutive() {
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         accessor.docid_cache = vec![0, 0, 2, 3];
         accessor.val_cache = vec![10, 10, 10, 10];
         accessor.dedup_docid_val_pairs();
@@ -381,7 +520,7 @@ mod tests {
     #[test]
     fn test_dedup_docid_val_pairs_non_consecutive() {
         // (0,1), (0,2), (0,1) — duplicate value not adjacent
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         accessor.docid_cache = vec![0, 0, 0];
         accessor.val_cache = vec![1, 2, 1];
         accessor.dedup_docid_val_pairs();
@@ -392,7 +531,7 @@ mod tests {
     #[test]
     fn test_dedup_docid_val_pairs_multi_doc() {
         // doc 0: values [3, 1, 3], doc 1: values [5, 5]
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         accessor.docid_cache = vec![0, 0, 0, 1, 1];
         accessor.val_cache = vec![3, 1, 3, 5, 5];
         accessor.dedup_docid_val_pairs();
@@ -402,7 +541,7 @@ mod tests {
 
     #[test]
     fn test_dedup_docid_val_pairs_no_duplicates() {
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         accessor.docid_cache = vec![0, 0, 1];
         accessor.val_cache = vec![1, 2, 3];
         accessor.dedup_docid_val_pairs();
@@ -412,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_dedup_docid_val_pairs_single_element() {
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         accessor.docid_cache = vec![0];
         accessor.val_cache = vec![1];
         accessor.dedup_docid_val_pairs();
@@ -445,14 +584,14 @@ mod tests {
             values,
         };
 
-        let check = |accessor: &mut ColumnBlockAccessor<u64>, docs: &[u32]| {
+        let check = |accessor: &mut ColumnBlockAccessor, docs: &[u32]| {
             accessor.fetch_block(docs, &column);
-            let got: Vec<(u32, u64)> = accessor.iter_docid_vals(docs, &column).collect();
+            let got: Vec<(u32, u64)> = accessor.iter_docid_vals(docs).collect();
             let expected: Vec<(u32, u64)> = docs.iter().map(|&d| (d, vals[d as usize])).collect();
             assert_eq!(got, expected);
         };
 
-        let mut accessor = ColumnBlockAccessor::<u64>::default();
+        let mut accessor = ColumnBlockAccessor::default();
         // Contiguous block -> get_range fast path.
         check(&mut accessor, &(10..74).collect::<Vec<u32>>());
         // Non-contiguous block -> get_vals gather path.

--- a/src/aggregation/block_accessor.rs
+++ b/src/aggregation/block_accessor.rs
@@ -1,9 +1,11 @@
 use std::cmp::Ordering;
 
-use crate::{Column, DocId, RowId};
+use columnar::{Column, RowId};
+
+use crate::DocId;
 
 #[derive(Debug, Default, Clone)]
-pub struct ColumnBlockAccessor<T> {
+pub(crate) struct ColumnBlockAccessor<T> {
     val_cache: Vec<T>,
     docid_cache: Vec<DocId>,
     missing_docids_cache: Vec<DocId>,
@@ -14,7 +16,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     ColumnBlockAccessor<T>
 {
     #[inline]
-    pub fn fetch_block<'a>(&'a mut self, docs: &'a [u32], accessor: &Column<T>) {
+    pub(crate) fn fetch_block<'a>(&'a mut self, docs: &'a [u32], accessor: &Column<T>) {
         self.fetch_block_with_is_full(docs, accessor, accessor.index.get_cardinality().is_full());
     }
 
@@ -23,7 +25,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     /// checked once at construction). `is_full` must equal
     /// `accessor.index.get_cardinality().is_full()`.
     #[inline]
-    pub fn fetch_block_with_is_full<'a>(
+    pub(crate) fn fetch_block_with_is_full<'a>(
         &'a mut self,
         docs: &'a [u32],
         accessor: &Column<T>,
@@ -59,7 +61,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
 
     /// Fetches a block and appends `missing_opt` for documents without a value.
     #[inline]
-    pub fn fetch_block_with_missing(
+    pub(crate) fn fetch_block_with_missing(
         &mut self,
         docs: &[u32],
         accessor: &Column<T>,
@@ -72,7 +74,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     /// true, the missing entries are inserted in document order instead of appended as a second
     /// run.
     #[inline]
-    pub fn fetch_block_with_missing_ordered(
+    pub(crate) fn fetch_block_with_missing_ordered(
         &mut self,
         docs: &[u32],
         accessor: &Column<T>,
@@ -142,7 +144,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     /// This is necessary for correct document counting in aggregations,
     /// where multi-valued fields can produce duplicate entries that inflate counts.
     #[inline]
-    pub fn fetch_block_with_missing_unique_per_doc(
+    pub(crate) fn fetch_block_with_missing_unique_per_doc(
         &mut self,
         docs: &[u32],
         accessor: &Column<T>,
@@ -211,18 +213,18 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
 
     /// Returns the values fetched by the last `fetch_block*` call.
     #[inline]
-    pub fn values(&self) -> &[T] {
+    pub(crate) fn values(&self) -> &[T] {
         &self.val_cache
     }
 
     /// Returns the document IDs corresponding to [`Self::values`] for a non-full column.
     #[inline]
-    pub fn docids(&self) -> &[DocId] {
+    pub(crate) fn docids(&self) -> &[DocId] {
         &self.docid_cache
     }
 
     #[inline]
-    pub fn iter_vals(&self) -> impl ExactSizeIterator<Item = T> + '_ {
+    pub(crate) fn iter_vals(&self) -> impl ExactSizeIterator<Item = T> + '_ {
         self.val_cache.iter().cloned()
     }
 
@@ -233,7 +235,7 @@ impl<T: PartialOrd + Copy + std::fmt::Debug + Send + Sync + 'static + Default>
     ///
     /// The docs is used if the column is full (each docs has exactly one value), otherwise the
     /// internal docid vec is used for the iterator, which e.g. may contain duplicate docs.
-    pub fn iter_docid_vals<'a>(
+    pub(crate) fn iter_docid_vals<'a>(
         &'a self,
         docs: &'a [u32],
         accessor: &Column<T>,
@@ -339,9 +341,9 @@ mod tests {
 
     #[test]
     fn test_fetch_block_with_missing_ordered() {
-        use crate::column_index::{ColumnIndex, OptionalIndex};
-        use crate::column_values::{
-            ALL_U64_CODEC_TYPES, serialize_and_load_u64_based_column_values,
+        use columnar::column_index::{ColumnIndex, OptionalIndex};
+        use columnar::column_values::{
+            serialize_and_load_u64_based_column_values, ALL_U64_CODEC_TYPES,
         };
 
         let vals = [10u64, 40, 70];
@@ -430,9 +432,9 @@ mod tests {
 
     #[test]
     fn test_fetch_block_contiguous_and_gather_match() {
-        use crate::column_index::ColumnIndex;
-        use crate::column_values::{
-            ALL_U64_CODEC_TYPES, serialize_and_load_u64_based_column_values,
+        use columnar::column_index::ColumnIndex;
+        use columnar::column_values::{
+            serialize_and_load_u64_based_column_values, ALL_U64_CODEC_TYPES,
         };
 
         let vals: Vec<u64> = (0..200u64).map(|i| i * 7 + 3).collect();

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -494,10 +494,7 @@ impl<B: BucketIdSlot> SegmentAggregationCollector for SegmentHistogramCollector<
             .fetch_block(docs, &req.accessor);
         // special path for nested buckets
         if let Some(sub_agg) = &mut self.sub_agg {
-            for (doc, val) in agg_data
-                .column_block_accessor
-                .iter_docid_vals(docs, &req.accessor)
-            {
+            for (doc, val) in agg_data.column_block_accessor.iter_docid_vals(docs) {
                 let val = f64_from_fastfield_u64(val, req.field_type);
                 if bounds.contains(val) {
                     let bucket = store.get_or_create(

--- a/src/aggregation/bucket/multi_terms/mod.rs
+++ b/src/aggregation/bucket/multi_terms/mod.rs
@@ -225,7 +225,7 @@ fn fetch_field_block(
     docs: &[crate::DocId],
     field: &MultiTermsFieldAccessor,
     missing: Option<&MultiTermsMissingAccessor>,
-    block_accessor: &mut ColumnBlockAccessor<u64>,
+    block_accessor: &mut ColumnBlockAccessor,
 ) -> bool {
     let missing_value = block_missing_value(missing);
     block_accessor.fetch_block_with_missing_unique_per_doc(
@@ -234,10 +234,7 @@ fn fetch_field_block(
         missing_value,
         true,
     );
-    if block_accessor.values().len() != docs.len() {
-        return false;
-    }
-    !field.column.get_cardinality().is_multivalue() || block_accessor.docids() == docs
+    block_accessor.has_one_value_per_doc(docs)
 }
 
 /// Packing operations used by the unified collector.
@@ -461,9 +458,8 @@ fn missing_value_for_doc(
 fn expand_partial_combinations_for_field<Packing: MultiTermsPacking>(
     packing: &Packing,
     field_idx: usize,
-    field: &MultiTermsFieldAccessor,
     missing: Option<&MultiTermsMissingAccessor>,
-    block_accessor: &ColumnBlockAccessor<u64>,
+    block_accessor: &ColumnBlockAccessor,
     keys_buf: &mut Vec<Packing::PackingType>,
     alive_docs: &mut Vec<DocId>,
     doc_ids_per_partial_combination: &mut Vec<DocId>,
@@ -483,9 +479,7 @@ fn expand_partial_combinations_for_field<Packing: MultiTermsPacking>(
     );
 
     {
-        let mut field_values = block_accessor
-            .iter_docid_vals(alive_docs, &field.column)
-            .peekable();
+        let mut field_values = block_accessor.iter_docid_vals(alive_docs).peekable();
         let mut doc_values = SmallVec::<[u64; 2]>::new();
         let mut combination_start = 0;
 
@@ -575,7 +569,7 @@ where
     fn build_keys_from_full_fields(
         &mut self,
         docs: &[DocId],
-        block_accessor: &mut ColumnBlockAccessor<u64>,
+        block_accessor: &mut ColumnBlockAccessor,
     ) {
         for (field_idx, field) in self.req_data.fields.iter().enumerate() {
             fetch_field_block(
@@ -595,7 +589,7 @@ where
     fn build_keys_from_non_full_fields(
         &mut self,
         docs: &[DocId],
-        block_accessor: &mut ColumnBlockAccessor<u64>,
+        block_accessor: &mut ColumnBlockAccessor,
     ) {
         self.alive_docs.clear();
         self.alive_docs.extend_from_slice(docs);
@@ -632,7 +626,7 @@ where
 
             // Until expansion, sparse single-value fields can filter keys in place.
             if self.doc_ids_per_partial_combination.is_empty()
-                && !field.column.get_cardinality().is_multivalue()
+                && !block_accessor.is_multivalued()
                 && missing.is_none()
             {
                 let mut source_idx = 0usize;
@@ -660,7 +654,6 @@ where
             expand_partial_combinations_for_field(
                 &self.packing,
                 field_idx,
-                field,
                 missing,
                 block_accessor,
                 &mut self.keys_buf,

--- a/src/aggregation/bucket/multi_terms/mod.rs
+++ b/src/aggregation/bucket/multi_terms/mod.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use columnar::column_values::CompactSpaceU64Accessor;
 use columnar::{
-    Column, ColumnBlockAccessor, ColumnType, Dictionary, MonotonicallyMappableToU128,
-    MonotonicallyMappableToU64, NumericalValue, StrColumn,
+    Column, ColumnType, Dictionary, MonotonicallyMappableToU128, MonotonicallyMappableToU64,
+    NumericalValue, StrColumn,
 };
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
@@ -30,7 +30,7 @@ use crate::aggregation::intermediate_agg_result::{
     IntermediateKey, IntermediateTermBucketEntry, PruneMode,
 };
 use crate::aggregation::segment_agg_result::{BucketIdProvider, SegmentAggregationCollector};
-use crate::aggregation::{f64_to_fastfield_u64, format_date, BucketId, Key};
+use crate::aggregation::{f64_to_fastfield_u64, format_date, BucketId, ColumnBlockAccessor, Key};
 use crate::{DocId, TantivyError};
 
 /// Multi-terms aggregation: one bucket per unique combination of values across N term fields.

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -285,10 +285,7 @@ impl<B: SubAggBuffer> SegmentAggregationCollector for SegmentRangeCollector<B> {
 
         let buckets = &mut self.parent_buckets[parent_bucket_id as usize];
 
-        for (doc, val) in agg_data
-            .column_block_accessor
-            .iter_docid_vals(docs, &self.req_data.accessor)
-        {
+        for (doc, val) in agg_data.column_block_accessor.iter_docid_vals(docs) {
             let bucket_pos = get_bucket_pos(val, buckets);
             let bucket = &mut buckets[bucket_pos];
             bucket.bucket.doc_count += 1;

--- a/src/aggregation/bucket/term_agg/fused_term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/fused_term_histogram.rs
@@ -39,7 +39,7 @@ const SINGLE_COUNT_LANE: usize = 1;
 const NUM_SMALL_LINEAR_BUCKETS: usize = 4;
 const NUM_LARGE_LINEAR_BUCKETS: usize = 8;
 
-trait FusedBucketResolver: Debug + 'static {
+trait BucketResolver: Debug + 'static {
     /// Fetches the histogram values needed for this block. Resolvers that do not inspect the
     /// histogram column (notably [`FusedSingleBucketResolver`]) leave this as a no-op.
     fn prepare_block(&mut self, docs: &[crate::DocId]);
@@ -82,21 +82,21 @@ fn increment_grid_count<const LANES: usize>(
 /// Resolver for a histogram whose entire value range maps to one bucket. It deliberately owns no
 /// block accessor: collecting this shape does not read or decode the histogram column at all.
 #[derive(Debug)]
-struct FusedSingleBucketResolver {
+struct SingleBucketResolver {
     next_count_lane: usize,
 }
 
-impl FusedSingleBucketResolver {
+impl SingleBucketResolver {
     fn new(hist_req_data: &HistogramAggReqData) -> Self {
         assert!(
             hist_req_data.accessor.get_cardinality().is_full(),
-            "FusedSingleBucketResolver requires a full histogram column"
+            "SingleBucketResolver requires a full histogram column"
         );
         Self { next_count_lane: 0 }
     }
 }
 
-impl FusedBucketResolver for FusedSingleBucketResolver {
+impl BucketResolver for SingleBucketResolver {
     #[inline]
     fn prepare_block(&mut self, _docs: &[crate::DocId]) {}
 
@@ -123,14 +123,14 @@ impl FusedBucketResolver for FusedSingleBucketResolver {
         _counts: &mut [[u32; LANES]],
         _term_counts: &mut [[u32; LANES]],
     ) {
-        unreachable!("FusedSingleBucketResolver is only constructed without hard bounds");
+        unreachable!("SingleBucketResolver is only constructed without hard bounds");
     }
 }
 
 /// The general resolver. It preserves the existing field conversion and floating-point bucket
 /// calculation for histograms that do not use a specialized resolver.
 #[derive(Debug)]
-struct FusedComputedBucketResolver {
+struct ComputedBucketResolver {
     hist_block: ColumnBlockAccessor,
     next_count_lane: usize,
     accessor: Column<u64>,
@@ -142,11 +142,11 @@ struct FusedComputedBucketResolver {
     bounds: crate::aggregation::bucket::HistogramBounds,
 }
 
-impl FusedComputedBucketResolver {
+impl ComputedBucketResolver {
     fn new(hist_req_data: &HistogramAggReqData, base_pos: i64, num_buckets: usize) -> Self {
         assert!(
             hist_req_data.accessor.get_cardinality().is_full(),
-            "FusedComputedBucketResolver requires a full histogram column"
+            "ComputedBucketResolver requires a full histogram column"
         );
         Self {
             hist_block: ColumnBlockAccessor::default(),
@@ -162,7 +162,7 @@ impl FusedComputedBucketResolver {
     }
 }
 
-impl FusedBucketResolver for FusedComputedBucketResolver {
+impl BucketResolver for ComputedBucketResolver {
     #[inline]
     fn prepare_block(&mut self, docs: &[crate::DocId]) {
         self.hist_block
@@ -224,7 +224,7 @@ impl FusedBucketResolver for FusedComputedBucketResolver {
 /// Resolver for a small histogram grid. Bucket starts are precomputed in monotonic fast-field
 /// `u64` space, then scanned linearly. `NUM_BUCKETS` is fixed so the optimizer can unroll the scan.
 #[derive(Debug)]
-struct FusedLinearBucketResolver<const NUM_BUCKETS: usize> {
+struct LinearBucketResolver<const NUM_BUCKETS: usize> {
     hist_block: ColumnBlockAccessor,
     next_count_lane: usize,
     accessor: Column<u64>,
@@ -232,7 +232,7 @@ struct FusedLinearBucketResolver<const NUM_BUCKETS: usize> {
     num_buckets: usize,
 }
 
-impl<const NUM_BUCKETS: usize> FusedLinearBucketResolver<NUM_BUCKETS> {
+impl<const NUM_BUCKETS: usize> LinearBucketResolver<NUM_BUCKETS> {
     fn new(
         hist_req_data: &HistogramAggReqData,
         base_pos: i64,
@@ -241,7 +241,7 @@ impl<const NUM_BUCKETS: usize> FusedLinearBucketResolver<NUM_BUCKETS> {
         assert!(num_time_buckets > 1 && num_time_buckets <= NUM_BUCKETS);
         assert!(
             hist_req_data.accessor.get_cardinality().is_full(),
-            "FusedLinearBucketResolver requires a full histogram column"
+            "LinearBucketResolver requires a full histogram column"
         );
         let max_encoded_value = hist_req_data.accessor.max_value();
         // Padding must compare false for every column value. There is no such `u64` sentinel when
@@ -278,7 +278,7 @@ impl<const NUM_BUCKETS: usize> FusedLinearBucketResolver<NUM_BUCKETS> {
     }
 }
 
-impl<const NUM_BUCKETS: usize> FusedBucketResolver for FusedLinearBucketResolver<NUM_BUCKETS> {
+impl<const NUM_BUCKETS: usize> BucketResolver for LinearBucketResolver<NUM_BUCKETS> {
     #[inline]
     fn prepare_block(&mut self, docs: &[crate::DocId]) {
         self.hist_block
@@ -312,8 +312,8 @@ impl<const NUM_BUCKETS: usize> FusedBucketResolver for FusedLinearBucketResolver
         _term_counts: &mut [[u32; LANES]],
     ) {
         panic!(
-            "FusedLinearBucketResolver does not support hard bounds and should not be constructed \
-             with them"
+            "LinearBucketResolver does not support hard bounds and should not be constructed with \
+             them"
         );
     }
 }
@@ -360,7 +360,7 @@ fn first_encoded_value_for_bucket(
 /// handed to the shared intermediate-result builders, so cross-segment merging is identical to the
 /// general path.
 #[derive(Debug)]
-struct FusedTermHistogramCollector<R: FusedBucketResolver, const LANES: usize> {
+struct FusedTermHistogramCollector<R: BucketResolver, const LANES: usize> {
     /// Per-term count of docs *outside* `hard_bounds` (still in `doc_count`, but in no bucket).
     /// Per-term total = this + the term's `counts` row-sum; left empty when there are no hard
     /// bounds (every doc is in-bounds, so there's no remainder to track).
@@ -385,7 +385,7 @@ struct FusedTermHistogramCollector<R: FusedBucketResolver, const LANES: usize> {
     all_docs_in_bounds: bool,
 }
 
-impl<R: FusedBucketResolver, const LANES: usize> SegmentAggregationCollector
+impl<R: BucketResolver, const LANES: usize> SegmentAggregationCollector
     for FusedTermHistogramCollector<R, LANES>
 {
     fn add_intermediate_aggregation_result(
@@ -453,7 +453,7 @@ impl<R: FusedBucketResolver, const LANES: usize> SegmentAggregationCollector
         );
 
         // The term column is always needed. The resolver fetches the histogram column only when
-        // bucket selection depends on its values; `FusedSingleBucketResolver` makes this a no-op.
+        // bucket selection depends on its values; `SingleBucketResolver` makes this a no-op.
         self.term_block
             .fetch_full_column_block(docs, &self.terms_req_data.accessor);
         self.bucket_resolver.prepare_block(docs);
@@ -601,8 +601,8 @@ fn build_fused_collector<const LANES: usize>(
     let all_docs_in_bounds =
         hist_req_data.bounds.min == f64::MIN && hist_req_data.bounds.max == f64::MAX;
     if all_docs_in_bounds && num_time_buckets == 1 {
-        let resolver = FusedSingleBucketResolver::new(&hist_req_data);
-        return build_fused_collector_with_resolver::<FusedSingleBucketResolver, LANES>(
+        let resolver = SingleBucketResolver::new(&hist_req_data);
+        return build_fused_collector_with_resolver::<SingleBucketResolver, LANES>(
             agg_data,
             terms_req_data,
             hist_req_data,
@@ -612,7 +612,7 @@ fn build_fused_collector<const LANES: usize>(
         );
     }
     if all_docs_in_bounds && num_time_buckets <= NUM_SMALL_LINEAR_BUCKETS {
-        if let Some(resolver) = FusedLinearBucketResolver::<NUM_SMALL_LINEAR_BUCKETS>::new(
+        if let Some(resolver) = LinearBucketResolver::<NUM_SMALL_LINEAR_BUCKETS>::new(
             &hist_req_data,
             base_pos,
             num_time_buckets,
@@ -627,7 +627,7 @@ fn build_fused_collector<const LANES: usize>(
             );
         }
     } else if all_docs_in_bounds && num_time_buckets <= NUM_LARGE_LINEAR_BUCKETS {
-        if let Some(resolver) = FusedLinearBucketResolver::<NUM_LARGE_LINEAR_BUCKETS>::new(
+        if let Some(resolver) = LinearBucketResolver::<NUM_LARGE_LINEAR_BUCKETS>::new(
             &hist_req_data,
             base_pos,
             num_time_buckets,
@@ -643,7 +643,7 @@ fn build_fused_collector<const LANES: usize>(
         }
     }
 
-    let resolver = FusedComputedBucketResolver::new(&hist_req_data, base_pos, num_time_buckets);
+    let resolver = ComputedBucketResolver::new(&hist_req_data, base_pos, num_time_buckets);
     build_fused_collector_with_resolver::<_, LANES>(
         agg_data,
         terms_req_data,
@@ -654,7 +654,7 @@ fn build_fused_collector<const LANES: usize>(
     )
 }
 
-fn build_fused_collector_with_resolver<R: FusedBucketResolver, const LANES: usize>(
+fn build_fused_collector_with_resolver<R: BucketResolver, const LANES: usize>(
     agg_data: &mut AggregationsSegmentCtx,
     terms_req_data: &TermsAggReqData,
     hist_req_data: HistogramAggReqData,

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -30,7 +30,7 @@ use crate::aggregation::{format_date, BucketId, Key};
 use crate::error::DataCorruption;
 use crate::TantivyError;
 
-mod term_histogram;
+mod fused_term_histogram;
 
 /// Contains all information required by the SegmentTermCollector to perform the
 /// terms aggregation on a segment.
@@ -429,7 +429,7 @@ pub(crate) fn build_segment_term_collector(
 
     // Fused fast path: low-cardinality terms × a single `histogram`/`date_histogram` leaf over full
     // columns with a small enough bucket grid. Anything else falls through to the general path.
-    if let Some(collector) = term_histogram::maybe_build_fused_collector(
+    if let Some(collector) = fused_term_histogram::maybe_build_fused_collector(
         req_data,
         node,
         &terms_req_data,

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -429,7 +429,7 @@ pub(crate) fn build_segment_term_collector(
 
     // Fused fast path: low-cardinality terms × a single `histogram`/`date_histogram` leaf over full
     // columns with a small enough bucket grid. Anything else falls through to the general path.
-    if let Some(collector) = term_histogram::maybe_build_collector(
+    if let Some(collector) = term_histogram::maybe_build_fused_collector(
         req_data,
         node,
         &terms_req_data,
@@ -1070,9 +1070,7 @@ impl<TermMap: TermAggregationMap, B: SubAggBuffer> SegmentAggregationCollector
 
         if let Some(sub_agg) = &mut self.sub_agg {
             let term_buckets = &mut self.parent_buckets[parent_bucket_id as usize];
-            let it = agg_data
-                .column_block_accessor
-                .iter_docid_vals(docs, &req_data.accessor);
+            let it = agg_data.column_block_accessor.iter_docid_vals(docs);
             if let Some(allowed_bs) = req_data.allowed_term_ids.as_ref() {
                 let it = it.filter(move |&(_doc, term_id)| allowed_bs.contains(term_id as u32));
                 Self::collect_terms_with_docs(

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Debug;
 
-use columnar::{Column, ColumnBlockAccessor, ColumnType};
+use columnar::{Column, ColumnType};
 
 use super::{
     Bucket, SegmentTermCollector, TermsAggReqData, VecTermBuckets, MAX_NUM_BUCKETS_FOR_COUNT_LANES,
@@ -22,7 +22,7 @@ use crate::aggregation::intermediate_agg_result::{
     IntermediateAggregationResult, IntermediateAggregationResults,
 };
 use crate::aggregation::segment_agg_result::{BucketIdProvider, SegmentAggregationCollector};
-use crate::aggregation::{f64_from_fastfield_u64, BucketId};
+use crate::aggregation::{f64_from_fastfield_u64, BucketId, ColumnBlockAccessor};
 
 /// Maximum number of physical counters in the fused flat grid. Above this the grid would be too
 /// large/cache-unfriendly, so we fall back to the general buffered path. Count lanes are included

--- a/src/aggregation/bucket/term_agg/term_histogram.rs
+++ b/src/aggregation/bucket/term_agg/term_histogram.rs
@@ -1,8 +1,8 @@
 //! Fused collector for the very common shape `terms` (low cardinality) × a single
 //! `histogram`/`date_histogram` sub-aggregation with nothing nested below it.
 //!
-//! See [`SegmentTermHistogramCollector`] for the approach and [`maybe_build_collector`] for the
-//! conditions under which it is used.
+//! See [`FusedTermHistogramCollector`] for the approach and [`maybe_build_fused_collector`] for
+//! the conditions under which it is used.
 
 use std::fmt::Debug;
 
@@ -39,9 +39,9 @@ const SINGLE_COUNT_LANE: usize = 1;
 const NUM_SMALL_LINEAR_BUCKETS: usize = 4;
 const NUM_LARGE_LINEAR_BUCKETS: usize = 8;
 
-trait BucketResolver: Debug + 'static {
+trait FusedBucketResolver: Debug + 'static {
     /// Fetches the histogram values needed for this block. Resolvers that do not inspect the
-    /// histogram column (notably [`SingleBucketResolver`]) leave this as a no-op.
+    /// histogram column (notably [`FusedSingleBucketResolver`]) leave this as a no-op.
     fn prepare_block(&mut self, docs: &[crate::DocId]);
 
     /// Number of logical histogram buckets produced by this resolver.
@@ -81,12 +81,22 @@ fn increment_grid_count<const LANES: usize>(
 
 /// Resolver for a histogram whose entire value range maps to one bucket. It deliberately owns no
 /// block accessor: collecting this shape does not read or decode the histogram column at all.
-#[derive(Debug, Default)]
-struct SingleBucketResolver {
+#[derive(Debug)]
+struct FusedSingleBucketResolver {
     next_count_lane: usize,
 }
 
-impl BucketResolver for SingleBucketResolver {
+impl FusedSingleBucketResolver {
+    fn new(hist_req_data: &HistogramAggReqData) -> Self {
+        assert!(
+            hist_req_data.accessor.get_cardinality().is_full(),
+            "FusedSingleBucketResolver requires a full histogram column"
+        );
+        Self { next_count_lane: 0 }
+    }
+}
+
+impl FusedBucketResolver for FusedSingleBucketResolver {
     #[inline]
     fn prepare_block(&mut self, _docs: &[crate::DocId]) {}
 
@@ -113,18 +123,17 @@ impl BucketResolver for SingleBucketResolver {
         _counts: &mut [[u32; LANES]],
         _term_counts: &mut [[u32; LANES]],
     ) {
-        unreachable!("SingleBucketResolver is only constructed without hard bounds");
+        unreachable!("FusedSingleBucketResolver is only constructed without hard bounds");
     }
 }
 
 /// The general resolver. It preserves the existing field conversion and floating-point bucket
 /// calculation for histograms that do not use a specialized resolver.
 #[derive(Debug)]
-struct ComputedBucketResolver {
-    hist_block: ColumnBlockAccessor<u64>,
+struct FusedComputedBucketResolver {
+    hist_block: ColumnBlockAccessor,
     next_count_lane: usize,
     accessor: Column<u64>,
-    is_full: bool,
     field_type: ColumnType,
     interval: f64,
     offset: f64,
@@ -133,13 +142,16 @@ struct ComputedBucketResolver {
     bounds: crate::aggregation::bucket::HistogramBounds,
 }
 
-impl ComputedBucketResolver {
+impl FusedComputedBucketResolver {
     fn new(hist_req_data: &HistogramAggReqData, base_pos: i64, num_buckets: usize) -> Self {
+        assert!(
+            hist_req_data.accessor.get_cardinality().is_full(),
+            "FusedComputedBucketResolver requires a full histogram column"
+        );
         Self {
             hist_block: ColumnBlockAccessor::default(),
             next_count_lane: 0,
             accessor: hist_req_data.accessor.clone(),
-            is_full: hist_req_data.accessor.get_cardinality().is_full(),
             field_type: hist_req_data.field_type,
             interval: hist_req_data.req.interval,
             offset: hist_req_data.offset,
@@ -150,11 +162,11 @@ impl ComputedBucketResolver {
     }
 }
 
-impl BucketResolver for ComputedBucketResolver {
+impl FusedBucketResolver for FusedComputedBucketResolver {
     #[inline]
     fn prepare_block(&mut self, docs: &[crate::DocId]) {
         self.hist_block
-            .fetch_block_with_is_full(docs, &self.accessor, self.is_full);
+            .fetch_full_column_block(docs, &self.accessor);
     }
 
     #[inline]
@@ -212,21 +224,25 @@ impl BucketResolver for ComputedBucketResolver {
 /// Resolver for a small histogram grid. Bucket starts are precomputed in monotonic fast-field
 /// `u64` space, then scanned linearly. `NUM_BUCKETS` is fixed so the optimizer can unroll the scan.
 #[derive(Debug)]
-struct LinearBucketResolver<const NUM_BUCKETS: usize> {
-    hist_block: ColumnBlockAccessor<u64>,
+struct FusedLinearBucketResolver<const NUM_BUCKETS: usize> {
+    hist_block: ColumnBlockAccessor,
     next_count_lane: usize,
     accessor: Column<u64>,
     boundaries: [u64; NUM_BUCKETS],
     num_buckets: usize,
 }
 
-impl<const NUM_BUCKETS: usize> LinearBucketResolver<NUM_BUCKETS> {
+impl<const NUM_BUCKETS: usize> FusedLinearBucketResolver<NUM_BUCKETS> {
     fn new(
         hist_req_data: &HistogramAggReqData,
         base_pos: i64,
         num_time_buckets: usize,
     ) -> Option<Self> {
         assert!(num_time_buckets > 1 && num_time_buckets <= NUM_BUCKETS);
+        assert!(
+            hist_req_data.accessor.get_cardinality().is_full(),
+            "FusedLinearBucketResolver requires a full histogram column"
+        );
         let max_encoded_value = hist_req_data.accessor.max_value();
         // Padding must compare false for every column value. There is no such `u64` sentinel when
         // the column contains `u64::MAX`, so that edge case uses the computed resolver instead.
@@ -262,11 +278,11 @@ impl<const NUM_BUCKETS: usize> LinearBucketResolver<NUM_BUCKETS> {
     }
 }
 
-impl<const NUM_BUCKETS: usize> BucketResolver for LinearBucketResolver<NUM_BUCKETS> {
+impl<const NUM_BUCKETS: usize> FusedBucketResolver for FusedLinearBucketResolver<NUM_BUCKETS> {
     #[inline]
     fn prepare_block(&mut self, docs: &[crate::DocId]) {
         self.hist_block
-            .fetch_block_with_is_full(docs, &self.accessor, true);
+            .fetch_full_column_block(docs, &self.accessor);
     }
 
     #[inline]
@@ -296,8 +312,8 @@ impl<const NUM_BUCKETS: usize> BucketResolver for LinearBucketResolver<NUM_BUCKE
         _term_counts: &mut [[u32; LANES]],
     ) {
         panic!(
-            "LinearBucketResolver does not support hard bounds and should not be constructed with \
-             them"
+            "FusedLinearBucketResolver does not support hard bounds and should not be constructed \
+             with them"
         );
     }
 }
@@ -344,7 +360,7 @@ fn first_encoded_value_for_bucket(
 /// handed to the shared intermediate-result builders, so cross-segment merging is identical to the
 /// general path.
 #[derive(Debug)]
-struct SegmentTermHistogramCollector<R: BucketResolver, const LANES: usize> {
+struct FusedTermHistogramCollector<R: FusedBucketResolver, const LANES: usize> {
     /// Per-term count of docs *outside* `hard_bounds` (still in `doc_count`, but in no bucket).
     /// Per-term total = this + the term's `counts` row-sum; left empty when there are no hard
     /// bounds (every doc is in-bounds, so there's no remainder to track).
@@ -363,17 +379,14 @@ struct SegmentTermHistogramCollector<R: BucketResolver, const LANES: usize> {
     hist_req_data: HistogramAggReqData,
     /// Private term block accessor. The bucket resolver owns a histogram block accessor when it
     /// needs one; the single-bucket resolver deliberately does not.
-    term_block: ColumnBlockAccessor<u64>,
+    term_block: ColumnBlockAccessor,
     bucket_resolver: R,
     /// No hard bounds, so every doc is in-bounds.
     all_docs_in_bounds: bool,
-    /// The term column is full (a fused-path precondition); cached so `collect` skips the
-    /// per-block cardinality lookup in `fetch_block`.
-    term_is_full: bool,
 }
 
-impl<R: BucketResolver, const LANES: usize> SegmentAggregationCollector
-    for SegmentTermHistogramCollector<R, LANES>
+impl<R: FusedBucketResolver, const LANES: usize> SegmentAggregationCollector
+    for FusedTermHistogramCollector<R, LANES>
 {
     fn add_intermediate_aggregation_result(
         &mut self,
@@ -440,12 +453,9 @@ impl<R: BucketResolver, const LANES: usize> SegmentAggregationCollector
         );
 
         // The term column is always needed. The resolver fetches the histogram column only when
-        // bucket selection depends on its values; `SingleBucketResolver` makes this a no-op.
-        self.term_block.fetch_block_with_is_full(
-            docs,
-            &self.terms_req_data.accessor,
-            self.term_is_full,
-        );
+        // bucket selection depends on its values; `FusedSingleBucketResolver` makes this a no-op.
+        self.term_block
+            .fetch_full_column_block(docs, &self.terms_req_data.accessor);
         self.bucket_resolver.prepare_block(docs);
 
         // Keep separate bounded and unbounded entry points so the common path has no bounds branch,
@@ -495,7 +505,7 @@ impl<R: BucketResolver, const LANES: usize> SegmentAggregationCollector
 /// Eligibility: top-level, low-cardinality terms over a full column with no missing/include-exclude
 /// handling; a single `histogram`/`date_histogram` leaf (no nesting below it) over a full column;
 /// and a physical counter grid no larger than [`MAX_FUSED_GRID_COUNTERS`].
-pub(super) fn maybe_build_collector(
+pub(super) fn maybe_build_fused_collector(
     agg_data: &mut AggregationsSegmentCtx,
     node: &AggRefNode,
     terms_req_data: &TermsAggReqData,
@@ -557,7 +567,7 @@ pub(super) fn maybe_build_collector(
     }
 
     let collector = if use_count_lanes {
-        build_collector::<NUM_LOW_CARD_COUNT_LANES>(
+        build_fused_collector::<NUM_LOW_CARD_COUNT_LANES>(
             agg_data,
             terms_req_data,
             hist_req_data,
@@ -566,7 +576,7 @@ pub(super) fn maybe_build_collector(
             range.base_pos,
         )?
     } else {
-        build_collector::<SINGLE_COUNT_LANE>(
+        build_fused_collector::<SINGLE_COUNT_LANE>(
             agg_data,
             terms_req_data,
             hist_req_data,
@@ -578,7 +588,7 @@ pub(super) fn maybe_build_collector(
     Ok(Some(collector))
 }
 
-fn build_collector<const LANES: usize>(
+fn build_fused_collector<const LANES: usize>(
     agg_data: &mut AggregationsSegmentCtx,
     terms_req_data: &TermsAggReqData,
     hist_req_data: HistogramAggReqData,
@@ -591,22 +601,23 @@ fn build_collector<const LANES: usize>(
     let all_docs_in_bounds =
         hist_req_data.bounds.min == f64::MIN && hist_req_data.bounds.max == f64::MAX;
     if all_docs_in_bounds && num_time_buckets == 1 {
-        return build_collector_with_resolver::<SingleBucketResolver, LANES>(
+        let resolver = FusedSingleBucketResolver::new(&hist_req_data);
+        return build_fused_collector_with_resolver::<FusedSingleBucketResolver, LANES>(
             agg_data,
             terms_req_data,
             hist_req_data,
             num_terms,
             base_pos,
-            SingleBucketResolver::default(),
+            resolver,
         );
     }
     if all_docs_in_bounds && num_time_buckets <= NUM_SMALL_LINEAR_BUCKETS {
-        if let Some(resolver) = LinearBucketResolver::<NUM_SMALL_LINEAR_BUCKETS>::new(
+        if let Some(resolver) = FusedLinearBucketResolver::<NUM_SMALL_LINEAR_BUCKETS>::new(
             &hist_req_data,
             base_pos,
             num_time_buckets,
         ) {
-            return build_collector_with_resolver::<_, LANES>(
+            return build_fused_collector_with_resolver::<_, LANES>(
                 agg_data,
                 terms_req_data,
                 hist_req_data,
@@ -616,12 +627,12 @@ fn build_collector<const LANES: usize>(
             );
         }
     } else if all_docs_in_bounds && num_time_buckets <= NUM_LARGE_LINEAR_BUCKETS {
-        if let Some(resolver) = LinearBucketResolver::<NUM_LARGE_LINEAR_BUCKETS>::new(
+        if let Some(resolver) = FusedLinearBucketResolver::<NUM_LARGE_LINEAR_BUCKETS>::new(
             &hist_req_data,
             base_pos,
             num_time_buckets,
         ) {
-            return build_collector_with_resolver::<_, LANES>(
+            return build_fused_collector_with_resolver::<_, LANES>(
                 agg_data,
                 terms_req_data,
                 hist_req_data,
@@ -632,8 +643,8 @@ fn build_collector<const LANES: usize>(
         }
     }
 
-    let resolver = ComputedBucketResolver::new(&hist_req_data, base_pos, num_time_buckets);
-    build_collector_with_resolver::<_, LANES>(
+    let resolver = FusedComputedBucketResolver::new(&hist_req_data, base_pos, num_time_buckets);
+    build_fused_collector_with_resolver::<_, LANES>(
         agg_data,
         terms_req_data,
         hist_req_data,
@@ -643,7 +654,7 @@ fn build_collector<const LANES: usize>(
     )
 }
 
-fn build_collector_with_resolver<R: BucketResolver, const LANES: usize>(
+fn build_fused_collector_with_resolver<R: FusedBucketResolver, const LANES: usize>(
     agg_data: &mut AggregationsSegmentCtx,
     terms_req_data: &TermsAggReqData,
     hist_req_data: HistogramAggReqData,
@@ -670,7 +681,7 @@ fn build_collector_with_resolver<R: BucketResolver, const LANES: usize>(
         .limits
         .add_memory_consumed(memory_consumption as u64)?;
 
-    Ok(Box::new(SegmentTermHistogramCollector::<R, LANES> {
+    Ok(Box::new(FusedTermHistogramCollector::<R, LANES> {
         term_counts,
         counts,
         base_pos,
@@ -679,7 +690,6 @@ fn build_collector_with_resolver<R: BucketResolver, const LANES: usize>(
         term_block: ColumnBlockAccessor::default(),
         bucket_resolver,
         all_docs_in_bounds,
-        term_is_full: terms_req_data.accessor.get_cardinality().is_full(),
     }))
 }
 
@@ -693,7 +703,7 @@ mod tests {
     use crate::aggregation::AggregationLimitsGuard;
 
     /// Hand-computed correctness check for the fused terms×histogram fast path
-    /// ([`super::SegmentTermHistogramCollector`]): low-cardinality terms × a histogram leaf over
+    /// ([`super::FusedTermHistogramCollector`]): low-cardinality terms × a histogram leaf over
     /// full columns, exercised single- and multi-segment.
     #[test]
     fn fused_term_histogram_test() -> crate::Result<()> {

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -285,16 +285,6 @@ impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
         docs: &[crate::DocId],
         agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
-        // TODO: remove once we fetch all values for all bucket ids in one go
-        if docs.len() == 1 && self.missing_u64.is_none() {
-            collect_stats::<COLUMN_TYPE_ID>(
-                &mut self.buckets[parent_bucket_id as usize],
-                self.accessor.values_for_doc(docs[0]),
-                self.is_number_or_date_type,
-            )?;
-
-            return Ok(());
-        }
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,
             &self.accessor,

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -132,6 +132,7 @@ mod agg_data;
 mod agg_limits;
 pub mod agg_req;
 pub mod agg_result;
+mod block_accessor;
 pub mod bucket;
 pub(crate) mod buffered_sub_aggs;
 mod collector;
@@ -142,6 +143,8 @@ pub mod metric;
 
 mod segment_agg_result;
 use std::fmt::Display;
+
+pub(crate) use block_accessor::ColumnBlockAccessor;
 
 #[cfg(test)]
 mod agg_tests;

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -663,6 +663,18 @@ impl<D: Document> IndexWriter<D> {
     ///
     /// Commit returns the `opstamp` of the last document
     /// that made it in the commit.
+    ///
+    /// Note that "published" here only means committed to the [`Directory`](crate::Directory).
+    /// Any already-open [`IndexReader`](crate::IndexReader) only picks up the change according
+    /// to its [`ReloadPolicy`](crate::ReloadPolicy): with the default
+    /// [`ReloadPolicy::OnCommitWithDelay`](crate::ReloadPolicy::OnCommitWithDelay), the reload
+    /// happens asynchronously and is not guaranteed to be done by the time `commit()` returns,
+    /// so a search right after `commit()` can still miss the documents just committed. Use
+    /// [`ReloadPolicy::Manual`](crate::ReloadPolicy::Manual) with an explicit
+    /// [`IndexReader::reload()`](crate::IndexReader::reload) call if you need the search to
+    /// deterministically reflect this commit (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     pub fn commit(&mut self) -> crate::Result<Opstamp> {
         self.prepare_commit()?.commit()
     }

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -5,10 +5,12 @@ use crate::query::{EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::{DocId, DocSet, Score, SegmentReader, TantivyError, Term};
 
 /// `ConstScoreQuery` is a wrapper over a query to provide a constant score.
-/// It can avoid unnecessary score computation on the wrapped query.
+/// The wrapped query is evaluated with scoring disabled and only determines which documents
+/// match, avoiding unnecessary score computation.
 ///
 /// The document set matched by the `ConstScoreQuery` is strictly the same as the underlying query.
-/// The configured score is used for each document.
+/// The configured score is used for each document. Score explanations only report this constant
+/// score and omit scoring details from the wrapped query.
 pub struct ConstScoreQuery {
     query: Box<dyn Query>,
     score: Score,
@@ -38,8 +40,9 @@ impl fmt::Debug for ConstScoreQuery {
 
 impl Query for ConstScoreQuery {
     fn weight(&self, enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
-        let inner_weight = self.query.weight(enable_scoring)?;
-        Ok(if enable_scoring.is_scoring_enabled() {
+        let scoring_enabled = enable_scoring.is_scoring_enabled();
+        let inner_weight = self.query.weight(enable_scoring.scoring_disabled())?;
+        Ok(if scoring_enabled {
             Box::new(ConstWeight::new(inner_weight, self.score))
         } else {
             inner_weight
@@ -70,15 +73,14 @@ impl Weight for ConstWeight {
 
     fn explain(&self, reader: &SegmentReader, doc: u32) -> crate::Result<Explanation> {
         let mut scorer = self.scorer(reader, 1.0)?;
-        if scorer.seek(doc) != doc {
+        if scorer.doc() > doc || scorer.seek(doc) != doc {
             return Err(TantivyError::InvalidArgument(format!(
                 "Document #({doc}) does not match"
             )));
         }
-        let mut explanation = Explanation::new("Const", self.score);
-        let underlying_explanation = self.weight.explain(reader, doc)?;
-        explanation.add_detail(underlying_explanation);
-        Ok(explanation)
+        // The child query only determines whether the document matches. Its score does not
+        // contribute to the constant score and is intentionally omitted from the explanation.
+        Ok(Explanation::new("Const", self.score))
     }
 
     fn count(&self, reader: &SegmentReader) -> crate::Result<u32> {
@@ -150,34 +152,168 @@ impl<TDocSet: DocSet + 'static> Scorer for ConstScorer<TDocSet> {
 #[cfg(test)]
 mod tests {
     use super::ConstScoreQuery;
-    use crate::query::{AllQuery, Query};
-    use crate::schema::Schema;
-    use crate::{DocAddress, Index, IndexWriter, TantivyDocument};
+    use crate::collector::TopDocs;
+    use crate::query::{
+        Bm25StatisticsProvider, BoostQuery, EnableScoring, Query, Scorer, TermQuery,
+    };
+    use crate::schema::{Field, IndexRecordOption, Schema, FAST, TEXT};
+    use crate::{DocAddress, Index, IndexWriter, TantivyDocument, TantivyError, Term, TERMINATED};
+
+    struct PanickingStatistics;
+
+    impl Bm25StatisticsProvider for PanickingStatistics {
+        fn total_num_tokens(&self, _field: Field) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested total_num_tokens")
+        }
+
+        fn total_num_docs(&self) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested total_num_docs")
+        }
+
+        fn doc_freq(&self, _term: &Term) -> crate::Result<u64> {
+            panic!("ConstScoreQuery child requested doc_freq")
+        }
+    }
 
     #[test]
-    fn test_const_score_query_explain() -> crate::Result<()> {
-        let schema = Schema::builder().build();
+    fn test_const_score_query_disables_child_scoring() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
         let index = Index::create_in_ram(schema);
         let mut index_writer: IndexWriter = index.writer_for_tests()?;
-        index_writer.add_document(TantivyDocument::new())?;
+        let mut document = TantivyDocument::new();
+        document.add_text(text_field, "rust");
+        index_writer.add_document(document)?;
+        let mut non_matching_document = TantivyDocument::new();
+        non_matching_document.add_text(text_field, "search");
+        index_writer.add_document(non_matching_document)?;
         index_writer.commit()?;
         let reader = index.reader()?;
         let searcher = reader.searcher();
-        let query = ConstScoreQuery::new(Box::new(AllQuery), 0.42);
-        let explanation = query.explain(&searcher, DocAddress::new(0, 0u32)).unwrap();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_text(text_field, "rust"),
+                IndexRecordOption::WithFreqs,
+            )),
+            0.42,
+        );
+
+        let weight = query.weight(EnableScoring::enabled_from_statistics_provider(
+            &PanickingStatistics,
+            &searcher,
+        ))?;
+        let mut scorer = weight.scorer(searcher.segment_reader(0), 1.0)?;
+        assert_eq!(scorer.doc(), 0);
+        assert_eq!(scorer.score(), 0.42);
+        assert_eq!(scorer.advance(), TERMINATED);
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_supports_term_query_on_fast_only_field() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let number_field = schema_builder.add_u64_field("number", FAST);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(number_field => 42u64))?;
+        index_writer.add_document(doc!(number_field => 7u64))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_u64(number_field, 42u64),
+                IndexRecordOption::Basic,
+            )),
+            1.5,
+        );
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(10).order_by_score())?;
+        assert_eq!(top_docs, vec![(1.5, DocAddress::new(0, 0))]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_explain_omits_child_scoring_details() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(text_field => "rust rust rust other"))?;
+        index_writer.add_document(doc!(text_field => "rust search"))?;
+        index_writer.add_document(doc!(text_field => "search only"))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let term = Term::from_field_text(text_field, "rust");
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(term.clone(), IndexRecordOption::WithFreqs)),
+            0.42,
+        );
+
+        let explanation = query.explain(&searcher, DocAddress::new(0, 0))?;
         assert_eq!(
             explanation.to_pretty_json(),
             r#"{
   "value": 0.42,
-  "description": "Const",
+  "description": "Const"
+}"#
+        );
+
+        let nested_query = BoostQuery::new(
+            Box::new(ConstScoreQuery::new(
+                Box::new(TermQuery::new(term, IndexRecordOption::WithFreqs)),
+                0.42,
+            )),
+            2.0,
+        );
+        let nested_explanation = nested_query.explain(&searcher, DocAddress::new(0, 0))?;
+        assert_eq!(
+            nested_explanation.to_pretty_json(),
+            r#"{
+  "value": 0.84,
+  "description": "Boost x2 of ...",
   "details": [
     {
-      "value": 1.0,
-      "description": "AllQuery"
+      "value": 0.42,
+      "description": "Const"
     }
   ]
 }"#
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_const_score_query_explain_before_first_match_returns_error() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let text_field = schema_builder.add_text_field("text", TEXT);
+        let schema = schema_builder.build();
+        let index = Index::create_in_ram(schema);
+        let mut index_writer: IndexWriter = index.writer_for_tests()?;
+        index_writer.add_document(doc!(text_field => "alpha"))?;
+        index_writer.add_document(doc!(text_field => "beta"))?;
+        index_writer.add_document(doc!(text_field => "beta"))?;
+        index_writer.commit()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = ConstScoreQuery::new(
+            Box::new(TermQuery::new(
+                Term::from_field_text(text_field, "beta"),
+                IndexRecordOption::Basic,
+            )),
+            0.42,
+        );
+
+        let error = query.explain(&searcher, DocAddress::new(0, 0)).unwrap_err();
+        assert!(matches!(
+            error,
+            TantivyError::InvalidArgument(message)
+                if message == "Document #(0) does not match"
+        ));
         Ok(())
     }
 }

--- a/src/query/more_like_this/query.rs
+++ b/src/query/more_like_this/query.rs
@@ -45,13 +45,10 @@ impl MoreLikeThisQuery {
 
 impl Query for MoreLikeThisQuery {
     fn weight(&self, enable_scoring: EnableScoring<'_>) -> crate::Result<Box<dyn Weight>> {
-        let searcher = match enable_scoring {
-            EnableScoring::Enabled { searcher, .. } => searcher,
-            EnableScoring::Disabled { .. } => {
-                let err = "MoreLikeThisQuery requires to enable scoring.".to_string();
-                return Err(crate::TantivyError::InvalidArgument(err));
-            }
-        };
+        let searcher = enable_scoring.searcher().ok_or_else(|| {
+            let err = "MoreLikeThisQuery requires a searcher.".to_string();
+            crate::TantivyError::InvalidArgument(err)
+        })?;
         match &self.target {
             TargetDocument::DocumentAddress(doc_address) => self
                 .mlt
@@ -190,8 +187,9 @@ impl MoreLikeThisQueryBuilder {
 mod tests {
     use super::{MoreLikeThisQuery, TargetDocument};
     use crate::collector::TopDocs;
+    use crate::query::{ConstScoreQuery, EnableScoring, Query};
     use crate::schema::{Schema, STORED, TEXT};
-    use crate::{DocAddress, Index, IndexWriter};
+    use crate::{DocAddress, Index, IndexWriter, TantivyError};
 
     fn create_test_index() -> crate::Result<Index> {
         let mut schema_builder = Schema::builder();
@@ -290,5 +288,59 @@ mod tests {
         assert_eq!(doc_ids.len(), 2);
         assert_eq!(doc_ids, vec![3, 4]);
         Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_as_const_score_child() -> crate::Result<()> {
+        let index = create_test_index()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let more_like_this_query = MoreLikeThisQuery::builder()
+            .with_min_doc_frequency(1)
+            .with_max_doc_frequency(10)
+            .with_min_term_frequency(1)
+            .with_min_word_length(2)
+            .with_max_word_length(5)
+            .with_stop_words(vec!["old".to_string()])
+            .with_document(DocAddress::new(0, 0));
+        let query = ConstScoreQuery::new(Box::new(more_like_this_query), 2.0);
+
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(5).order_by_score())?;
+        assert_eq!(top_docs.len(), 3);
+        assert!(top_docs.iter().all(|(score, _)| *score == 2.0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_count_without_scoring() -> crate::Result<()> {
+        let index = create_test_index()?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        let query = MoreLikeThisQuery::builder()
+            .with_min_doc_frequency(1)
+            .with_max_doc_frequency(10)
+            .with_min_term_frequency(1)
+            .with_min_word_length(2)
+            .with_max_word_length(5)
+            .with_stop_words(vec!["old".to_string()])
+            .with_document(DocAddress::new(0, 0));
+
+        assert_eq!(query.count(&searcher)?, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_more_like_this_query_without_searcher_errors() {
+        let schema = Schema::builder().build();
+        let query = MoreLikeThisQuery::builder().with_document(DocAddress::new(0, 0));
+
+        let Err(error) = query.weight(EnableScoring::disabled_from_schema(&schema)) else {
+            panic!("MoreLikeThisQuery should require a searcher");
+        };
+        assert!(matches!(
+            error,
+            TantivyError::InvalidArgument(message)
+                if message == "MoreLikeThisQuery requires a searcher."
+        ));
     }
 }

--- a/src/query/query.rs
+++ b/src/query/query.rs
@@ -89,6 +89,14 @@ impl<'a> EnableScoring<'a> {
     pub fn is_scoring_enabled(&self) -> bool {
         matches!(self, EnableScoring::Enabled { .. })
     }
+
+    /// Returns an equivalent context with scoring disabled.
+    pub(crate) fn scoring_disabled(self) -> Self {
+        match self {
+            EnableScoring::Enabled { searcher, .. } => Self::disabled_from_searcher(searcher),
+            disabled @ EnableScoring::Disabled { .. } => disabled,
+        }
+    }
 }
 
 /// The `Query` trait defines a set of documents and a scoring method

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -27,6 +27,16 @@ pub enum ReloadPolicy {
     Manual,
     /// The index is reloaded within milliseconds after a new commit is available.
     /// This is made possible by watching changes in the `meta.json` file.
+    ///
+    /// This reload happens on a background thread and is **not** guaranteed to have
+    /// completed by the time [`IndexWriter::commit()`](crate::IndexWriter::commit) returns,
+    /// on any [`Directory`] implementation, including [`RamDirectory`](crate::directory::RamDirectory).
+    /// A search performed immediately after `commit()` can therefore still observe the
+    /// pre-commit state. If you need a search to deterministically reflect a commit you just
+    /// made, use [`ReloadPolicy::Manual`] and call [`IndexReader::reload()`] yourself right
+    /// after `commit()` (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     OnCommitWithDelay, // TODO add NEAR_REAL_TIME(target_ms)
 }
 
@@ -282,8 +292,15 @@ impl IndexReader {
     /// every commit should be rapidly reflected on your `IndexReader` and you should
     /// not need to call `reload()` at all.
     ///
-    /// This automatic reload can take 10s of milliseconds to kick in however, and in unit tests
-    /// it can be nice to deterministically force the reload of searchers.
+    /// This automatic reload can take 10s of milliseconds to kick in however, and it is not
+    /// synchronized with the return of [`IndexWriter::commit()`](crate::IndexWriter::commit) —
+    /// this holds for every [`Directory`] implementation, including an in-memory
+    /// [`RamDirectory`](crate::directory::RamDirectory). If your code (or a test) needs to
+    /// search immediately after a commit and deterministically see its results, build the
+    /// reader with [`ReloadPolicy::Manual`] and call `reload()` explicitly after `commit()`
+    /// instead of relying on the automatic reload's timing (see the
+    /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
+    /// example).
     pub fn reload(&self) -> crate::Result<()> {
         self.inner.reload()
     }

--- a/src/reader/mod.rs
+++ b/src/reader/mod.rs
@@ -30,11 +30,11 @@ pub enum ReloadPolicy {
     ///
     /// This reload happens on a background thread and is **not** guaranteed to have
     /// completed by the time [`IndexWriter::commit()`](crate::IndexWriter::commit) returns,
-    /// on any [`Directory`] implementation, including [`RamDirectory`](crate::directory::RamDirectory).
-    /// A search performed immediately after `commit()` can therefore still observe the
-    /// pre-commit state. If you need a search to deterministically reflect a commit you just
-    /// made, use [`ReloadPolicy::Manual`] and call [`IndexReader::reload()`] yourself right
-    /// after `commit()` (see the
+    /// on any [`Directory`] implementation, including
+    /// [`RamDirectory`](crate::directory::RamDirectory). A search performed immediately after
+    /// `commit()` can therefore still observe the pre-commit state. If you need a search to
+    /// deterministically reflect a commit you just made, use [`ReloadPolicy::Manual`] and call
+    /// [`IndexReader::reload()`] yourself right after `commit()` (see the
     /// [`reload_after_commit`](https://github.com/quickwit-oss/tantivy/blob/main/examples/reload_after_commit.rs)
     /// example).
     OnCommitWithDelay, // TODO add NEAR_REAL_TIME(target_ms)


### PR DESCRIPTION
Small refactoring to prepare for the introduction to calcualtd fields.

Instead of materializing a full Column, this PR tries to mildly tweak ColumnBlockAccessor so that it can be filled by different value sources.

The change was actually minor. Some of its accessor required passing a column object, but it was actually only to get cardinality information. The accessor object now stores the cardinality.

As part of the refacotring, I also renamed a bunch of struct and methods that are specific to fused term group bys to have a fused prefix, added assert to make sure we never build them with a column that is not full, and used the accessors specialized for full columns.

Also I removed the generics on ColumnBlockAccessor, as it is only used for u64 representation at the moment.