### PR TITLE
aggregation: evaluate numerical calculated columns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rayon = "1.5.2"
 lru = "0.18.2"
 fastdivide = "0.4.0"
 itertools = "0.14.0"
+jitexpr = { version = "0.1", path = "./jitexpr" }
 measure_time = "0.9.0"
 arc-swap = "1.5.0"
 bon = "3.3.1"

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -29,7 +29,9 @@ use crate::aggregation::metric::{
 use crate::aggregation::segment_agg_result::{
     GenericSegmentAggregationResultsCollector, SegmentAggregationCollector,
 };
-use crate::aggregation::{f64_to_fastfield_u64, AggContextParams, ColumnBlockAccessor, Key};
+use crate::aggregation::{
+    f64_to_fastfield_u64, AggContextParams, ColumnBlockAccessor, Key, SegmentValueSourcePlan,
+};
 use crate::{SegmentOrdinal, SegmentReader};
 
 #[derive(Default)]
@@ -338,7 +340,11 @@ pub(crate) fn build_segment_agg_collector(
                         SegmentPercentilesCollector::from_req_and_validate(
                             req_data.field_type,
                             req_data.missing_u64,
-                            req_data.accessor.clone(),
+                            req_data
+                                .source
+                                .physical_column()
+                                .expect("percentiles only supports physical value sources")
+                                .clone(),
                             node.idx_in_req_data,
                         ),
                     ))
@@ -578,7 +584,7 @@ fn build_nodes(
             };
             let (accessor, field_type) = get_ff_reader(reader, field, allowed_column_types)?;
             let idx_in_req_data = data.push_metric_req_data(MetricAggReqData {
-                accessor,
+                source: SegmentValueSourcePlan::physical(accessor, field_type),
                 field_type,
                 name: agg_name.to_string(),
                 collecting_for,
@@ -605,7 +611,7 @@ fn build_nodes(
                 Some(get_numeric_or_date_column_types()),
             )?;
             let idx_in_req_data = data.push_metric_req_data(MetricAggReqData {
-                accessor,
+                source: SegmentValueSourcePlan::physical(accessor, field_type),
                 field_type,
                 name: agg_name.to_string(),
                 collecting_for: StatsType::Percentiles,

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use columnar::{Column, ColumnType, StrColumn};
 use common::BitSet;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Serialize;
 use tantivy_fst::Regex;
 
@@ -29,6 +29,9 @@ use crate::aggregation::metric::{
 use crate::aggregation::segment_agg_result::{
     GenericSegmentAggregationResultsCollector, SegmentAggregationCollector,
 };
+use crate::aggregation::value_source::{
+    resolve_segment_value_source, validate_calculated_column_names,
+};
 use crate::aggregation::{
     f64_to_fastfield_u64, AggContextParams, ColumnBlockAccessor, Key, SegmentValueSourcePlan,
 };
@@ -42,6 +45,7 @@ pub struct AggregationsSegmentCtx {
     pub per_request: PerRequestAggSegCtx,
     pub context: AggContextParams,
     pub(crate) column_block_accessor: ColumnBlockAccessor,
+    calculated_source_plans: FxHashMap<String, SegmentValueSourcePlan>,
 }
 
 impl AggregationsSegmentCtx {
@@ -429,16 +433,21 @@ pub(crate) fn build_aggregations_data_from_req(
     segment_ordinal: SegmentOrdinal,
     context: AggContextParams,
 ) -> crate::Result<AggregationsSegmentCtx> {
+    validate_calculated_column_names(reader, &context.calculated_columns)?;
     let mut data = AggregationsSegmentCtx {
         per_request: Default::default(),
         context,
         column_block_accessor: ColumnBlockAccessor::default(),
+        calculated_source_plans: FxHashMap::default(),
     };
 
     for (name, agg) in aggs.iter() {
         let nodes = build_nodes(name, agg, reader, segment_ordinal, &mut data, true)?;
         data.per_request.agg_tree.extend(nodes);
     }
+    // Source plans have now been cloned into each request entry. Drop the build-only lookup map so
+    // the segment context does not retain duplicate names and plan references during collection.
+    data.calculated_source_plans = FxHashMap::default();
     Ok(data)
 }
 
@@ -451,6 +460,22 @@ fn build_nodes(
     is_top_level: bool,
 ) -> crate::Result<Vec<AggRefNode>> {
     use AggregationVariants::*;
+    let supports_calculated_number = matches!(
+        &req.agg,
+        Average(_) | Count(_) | Max(_) | Min(_) | Stats(_) | Sum(_)
+    );
+    if !supports_calculated_number {
+        if let Some(field_name) = req
+            .agg
+            .get_fast_field_names()
+            .into_iter()
+            .find(|field_name| data.context.calculated_columns.contains(field_name))
+        {
+            return Err(crate::TantivyError::InvalidArgument(format!(
+                "Calculated column {field_name:?} is not supported by this aggregation"
+            )));
+        }
+    }
     match &req.agg {
         Range(range_req) => {
             let (accessor, field_type) = get_ff_reader(
@@ -582,9 +607,15 @@ fn build_nodes(
                     ))
                 }
             };
-            let (accessor, field_type) = get_ff_reader(reader, field, allowed_column_types)?;
+            let (source, field_type) = resolve_segment_value_source(
+                reader,
+                field,
+                allowed_column_types,
+                &data.context.calculated_columns,
+                &mut data.calculated_source_plans,
+            )?;
             let idx_in_req_data = data.push_metric_req_data(MetricAggReqData {
-                source: SegmentValueSourcePlan::physical(accessor, field_type),
+                source,
                 field_type,
                 name: agg_name.to_string(),
                 collecting_for,

--- a/src/aggregation/agg_req.rs
+++ b/src/aggregation/agg_req.rs
@@ -115,6 +115,27 @@ pub fn get_fast_field_names(aggs: &Aggregations) -> HashSet<String> {
     fast_field_names
 }
 
+/// Extracts physical fast-field dependencies while expanding calculated-column aliases.
+///
+/// The existing [`get_fast_field_names`] behavior remains unchanged for callers that do not use
+/// calculated columns.
+pub fn get_fast_field_names_with_context(
+    aggs: &Aggregations,
+    context: &crate::aggregation::AggContextParams,
+) -> crate::Result<HashSet<String>> {
+    let mut dependencies = HashSet::new();
+    for field_name in get_fast_field_names(aggs) {
+        if let Some(calculated_dependencies) =
+            context.calculated_columns.dependencies(&field_name)?
+        {
+            dependencies.extend(calculated_dependencies);
+        } else {
+            dependencies.insert(field_name);
+        }
+    }
+    Ok(dependencies)
+}
+
 /// Validates that all fields referenced in the aggregation request exist in the schema
 /// and are configured as fast fields.
 ///
@@ -159,6 +180,25 @@ pub fn validate_aggregation_fields_exist(
     reader: &crate::SegmentReader,
 ) -> crate::Result<()> {
     let field_names = get_fast_field_names(aggs);
+    validate_fast_field_names_exist(field_names, reader)
+}
+
+/// Context-aware form of [`validate_aggregation_fields_exist`] which expands calculated aliases
+/// into their physical dependencies and rejects calculated/physical name collisions.
+pub fn validate_aggregation_fields_exist_with_context(
+    aggs: &Aggregations,
+    reader: &crate::SegmentReader,
+    context: &crate::aggregation::AggContextParams,
+) -> crate::Result<()> {
+    super::value_source::validate_calculated_column_names(reader, &context.calculated_columns)?;
+    let field_names = get_fast_field_names_with_context(aggs, context)?;
+    validate_fast_field_names_exist(field_names, reader)
+}
+
+fn validate_fast_field_names_exist(
+    field_names: HashSet<String>,
+    reader: &crate::SegmentReader,
+) -> crate::Result<()> {
     let schema = reader.schema();
 
     for field_name in field_names {

--- a/src/aggregation/block_accessor.rs
+++ b/src/aggregation/block_accessor.rs
@@ -12,7 +12,7 @@ use crate::DocId;
 /// `docids` with one document id per value.
 pub(crate) trait BlockValueSource {
     fn load_block(
-        &self,
+        &mut self,
         docs: &[DocId],
         values: &mut Vec<u64>,
         docids: &mut Vec<DocId>,
@@ -46,7 +46,7 @@ pub(crate) struct ColumnBlockAccessor {
 impl BlockValueSource for Column<u64> {
     #[inline]
     fn load_block(
-        &self,
+        &mut self,
         docs: &[DocId],
         values: &mut Vec<u64>,
         docids: &mut Vec<DocId>,
@@ -68,7 +68,7 @@ impl BlockValueSource for Column<u64> {
 
 impl ColumnBlockAccessor {
     #[inline]
-    pub(crate) fn fetch_block(&mut self, docs: &[DocId], source: &impl BlockValueSource) {
+    pub(crate) fn fetch_block(&mut self, docs: &[DocId], source: &mut impl BlockValueSource) {
         self.cardinality = source.load_block(
             docs,
             &mut self.val_cache,
@@ -93,7 +93,7 @@ impl ColumnBlockAccessor {
     pub(crate) fn fetch_block_with_missing(
         &mut self,
         docs: &[DocId],
-        source: &impl BlockValueSource,
+        source: &mut impl BlockValueSource,
         missing_opt: Option<u64>,
     ) {
         self.fetch_block_with_missing_ordered(docs, source, missing_opt, false)
@@ -106,7 +106,7 @@ impl ColumnBlockAccessor {
     pub(crate) fn fetch_block_with_missing_ordered(
         &mut self,
         docs: &[DocId],
-        source: &impl BlockValueSource,
+        source: &mut impl BlockValueSource,
         missing_opt: Option<u64>,
         ordered: bool,
     ) {
@@ -176,7 +176,7 @@ impl ColumnBlockAccessor {
     pub(crate) fn fetch_block_with_missing_unique_per_doc(
         &mut self,
         docs: &[DocId],
-        source: &impl BlockValueSource,
+        source: &mut impl BlockValueSource,
         missing: Option<u64>,
         ordered: bool,
     ) {
@@ -365,7 +365,7 @@ mod tests {
 
     impl BlockValueSource for TestValueSource {
         fn load_block(
-            &self,
+            &mut self,
             docs: &[DocId],
             values: &mut Vec<u64>,
             docids: &mut Vec<DocId>,
@@ -421,13 +421,13 @@ mod tests {
     #[test]
     fn test_source_neutral_full_block_alignment() {
         let docs = [2, 4, 8];
-        let source = TestValueSource {
+        let mut source = TestValueSource {
             cardinality: Cardinality::Full,
             entries: vec![(2, 20), (4, 40), (8, 80)],
         };
         let mut accessor = ColumnBlockAccessor::default();
 
-        accessor.fetch_block(&docs, &source);
+        accessor.fetch_block(&docs, &mut source);
 
         assert!(accessor.has_one_value_per_doc(&docs));
         assert_eq!(
@@ -439,13 +439,13 @@ mod tests {
     #[test]
     fn test_source_neutral_optional_block_with_missing() {
         let docs = [0, 1, 2, 4];
-        let source = TestValueSource {
+        let mut source = TestValueSource {
             cardinality: Cardinality::Optional,
             entries: vec![(1, 10), (4, 40)],
         };
         let mut accessor = ColumnBlockAccessor::default();
 
-        accessor.fetch_block_with_missing_ordered(&docs, &source, Some(99), true);
+        accessor.fetch_block_with_missing_ordered(&docs, &mut source, Some(99), true);
 
         assert!(accessor.has_one_value_per_doc(&docs));
         assert_eq!(
@@ -457,13 +457,13 @@ mod tests {
     #[test]
     fn test_source_neutral_multivalue_block_deduplication() {
         let docs = [0, 1];
-        let source = TestValueSource {
+        let mut source = TestValueSource {
             cardinality: Cardinality::Multivalued,
             entries: vec![(0, 3), (0, 1), (0, 3), (1, 5), (1, 5)],
         };
         let mut accessor = ColumnBlockAccessor::default();
 
-        accessor.fetch_block_with_missing_unique_per_doc(&docs, &source, None, false);
+        accessor.fetch_block_with_missing_unique_per_doc(&docs, &mut source, None, false);
 
         assert!(!accessor.has_one_value_per_doc(&docs));
         assert_eq!(
@@ -482,14 +482,14 @@ mod tests {
         let vals = [10u64, 40, 70];
         let values =
             serialize_and_load_u64_based_column_values::<u64>(&&vals[..], &ALL_U64_CODEC_TYPES);
-        let column = Column {
+        let mut column = Column {
             index: ColumnIndex::Optional(OptionalIndex::for_test(9, &[1, 4, 7])),
             values,
         };
         let docs = [0, 1, 2, 4, 7, 8];
         let mut accessor = ColumnBlockAccessor::default();
 
-        accessor.fetch_block_with_missing_ordered(&docs, &column, Some(99), true);
+        accessor.fetch_block_with_missing_ordered(&docs, &mut column, Some(99), true);
 
         assert_eq!(
             accessor.iter_vals().collect::<Vec<_>>(),
@@ -573,13 +573,13 @@ mod tests {
         let vals: Vec<u64> = (0..200u64).map(|i| i * 7 + 3).collect();
         let values =
             serialize_and_load_u64_based_column_values::<u64>(&&vals[..], &ALL_U64_CODEC_TYPES);
-        let column = Column {
+        let mut column = Column {
             index: ColumnIndex::Full,
             values,
         };
 
-        let check = |accessor: &mut ColumnBlockAccessor, docs: &[u32]| {
-            accessor.fetch_block(docs, &column);
+        let check = |accessor: &mut ColumnBlockAccessor, docs: &[u32], column: &mut Column<u64>| {
+            accessor.fetch_block(docs, column);
             let got: Vec<(u32, u64)> = accessor.iter_docid_vals(docs).collect();
             let expected: Vec<(u32, u64)> = docs.iter().map(|&d| (d, vals[d as usize])).collect();
             assert_eq!(got, expected);
@@ -587,11 +587,11 @@ mod tests {
 
         let mut accessor = ColumnBlockAccessor::default();
         // Contiguous block -> get_range fast path.
-        check(&mut accessor, &(10..74).collect::<Vec<u32>>());
+        check(&mut accessor, &(10..74).collect::<Vec<u32>>(), &mut column);
         // Non-contiguous block -> get_vals gather path.
-        check(&mut accessor, &[0, 5, 9, 100, 199]);
+        check(&mut accessor, &[0, 5, 9, 100, 199], &mut column);
         // Single doc and full span.
-        check(&mut accessor, &[42]);
-        check(&mut accessor, &(0..200).collect::<Vec<u32>>());
+        check(&mut accessor, &[42], &mut column);
+        check(&mut accessor, &(0..200).collect::<Vec<u32>>(), &mut column);
     }
 }

--- a/src/aggregation/bucket/histogram/histogram.rs
+++ b/src/aggregation/bucket/histogram/histogram.rs
@@ -483,7 +483,7 @@ impl<B: BucketIdSlot> SegmentAggregationCollector for SegmentHistogramCollector<
         // Upgrade to dense storage before processing the block if the buckets are dense enough.
         store.maybe_densify(dense_range);
 
-        let req = &self.req_data;
+        let req = &mut self.req_data;
         let bounds = req.bounds;
         let interval = req.req.interval;
         let offset = req.offset;
@@ -491,7 +491,7 @@ impl<B: BucketIdSlot> SegmentAggregationCollector for SegmentHistogramCollector<
 
         agg_data
             .column_block_accessor
-            .fetch_block(docs, &req.accessor);
+            .fetch_block(docs, &mut req.accessor);
         // special path for nested buckets
         if let Some(sub_agg) = &mut self.sub_agg {
             for (doc, val) in agg_data.column_block_accessor.iter_docid_vals(docs) {

--- a/src/aggregation/bucket/multi_terms/mod.rs
+++ b/src/aggregation/bucket/multi_terms/mod.rs
@@ -223,14 +223,14 @@ fn block_missing_value(missing: Option<&MultiTermsMissingAccessor>) -> Option<u6
 #[inline]
 fn fetch_field_block(
     docs: &[crate::DocId],
-    field: &MultiTermsFieldAccessor,
+    field: &mut MultiTermsFieldAccessor,
     missing: Option<&MultiTermsMissingAccessor>,
     block_accessor: &mut ColumnBlockAccessor,
 ) -> bool {
     let missing_value = block_missing_value(missing);
     block_accessor.fetch_block_with_missing_unique_per_doc(
         docs,
-        &field.column,
+        &mut field.column,
         missing_value,
         true,
     );
@@ -571,7 +571,7 @@ where
         docs: &[DocId],
         block_accessor: &mut ColumnBlockAccessor,
     ) {
-        for (field_idx, field) in self.req_data.fields.iter().enumerate() {
+        for (field_idx, field) in self.req_data.fields.iter_mut().enumerate() {
             fetch_field_block(
                 docs,
                 field,
@@ -595,7 +595,7 @@ where
         self.alive_docs.extend_from_slice(docs);
         self.doc_ids_per_partial_combination.clear();
 
-        for (field_idx, field) in self.req_data.fields.iter().enumerate() {
+        for (field_idx, field) in self.req_data.fields.iter_mut().enumerate() {
             let missing = self.req_data.missing_accessors[field_idx].as_ref();
             let has_one_value_per_doc =
                 fetch_field_block(&self.alive_docs, field, missing, block_accessor);

--- a/src/aggregation/bucket/range.rs
+++ b/src/aggregation/bucket/range.rs
@@ -281,7 +281,7 @@ impl<B: SubAggBuffer> SegmentAggregationCollector for SegmentRangeCollector<B> {
     ) -> crate::Result<()> {
         agg_data
             .column_block_accessor
-            .fetch_block(docs, &self.req_data.accessor);
+            .fetch_block(docs, &mut self.req_data.accessor);
 
         let buckets = &mut self.parent_buckets[parent_bucket_id as usize];
 

--- a/src/aggregation/bucket/term_agg/mod.rs
+++ b/src/aggregation/bucket/term_agg/mod.rs
@@ -1064,7 +1064,7 @@ impl<TermMap: TermAggregationMap, B: SubAggBuffer> SegmentAggregationCollector
             .column_block_accessor
             .fetch_block_with_missing_unique_per_doc(
                 docs,
-                &req_data.accessor,
+                &mut req_data.accessor,
                 req_data.missing_value_for_accessor,
                 false,
             );

--- a/src/aggregation/metric/cardinality.rs
+++ b/src/aggregation/metric/cardinality.rs
@@ -638,7 +638,7 @@ impl<S: TermOrdAccumulator> SegmentCardinalityCollector<S> {
     ) {
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,
-            &self.accessor,
+            &mut self.accessor,
             self.missing_value_for_accessor,
         );
     }

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -373,9 +373,11 @@ impl SegmentAggregationCollector for SegmentExtendedStatsCollector {
     ) -> crate::Result<()> {
         let mut extended_stats = self.buckets[parent_bucket_id as usize].clone();
 
-        agg_data
-            .column_block_accessor
-            .fetch_block_with_missing(docs, &self.accessor, self.missing);
+        agg_data.column_block_accessor.fetch_block_with_missing(
+            docs,
+            &mut self.accessor,
+            self.missing,
+        );
         for val in agg_data.column_block_accessor.iter_vals() {
             let val1 = f64_from_fastfield_u64(val, self.field_type);
             extended_stats.collect(val1);

--- a/src/aggregation/metric/extended_stats.rs
+++ b/src/aggregation/metric/extended_stats.rs
@@ -335,7 +335,11 @@ impl SegmentExtendedStatsCollector {
         Self {
             name: req.name.clone(),
             field_type: req.field_type,
-            accessor: req.accessor.clone(),
+            accessor: req
+                .source
+                .physical_column()
+                .expect("extended stats only supports physical value sources")
+                .clone(),
             missing,
             buckets: vec![IntermediateExtendedStats::with_sigma(sigma); 16],
             sigma,

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 
 pub use average::*;
 pub use cardinality::*;
-use columnar::{Column, ColumnType};
+use columnar::ColumnType;
 pub use count::*;
 pub use extended_stats::*;
 pub use max::*;
@@ -43,6 +43,7 @@ pub use stats::*;
 pub use sum::*;
 pub use top_hits::*;
 
+use crate::aggregation::SegmentValueSourcePlan;
 use crate::schema::OwnedValue;
 
 /// Contains all information required by metric aggregations like avg, min, max, sum, stats,
@@ -55,8 +56,8 @@ pub struct MetricAggReqData {
     pub field_type: ColumnType,
     /// The missing value normalized to the internal u64 representation of the field type.
     pub missing_u64: Option<u64>,
-    /// The column accessor to access the fast field values.
-    pub accessor: Column<u64>,
+    /// Immutable recipe used to instantiate one runtime source per segment collector.
+    pub(crate) source: SegmentValueSourcePlan,
     /// Used when converting to intermediate result
     pub collecting_for: StatsType,
     /// The missing value
@@ -146,12 +147,14 @@ pub struct TopHitsMetricResult {
 
 #[cfg(test)]
 mod tests {
+    use std::net::Ipv6Addr;
+
     use crate::aggregation::agg_req::Aggregations;
     use crate::aggregation::agg_result::AggregationResults;
     use crate::aggregation::AggregationCollector;
     use crate::query::AllQuery;
-    use crate::schema::{NumericOptions, Schema};
-    use crate::{Index, IndexWriter};
+    use crate::schema::{NumericOptions, Schema, FAST};
+    use crate::{DateTime, Index, IndexWriter};
 
     #[test]
     fn test_metric_aggregations() {
@@ -199,5 +202,51 @@ mod tests {
         assert_eq!(aggregations_res_json["price_max"]["value"], 5.0);
         assert_eq!(aggregations_res_json["price_min"]["value"], 0.0);
         assert_eq!(aggregations_res_json["price_sum"]["value"], 15.0);
+    }
+
+    #[test]
+    fn test_value_count_all_supported_physical_types_and_missing() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let i64_field = schema_builder.add_i64_field("i64", FAST);
+        let u64_field = schema_builder.add_u64_field("u64", FAST);
+        let f64_field = schema_builder.add_f64_field("f64", FAST);
+        let str_field = schema_builder.add_text_field("str", FAST);
+        let date_field = schema_builder.add_date_field("date", FAST);
+        let bool_field = schema_builder.add_bool_field("bool", FAST);
+        let ip_field = schema_builder.add_ip_addr_field("ip", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(
+            i64_field => -1i64,
+            u64_field => 2u64,
+            f64_field => 3.5f64,
+            str_field => "value",
+            date_field => DateTime::from_timestamp_secs(1_700_000_000),
+            bool_field => true,
+            ip_field => Ipv6Addr::LOCALHOST,
+        ))?;
+        writer.add_document(doc!())?;
+        writer.commit()?;
+
+        let aggregations: Aggregations = serde_json::from_value(json!({
+            "i64": { "value_count": { "field": "i64" } },
+            "u64": { "value_count": { "field": "u64" } },
+            "f64": { "value_count": { "field": "f64" } },
+            "str": { "value_count": { "field": "str" } },
+            "date": { "value_count": { "field": "date" } },
+            "bool": { "value_count": { "field": "bool" } },
+            "ip": { "value_count": { "field": "ip" } },
+            "f64_missing": { "value_count": { "field": "f64", "missing": 0.0 } }
+        }))?;
+        let collector = AggregationCollector::from_aggs(aggregations, Default::default());
+        let result: AggregationResults =
+            index.reader()?.searcher().search(&AllQuery, &collector)?;
+        let result = serde_json::to_value(result)?;
+
+        for name in ["i64", "u64", "f64", "str", "date", "bool", "ip"] {
+            assert_eq!(result[name]["value"], 1.0, "field {name}");
+        }
+        assert_eq!(result["f64_missing"]["value"], 2.0);
+        Ok(())
     }
 }

--- a/src/aggregation/metric/mod.rs
+++ b/src/aggregation/metric/mod.rs
@@ -149,9 +149,11 @@ pub struct TopHitsMetricResult {
 mod tests {
     use std::net::Ipv6Addr;
 
+    use jitexpr::ast::UntypedExpr;
+
     use crate::aggregation::agg_req::Aggregations;
     use crate::aggregation::agg_result::AggregationResults;
-    use crate::aggregation::AggregationCollector;
+    use crate::aggregation::{AggContextParams, AggregationCollector};
     use crate::query::AllQuery;
     use crate::schema::{NumericOptions, Schema, FAST};
     use crate::{DateTime, Index, IndexWriter};
@@ -247,6 +249,118 @@ mod tests {
             assert_eq!(result[name]["value"], 1.0, "field {name}");
         }
         assert_eq!(result["f64_missing"]["value"], 2.0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_calculated_number_parity_for_shared_metrics_and_nested_collection() -> crate::Result<()>
+    {
+        let mut schema_builder = Schema::builder();
+        let value = schema_builder.add_f64_field("value", FAST);
+        let group = schema_builder.add_text_field("group", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(value => 1.5f64, group => "a"))?;
+        writer.add_document(doc!(group => "a"))?;
+        writer.commit()?;
+        writer.add_document(doc!(value => 4.5f64, group => "b"))?;
+        writer.add_document(doc!(value => -2.0f64, group => "b"))?;
+        writer.commit()?;
+
+        let metric_pairs = json!({
+            "physical_avg": { "avg": { "field": "value" } },
+            "calculated_avg": { "avg": { "field": "calculated" } },
+            "physical_count": { "value_count": { "field": "value" } },
+            "calculated_count": { "value_count": { "field": "calculated" } },
+            "physical_max": { "max": { "field": "value" } },
+            "calculated_max": { "max": { "field": "calculated" } },
+            "physical_min": { "min": { "field": "value" } },
+            "calculated_min": { "min": { "field": "calculated" } },
+            "physical_stats": { "stats": { "field": "value" } },
+            "calculated_stats": { "stats": { "field": "calculated" } },
+            "physical_sum": { "sum": { "field": "value" } },
+            "calculated_sum": { "sum": { "field": "calculated" } }
+        });
+        let aggregations: Aggregations = serde_json::from_value(json!({
+            "physical_avg": metric_pairs["physical_avg"],
+            "calculated_avg": metric_pairs["calculated_avg"],
+            "physical_count": metric_pairs["physical_count"],
+            "calculated_count": metric_pairs["calculated_count"],
+            "physical_max": metric_pairs["physical_max"],
+            "calculated_max": metric_pairs["calculated_max"],
+            "physical_min": metric_pairs["physical_min"],
+            "calculated_min": metric_pairs["calculated_min"],
+            "physical_stats": metric_pairs["physical_stats"],
+            "calculated_stats": metric_pairs["calculated_stats"],
+            "physical_sum": metric_pairs["physical_sum"],
+            "calculated_sum": metric_pairs["calculated_sum"],
+            "groups": {
+                "terms": { "field": "group" },
+                "aggs": metric_pairs
+            }
+        }))?;
+        let mut context = AggContextParams::default();
+        context.register_calculated_column("calculated", UntypedExpr::variable("value"))?;
+        let dependencies = crate::aggregation::agg_req::get_fast_field_names_with_context(
+            &aggregations,
+            &context,
+        )?;
+        assert!(dependencies.contains("value"));
+        assert!(!dependencies.contains("calculated"));
+        for segment_reader in index.reader()?.searcher().segment_readers() {
+            crate::aggregation::agg_req::validate_aggregation_fields_exist_with_context(
+                &aggregations,
+                segment_reader,
+                &context,
+            )?;
+        }
+        let result: AggregationResults = index.reader()?.searcher().search(
+            &AllQuery,
+            &AggregationCollector::from_aggs(aggregations, context),
+        )?;
+        let result = serde_json::to_value(result)?;
+
+        for metric in ["avg", "count", "max", "min", "stats", "sum"] {
+            assert_eq!(
+                result[format!("physical_{metric}")],
+                result[format!("calculated_{metric}")],
+                "top-level {metric}"
+            );
+            for bucket in result["groups"]["buckets"].as_array().unwrap() {
+                assert_eq!(
+                    bucket[format!("physical_{metric}")],
+                    bucket[format!("calculated_{metric}")],
+                    "nested {metric} in bucket {}",
+                    bucket["key"]
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_calculated_number_is_rejected_by_unmigrated_aggregation() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let value = schema_builder.add_f64_field("value", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(value => 1.0f64))?;
+        writer.commit()?;
+
+        let aggregations: Aggregations = serde_json::from_value(json!({
+            "unsupported": { "terms": { "field": "calculated" } }
+        }))?;
+        let mut context = AggContextParams::default();
+        context.register_calculated_column("calculated", UntypedExpr::variable("value"))?;
+        let error = index
+            .reader()?
+            .searcher()
+            .search(
+                &AllQuery,
+                &AggregationCollector::from_aggs(aggregations, context),
+            )
+            .unwrap_err();
+        assert!(error.to_string().contains("not supported"));
         Ok(())
     }
 }

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use columnar::Column;
 use serde::{Deserialize, Serialize};
 
 use super::*;

--- a/src/aggregation/metric/percentiles.rs
+++ b/src/aggregation/metric/percentiles.rs
@@ -299,7 +299,7 @@ impl SegmentAggregationCollector for SegmentPercentilesCollector {
         let percentiles = &mut self.buckets[parent_bucket_id as usize];
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,
-            &self.accessor,
+            &mut self.accessor,
             self.missing_u64,
         );
 

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -290,15 +290,18 @@ impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
         // skips the block accessor's buffers entirely.
         // Only valid without a missing value: `values_for_doc` yields nothing for a doc without a
         // value, so the substitute would be silently dropped.
+        // Only valid for a physical column: a calculated column has no per-doc accessor.
         // TODO: remove once we fetch all values for all bucket ids in one go
         if docs.len() == 1 && self.missing_u64.is_none() {
-            collect_stats::<COLUMN_TYPE_ID>(
-                &mut self.buckets[parent_bucket_id as usize],
-                self.accessor.values_for_doc(docs[0]),
-                self.is_number_or_date_type,
-            )?;
+            if let Some(column) = self.source.physical_column() {
+                collect_stats::<COLUMN_TYPE_ID>(
+                    &mut self.buckets[parent_bucket_id as usize],
+                    column.values_for_doc(docs[0]),
+                    self.is_number_or_date_type,
+                )?;
 
-            return Ok(());
+                return Ok(());
+            }
         }
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use columnar::{Column, ColumnType};
+use columnar::ColumnType;
 use serde::{Deserialize, Serialize};
 
 use super::*;
@@ -205,7 +205,7 @@ fn create_collector<const TYPE_ID: u8>(
         collecting_for: req.collecting_for,
         is_number_or_date_type: req.is_number_or_date_type,
         missing_u64: req.missing_u64,
-        accessor: req.accessor.clone(),
+        source: req.source.instantiate(),
         buckets: vec![IntermediateStats::default()],
     })
 }
@@ -214,7 +214,7 @@ fn create_collector<const TYPE_ID: u8>(
 pub(crate) fn build_segment_stats_collector(
     req: &MetricAggReqData,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
-    match req.field_type {
+    match req.source.capabilities().output_type() {
         ColumnType::I64 => Ok(create_collector::<{ ColumnType::I64 as u8 }>(req)),
         ColumnType::U64 => Ok(create_collector::<{ ColumnType::U64 as u8 }>(req)),
         ColumnType::F64 => Ok(create_collector::<{ ColumnType::F64 as u8 }>(req)),
@@ -227,10 +227,10 @@ pub(crate) fn build_segment_stats_collector(
 }
 
 #[repr(C)]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(crate) struct SegmentStatsCollector<const COLUMN_TYPE_ID: u8> {
     pub(crate) missing_u64: Option<u64>,
-    pub(crate) accessor: Column<u64>,
+    pub(crate) source: SegmentValueSource,
     pub(crate) is_number_or_date_type: bool,
     pub(crate) buckets: Vec<IntermediateStats>,
     pub(crate) name: String,
@@ -302,7 +302,7 @@ impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
         }
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,
-            &mut self.accessor,
+            &mut self.source,
             self.missing_u64,
         );
         collect_stats::<COLUMN_TYPE_ID>(

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -302,7 +302,7 @@ impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
         }
         agg_data.column_block_accessor.fetch_block_with_missing(
             docs,
-            &self.accessor,
+            &mut self.accessor,
             self.missing_u64,
         );
         collect_stats::<COLUMN_TYPE_ID>(

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -142,9 +142,11 @@ pub mod intermediate_agg_result;
 pub mod metric;
 
 mod segment_agg_result;
+mod value_source;
 use std::fmt::Display;
 
 pub(crate) use block_accessor::ColumnBlockAccessor;
+pub(crate) use value_source::{SegmentValueSource, SegmentValueSourcePlan};
 
 #[cfg(test)]
 mod agg_tests;

--- a/src/aggregation/mod.rs
+++ b/src/aggregation/mod.rs
@@ -143,7 +143,9 @@ pub mod metric;
 
 mod segment_agg_result;
 mod value_source;
+use std::collections::BTreeMap;
 use std::fmt::Display;
+use std::sync::Arc;
 
 pub(crate) use block_accessor::ColumnBlockAccessor;
 pub(crate) use value_source::{SegmentValueSource, SegmentValueSourcePlan};
@@ -162,10 +164,84 @@ use columnar::{ColumnType, MonotonicallyMappableToU64};
 pub(crate) use date::format_date;
 pub use error::AggregationError;
 use itertools::Itertools;
+use jitexpr::ast::{infer_types, UntypedExpr};
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::tokenizer::TokenizerManager;
+
+/// Named expressions which can be used as aggregation fields.
+///
+/// Expressions are kept immutable and shared between segment source plans. Compilation is
+/// segment-local and all mutable evaluation state is collector-local.
+#[derive(Clone, Default)]
+pub struct CalculatedColumns {
+    expressions: BTreeMap<String, Arc<UntypedExpr>>,
+}
+
+impl CalculatedColumns {
+    /// Creates an empty calculated-column registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a named expression.
+    pub fn register(
+        &mut self,
+        name: impl Into<String>,
+        expression: UntypedExpr,
+    ) -> crate::Result<()> {
+        let name = name.into();
+        if self.expressions.contains_key(&name) {
+            return Err(crate::TantivyError::InvalidArgument(format!(
+                "Calculated column {name:?} is registered more than once"
+            )));
+        }
+        self.expressions.insert(name, Arc::new(expression));
+        Ok(())
+    }
+
+    /// Registers a named expression and returns the updated registry.
+    pub fn with_column(
+        mut self,
+        name: impl Into<String>,
+        expression: UntypedExpr,
+    ) -> crate::Result<Self> {
+        self.register(name, expression)?;
+        Ok(self)
+    }
+
+    /// Returns true if the registry contains `name`.
+    pub fn contains(&self, name: &str) -> bool {
+        self.expressions.contains_key(name)
+    }
+
+    /// Returns the sorted physical-column dependencies of a calculated column.
+    pub fn dependencies(&self, name: &str) -> crate::Result<Option<Vec<String>>> {
+        let Some(expression) = self.expressions.get(name) else {
+            return Ok(None);
+        };
+        let inferred = infer_types(expression).map_err(|error| {
+            crate::TantivyError::InvalidArgument(format!(
+                "Failed to infer types for calculated column {name:?}: {error}"
+            ))
+        })?;
+        let mut dependencies: Vec<String> =
+            inferred.keys().map(|name| (*name).to_string()).collect();
+        dependencies.sort();
+        Ok(Some(dependencies))
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<&Arc<UntypedExpr>> {
+        self.expressions.get(name)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &Arc<UntypedExpr>)> {
+        self.expressions
+            .iter()
+            .map(|(name, expression)| (name.as_str(), expression))
+    }
+}
 
 /// A bucket id is a dense identifier for a bucket within an aggregation.
 /// It is used to index into a Vec that hold per-bucket data.
@@ -191,12 +267,37 @@ pub struct AggContextParams {
     pub limits: AggregationLimitsGuard,
     /// Tokenizer manager for query string parsing
     pub tokenizers: TokenizerManager,
+    /// Named calculated columns available to aggregation field resolution.
+    pub calculated_columns: CalculatedColumns,
 }
 
 impl AggContextParams {
     /// Create new aggregation context parameters
     pub fn new(limits: AggregationLimitsGuard, tokenizers: TokenizerManager) -> Self {
-        Self { limits, tokenizers }
+        Self {
+            limits,
+            tokenizers,
+            calculated_columns: CalculatedColumns::default(),
+        }
+    }
+
+    /// Registers a calculated column in this context.
+    pub fn register_calculated_column(
+        &mut self,
+        name: impl Into<String>,
+        expression: UntypedExpr,
+    ) -> crate::Result<()> {
+        self.calculated_columns.register(name, expression)
+    }
+
+    /// Registers a calculated column and returns the updated context.
+    pub fn with_calculated_column(
+        mut self,
+        name: impl Into<String>,
+        expression: UntypedExpr,
+    ) -> crate::Result<Self> {
+        self.register_calculated_column(name, expression)?;
+        Ok(self)
     }
 }
 

--- a/src/aggregation/value_source.rs
+++ b/src/aggregation/value_source.rs
@@ -1,0 +1,204 @@
+use columnar::{Cardinality, Column, ColumnType, RowId};
+
+use super::block_accessor::BlockValueSource;
+use crate::DocId;
+
+/// Whether the encoded values produced by a source preserve their semantic ordering.
+///
+/// Physical columns use Tantivy's monotonic encoding (or dictionary ordinals) and therefore
+/// preserve semantic ordering. Calculated sources may use private ordinals whose ordering has no
+/// semantic meaning.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub(crate) enum OrdinalOrdering {
+    Semantic,
+    Unordered,
+}
+
+/// Immutable properties collectors may use to select safe fast paths.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ValueSourceCapabilities {
+    output_type: ColumnType,
+    cardinality: Cardinality,
+    encoded_bounds: Option<(u64, u64)>,
+    ordinal_ordering: OrdinalOrdering,
+    physical: bool,
+}
+
+#[allow(dead_code)]
+impl ValueSourceCapabilities {
+    pub(crate) fn output_type(self) -> ColumnType {
+        self.output_type
+    }
+
+    pub(crate) fn cardinality(self) -> Cardinality {
+        self.cardinality
+    }
+
+    pub(crate) fn encoded_bounds(self) -> Option<(u64, u64)> {
+        self.encoded_bounds
+    }
+
+    pub(crate) fn ordinal_ordering(self) -> OrdinalOrdering {
+        self.ordinal_ordering
+    }
+
+    pub(crate) fn is_physical(self) -> bool {
+        self.physical
+    }
+}
+
+/// Immutable and cheaply clonable recipe for a per-collector value source.
+#[derive(Clone, Debug)]
+pub(crate) enum SegmentValueSourcePlan {
+    Physical(PhysicalValueSourcePlan),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PhysicalValueSourcePlan {
+    column: Column<u64>,
+    capabilities: ValueSourceCapabilities,
+}
+
+impl SegmentValueSourcePlan {
+    pub(crate) fn physical(column: Column<u64>, output_type: ColumnType) -> Self {
+        let encoded_bounds =
+            (column.values.num_vals() != 0).then(|| (column.min_value(), column.max_value()));
+        let capabilities = ValueSourceCapabilities {
+            output_type,
+            cardinality: column.get_cardinality(),
+            encoded_bounds,
+            ordinal_ordering: OrdinalOrdering::Semantic,
+            physical: true,
+        };
+        Self::Physical(PhysicalValueSourcePlan {
+            column,
+            capabilities,
+        })
+    }
+
+    pub(crate) fn capabilities(&self) -> ValueSourceCapabilities {
+        match self {
+            Self::Physical(plan) => plan.capabilities,
+        }
+    }
+
+    /// Returns the physical column when this plan can participate in a physical-only fast path.
+    pub(crate) fn physical_column(&self) -> Option<&Column<u64>> {
+        match self {
+            Self::Physical(plan) => Some(&plan.column),
+        }
+    }
+
+    /// Creates runtime state owned exclusively by one segment collector.
+    pub(crate) fn instantiate(&self) -> SegmentValueSource {
+        match self {
+            Self::Physical(plan) => SegmentValueSource::Physical(PhysicalValueSource {
+                column: plan.column.clone(),
+                capabilities: plan.capabilities,
+            }),
+        }
+    }
+}
+
+/// Stateful value source owned by one segment collector.
+///
+/// This type intentionally does not implement `Clone`: future calculated variants carry mutable
+/// execution contexts and scratch buffers which must never be shared between collectors.
+#[derive(Debug)]
+pub(crate) enum SegmentValueSource {
+    Physical(PhysicalValueSource),
+}
+
+#[derive(Debug)]
+pub(crate) struct PhysicalValueSource {
+    column: Column<u64>,
+    capabilities: ValueSourceCapabilities,
+}
+
+#[allow(dead_code)]
+impl SegmentValueSource {
+    pub(crate) fn capabilities(&self) -> ValueSourceCapabilities {
+        match self {
+            Self::Physical(source) => source.capabilities,
+        }
+    }
+
+    /// Returns the physical column when this runtime can participate in a physical-only fast path.
+    pub(crate) fn physical_column(&self) -> Option<&Column<u64>> {
+        match self {
+            Self::Physical(source) => Some(&source.column),
+        }
+    }
+}
+
+impl BlockValueSource for SegmentValueSource {
+    fn load_block(
+        &mut self,
+        docs: &[DocId],
+        values: &mut Vec<u64>,
+        docids: &mut Vec<DocId>,
+        row_ids: &mut Vec<RowId>,
+    ) -> Cardinality {
+        match self {
+            Self::Physical(source) => source.column.load_block(docs, values, docids, row_ids),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use columnar::column_index::{ColumnIndex, OptionalIndex};
+    use columnar::column_values::{
+        serialize_and_load_u64_based_column_values, ALL_U64_CODEC_TYPES,
+    };
+
+    use super::*;
+    use crate::aggregation::ColumnBlockAccessor;
+
+    fn optional_column() -> Column<u64> {
+        let values = serialize_and_load_u64_based_column_values::<u64>(
+            &&[10u64, 30][..],
+            &ALL_U64_CODEC_TYPES,
+        );
+        Column {
+            index: ColumnIndex::Optional(OptionalIndex::for_test(4, &[1, 3])),
+            values,
+        }
+    }
+
+    #[test]
+    fn physical_plan_reports_capabilities_and_handle() {
+        let plan = SegmentValueSourcePlan::physical(optional_column(), ColumnType::U64);
+        let capabilities = plan.capabilities();
+        assert_eq!(capabilities.output_type(), ColumnType::U64);
+        assert_eq!(capabilities.cardinality(), Cardinality::Optional);
+        assert_eq!(capabilities.encoded_bounds(), Some((10, 30)));
+        assert_eq!(capabilities.ordinal_ordering(), OrdinalOrdering::Semantic);
+        assert!(capabilities.is_physical());
+        assert!(plan.physical_column().is_some());
+    }
+
+    #[test]
+    fn empty_physical_plan_has_no_encoded_bounds() {
+        let plan = SegmentValueSourcePlan::physical(Column::build_empty_column(3), ColumnType::F64);
+        assert_eq!(plan.capabilities().encoded_bounds(), None);
+    }
+
+    #[test]
+    fn cloned_plans_instantiate_independent_runtimes() {
+        let plan = SegmentValueSourcePlan::physical(optional_column(), ColumnType::U64);
+        let mut left = plan.instantiate();
+        let mut right = plan.clone().instantiate();
+        let mut left_block = ColumnBlockAccessor::default();
+        let mut right_block = ColumnBlockAccessor::default();
+
+        left_block.fetch_block(&[1], &mut left);
+        right_block.fetch_block(&[3], &mut right);
+
+        assert_eq!(left_block.values(), &[10]);
+        assert_eq!(right_block.values(), &[30]);
+        assert_eq!(left.capabilities(), right.capabilities());
+        assert!(left.physical_column().is_some());
+    }
+}

--- a/src/aggregation/value_source.rs
+++ b/src/aggregation/value_source.rs
@@ -1,7 +1,15 @@
-use columnar::{Cardinality, Column, ColumnType, RowId};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use columnar::{Cardinality, Column, ColumnType, MonotonicallyMappableToU64, RowId};
+use jitexpr::ast::{infer_types, Function, UntypedExpr};
+use jitexpr::compile::{compile, CompiledFn, CompiledFnCtx};
+use jitexpr::types::{VarType, VariablePrimitive, VariablePrimitiveOpt, VariableValue};
 
 use super::block_accessor::BlockValueSource;
-use crate::DocId;
+use super::CalculatedColumns;
+use crate::{DocId, SegmentReader};
 
 /// Whether the encoded values produced by a source preserve their semantic ordering.
 ///
@@ -49,15 +57,44 @@ impl ValueSourceCapabilities {
 }
 
 /// Immutable and cheaply clonable recipe for a per-collector value source.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) enum SegmentValueSourcePlan {
     Physical(PhysicalValueSourcePlan),
+    CalculatedNumber(CalculatedNumberValueSourcePlan),
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct PhysicalValueSourcePlan {
     column: Column<u64>,
     capabilities: ValueSourceCapabilities,
+}
+
+#[derive(Clone)]
+pub(crate) struct CalculatedNumberValueSourcePlan {
+    name: String,
+    compiled: Arc<CompiledFn>,
+    bindings: Arc<[CalculatedInputBinding]>,
+    capabilities: ValueSourceCapabilities,
+}
+
+#[derive(Clone, Debug)]
+struct CalculatedInputBinding {
+    variable_type: VarType,
+    column: Option<Column<u64>>,
+}
+
+impl fmt::Debug for SegmentValueSourcePlan {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Physical(plan) => formatter.debug_tuple("Physical").field(plan).finish(),
+            Self::CalculatedNumber(plan) => formatter
+                .debug_struct("CalculatedNumber")
+                .field("name", &plan.name)
+                .field("bindings", &plan.bindings)
+                .field("capabilities", &plan.capabilities)
+                .finish_non_exhaustive(),
+        }
+    }
 }
 
 impl SegmentValueSourcePlan {
@@ -77,9 +114,82 @@ impl SegmentValueSourcePlan {
         })
     }
 
+    pub(crate) fn calculated_number(
+        name: &str,
+        expression: &UntypedExpr,
+        reader: &SegmentReader,
+        calculated_columns: &CalculatedColumns,
+    ) -> crate::Result<Self> {
+        // `CompiledFn` does not expose its output type. Make the F64 output contract explicit in
+        // the expression passed to inference and compilation, while retaining the original
+        // expression in the public registry so later source kinds can apply their own contract.
+        let f64_expression =
+            Function::Add.call_untyped_expr(vec![expression.clone(), UntypedExpr::literal(0.0f64)]);
+        let inferred = infer_types(&f64_expression).map_err(|error| {
+            crate::TantivyError::InvalidArgument(format!(
+                "Failed to infer types for calculated column {name:?}: {error}"
+            ))
+        })?;
+
+        let mut variable_names: Vec<&str> = inferred.keys().copied().collect();
+        variable_names.sort_unstable();
+        let mut variable_types: HashMap<&str, VarType> = HashMap::new();
+        let mut selected_bindings = HashMap::new();
+        for variable_name in variable_names {
+            if calculated_columns.contains(variable_name) {
+                return Err(crate::TantivyError::InvalidArgument(format!(
+                    "Calculated column {name:?} cannot depend on calculated column \
+                     {variable_name:?}"
+                )));
+            }
+            let accepted_types = &inferred[variable_name];
+            let binding = select_numeric_binding(reader, variable_name, accepted_types, name)?;
+            variable_types.insert(variable_name, binding.variable_type);
+            selected_bindings.insert(variable_name, binding);
+        }
+        let compiled: Arc<CompiledFn> =
+            compile(&f64_expression, &variable_types).map_err(|error| {
+                crate::TantivyError::InvalidArgument(format!(
+                    "Failed to compile calculated column {name:?} as an F64 expression: {error}"
+                ))
+            })?;
+
+        let mut bindings = Vec::with_capacity(compiled.inputs.len());
+        for input in compiled.inputs.iter() {
+            let binding = selected_bindings
+                .remove(input.variable_name.as_ref())
+                .ok_or_else(|| {
+                    crate::TantivyError::InternalError(format!(
+                        "Calculated column {name:?} compiler returned unknown input {:?}",
+                        input.variable_name
+                    ))
+                })?;
+            if input.r#type != binding.variable_type {
+                return Err(crate::TantivyError::InternalError(format!(
+                    "Calculated column {name:?} compiler changed input {:?} from {:?} to {:?}",
+                    input.variable_name, binding.variable_type, input.r#type
+                )));
+            }
+            bindings.push(binding);
+        }
+        Ok(Self::CalculatedNumber(CalculatedNumberValueSourcePlan {
+            name: name.to_string(),
+            compiled,
+            bindings: bindings.into(),
+            capabilities: ValueSourceCapabilities {
+                output_type: ColumnType::F64,
+                cardinality: Cardinality::Optional,
+                encoded_bounds: None,
+                ordinal_ordering: OrdinalOrdering::Semantic,
+                physical: false,
+            },
+        }))
+    }
+
     pub(crate) fn capabilities(&self) -> ValueSourceCapabilities {
         match self {
             Self::Physical(plan) => plan.capabilities,
+            Self::CalculatedNumber(plan) => plan.capabilities,
         }
     }
 
@@ -87,6 +197,7 @@ impl SegmentValueSourcePlan {
     pub(crate) fn physical_column(&self) -> Option<&Column<u64>> {
         match self {
             Self::Physical(plan) => Some(&plan.column),
+            Self::CalculatedNumber(_) => None,
         }
     }
 
@@ -97,17 +208,139 @@ impl SegmentValueSourcePlan {
                 column: plan.column.clone(),
                 capabilities: plan.capabilities,
             }),
+            Self::CalculatedNumber(plan) => {
+                SegmentValueSource::CalculatedNumber(CalculatedNumberValueSource {
+                    name: plan.name.clone(),
+                    context: CompiledFnCtx::new(Arc::clone(&plan.compiled)),
+                    bindings: Arc::clone(&plan.bindings),
+                    input_values: Vec::with_capacity(plan.bindings.len()),
+                    input_scratch: vec![Vec::new(); plan.bindings.len()],
+                    capabilities: plan.capabilities,
+                })
+            }
         }
     }
+}
+
+fn select_numeric_binding(
+    reader: &SegmentReader,
+    variable_name: &str,
+    accepted_types: &jitexpr::ast::InferredTypeSet,
+    calculated_name: &str,
+) -> crate::Result<CalculatedInputBinding> {
+    // Keep this priority stable: lenient JSON paths can expose several compatible numerical
+    // columns, and every segment must make the same choice for the same available types.
+    let candidates = [
+        (ColumnType::F64, VarType::F64),
+        (ColumnType::U64, VarType::U64),
+        (ColumnType::I64, VarType::I64),
+    ];
+    for (column_type, variable_type) in candidates {
+        if !accepted_types.contains(variable_type) {
+            continue;
+        }
+        if let Some((column, actual_type)) = reader
+            .fast_fields()
+            .u64_lenient_for_type(Some(&[column_type]), variable_name)?
+        {
+            debug_assert_eq!(actual_type, column_type);
+            if column.get_cardinality().is_multivalue() {
+                return Err(crate::TantivyError::InvalidArgument(format!(
+                    "Calculated column {calculated_name:?} input {variable_name:?} is \
+                     multivalued; calculated numerical columns require at most one value per \
+                     document"
+                )));
+            }
+            return Ok(CalculatedInputBinding {
+                variable_type,
+                column: Some(column),
+            });
+        }
+    }
+
+    let available_columns = reader.fast_fields().dynamic_column_handles(variable_name)?;
+    if available_columns.is_empty() {
+        return Ok(CalculatedInputBinding {
+            variable_type: VarType::None,
+            column: None,
+        });
+    }
+
+    let mut available_types: Vec<ColumnType> = available_columns
+        .iter()
+        .map(|column| column.column_type())
+        .collect();
+    available_types.sort_unstable();
+    available_types.dedup();
+    Err(crate::TantivyError::InvalidArgument(format!(
+        "Calculated column {calculated_name:?} input {variable_name:?} has incompatible physical \
+         column types {available_types:?}"
+    )))
+}
+
+pub(crate) fn validate_calculated_column_names(
+    reader: &SegmentReader,
+    calculated_columns: &CalculatedColumns,
+) -> crate::Result<()> {
+    for (name, _) in calculated_columns.iter() {
+        let is_schema_field_or_json_path = reader.schema().find_field(name).is_some();
+        let is_physical_path = !reader
+            .fast_fields()
+            .dynamic_column_handles(name)?
+            .is_empty();
+        if is_schema_field_or_json_path || is_physical_path {
+            return Err(crate::TantivyError::InvalidArgument(format!(
+                "Calculated column {name:?} collides with a physical field or JSON path"
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn resolve_segment_value_source(
+    reader: &SegmentReader,
+    field_name: &str,
+    allowed_column_types: Option<&[ColumnType]>,
+    calculated_columns: &CalculatedColumns,
+    calculated_source_plans: &mut rustc_hash::FxHashMap<String, SegmentValueSourcePlan>,
+) -> crate::Result<(SegmentValueSourcePlan, ColumnType)> {
+    if let Some(expression) = calculated_columns.get(field_name) {
+        if !allowed_column_types
+            .map(|types| types.contains(&ColumnType::F64))
+            .unwrap_or(true)
+        {
+            return Err(crate::TantivyError::InvalidArgument(format!(
+                "Calculated numerical column {field_name:?} is not supported by this aggregation"
+            )));
+        }
+        if let Some(plan) = calculated_source_plans.get(field_name) {
+            return Ok((plan.clone(), ColumnType::F64));
+        }
+        let plan = SegmentValueSourcePlan::calculated_number(
+            field_name,
+            expression,
+            reader,
+            calculated_columns,
+        )?;
+        calculated_source_plans.insert(field_name.to_string(), plan.clone());
+        return Ok((plan, ColumnType::F64));
+    }
+
+    let (column, column_type) =
+        super::accessor_helpers::get_ff_reader(reader, field_name, allowed_column_types)?;
+    Ok((
+        SegmentValueSourcePlan::physical(column, column_type),
+        column_type,
+    ))
 }
 
 /// Stateful value source owned by one segment collector.
 ///
 /// This type intentionally does not implement `Clone`: future calculated variants carry mutable
 /// execution contexts and scratch buffers which must never be shared between collectors.
-#[derive(Debug)]
 pub(crate) enum SegmentValueSource {
     Physical(PhysicalValueSource),
+    CalculatedNumber(CalculatedNumberValueSource),
 }
 
 #[derive(Debug)]
@@ -116,11 +349,35 @@ pub(crate) struct PhysicalValueSource {
     capabilities: ValueSourceCapabilities,
 }
 
+pub(crate) struct CalculatedNumberValueSource {
+    name: String,
+    context: CompiledFnCtx,
+    bindings: Arc<[CalculatedInputBinding]>,
+    input_values: Vec<VariableValue<'static>>,
+    input_scratch: Vec<Vec<Option<u64>>>,
+    capabilities: ValueSourceCapabilities,
+}
+
+impl fmt::Debug for SegmentValueSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Physical(source) => formatter.debug_tuple("Physical").field(source).finish(),
+            Self::CalculatedNumber(source) => formatter
+                .debug_struct("CalculatedNumber")
+                .field("name", &source.name)
+                .field("bindings", &source.bindings)
+                .field("capabilities", &source.capabilities)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
 #[allow(dead_code)]
 impl SegmentValueSource {
     pub(crate) fn capabilities(&self) -> ValueSourceCapabilities {
         match self {
             Self::Physical(source) => source.capabilities,
+            Self::CalculatedNumber(source) => source.capabilities,
         }
     }
 
@@ -128,6 +385,7 @@ impl SegmentValueSource {
     pub(crate) fn physical_column(&self) -> Option<&Column<u64>> {
         match self {
             Self::Physical(source) => Some(&source.column),
+            Self::CalculatedNumber(_) => None,
         }
     }
 }
@@ -142,8 +400,78 @@ impl BlockValueSource for SegmentValueSource {
     ) -> Cardinality {
         match self {
             Self::Physical(source) => source.column.load_block(docs, values, docids, row_ids),
+            Self::CalculatedNumber(source) => source.load_block(docs, values, docids, row_ids),
         }
     }
+}
+
+impl CalculatedNumberValueSource {
+    fn load_block(
+        &mut self,
+        docs: &[DocId],
+        values: &mut Vec<u64>,
+        docids: &mut Vec<DocId>,
+        row_ids: &mut Vec<RowId>,
+    ) -> Cardinality {
+        values.clear();
+        docids.clear();
+        row_ids.clear();
+
+        for (binding, scratch) in self.bindings.iter().zip(&mut self.input_scratch) {
+            scratch.clear();
+            scratch.resize(docs.len(), None);
+            if let Some(column) = &binding.column {
+                column.first_vals(docs, scratch);
+            }
+        }
+
+        self.input_values.clear();
+        self.input_values.resize_with(self.bindings.len(), || {
+            nullable_primitive(VarType::None, None)
+        });
+        for (doc_offset, &doc) in docs.iter().enumerate() {
+            for (input_idx, binding) in self.bindings.iter().enumerate() {
+                self.input_values[input_idx] = nullable_primitive(
+                    binding.variable_type,
+                    self.input_scratch[input_idx][doc_offset],
+                );
+            }
+
+            // Safety: bindings follow `CompiledFn::inputs`; each value uses the exact union member
+            // matching the compiler-provided `VarType`; and numeric-plan normalization forces the
+            // expression result to F64 before compilation.
+            let output = unsafe { self.context.call(&self.input_values).as_f64() };
+            // Aggregation requests reject non-finite literal/missing values. Calculated results use
+            // the same usable-value policy by treating non-finite values as missing.
+            if let Some(output) = output.filter(|output| output.is_finite()) {
+                values.push(output.to_u64());
+                docids.push(doc);
+            }
+        }
+        Cardinality::Optional
+    }
+}
+
+fn nullable_primitive(
+    variable_type: VarType,
+    encoded_value: Option<u64>,
+) -> VariableValue<'static> {
+    let is_present = encoded_value.is_some();
+    let encoded_value = encoded_value.unwrap_or_default();
+    let value = match variable_type {
+        VarType::F64 => VariablePrimitive {
+            float: f64::from_u64(encoded_value),
+        },
+        VarType::U64 => VariablePrimitive {
+            int_u64: encoded_value,
+        },
+        VarType::I64 => VariablePrimitive {
+            int_i64: i64::from_u64(encoded_value),
+        },
+        VarType::None => VariablePrimitive { float: 0.0 },
+        other => unreachable!("unsupported calculated numeric input type {other:?}"),
+    };
+    VariableValue::from(VariablePrimitiveOpt { is_present, value })
 }
 
 #[cfg(test)]
@@ -152,9 +480,12 @@ mod tests {
     use columnar::column_values::{
         serialize_and_load_u64_based_column_values, ALL_U64_CODEC_TYPES,
     };
+    use jitexpr::ast::Function;
 
     use super::*;
-    use crate::aggregation::ColumnBlockAccessor;
+    use crate::aggregation::{CalculatedColumns, ColumnBlockAccessor};
+    use crate::schema::{Schema, FAST};
+    use crate::Index;
 
     fn optional_column() -> Column<u64> {
         let values = serialize_and_load_u64_based_column_values::<u64>(
@@ -165,6 +496,33 @@ mod tests {
             index: ColumnIndex::Optional(OptionalIndex::for_test(4, &[1, 3])),
             values,
         }
+    }
+
+    fn segment_reader(index: &Index) -> SegmentReader {
+        index.reader().unwrap().searcher().segment_reader(0).clone()
+    }
+
+    fn calculated_plan(
+        reader: &SegmentReader,
+        name: &str,
+        expression: UntypedExpr,
+    ) -> crate::Result<SegmentValueSourcePlan> {
+        let mut columns = CalculatedColumns::new();
+        columns.register(name, expression)?;
+        SegmentValueSourcePlan::calculated_number(
+            name,
+            columns.get(name).unwrap(),
+            reader,
+            &columns,
+        )
+    }
+
+    fn decoded_values(accessor: &ColumnBlockAccessor) -> Vec<f64> {
+        accessor
+            .values()
+            .iter()
+            .map(|&value| f64::from_u64(value))
+            .collect()
     }
 
     #[test]
@@ -200,5 +558,277 @@ mod tests {
         assert_eq!(right_block.values(), &[30]);
         assert_eq!(left.capabilities(), right.capabilities());
         assert!(left.physical_column().is_some());
+    }
+
+    #[test]
+    fn calculated_inputs_follow_compiler_order_and_convert_numeric_types() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let f64_field = schema_builder.add_f64_field("f64_input", FAST);
+        let u64_field = schema_builder.add_u64_field("u64_input", FAST);
+        let i64_field = schema_builder.add_i64_field("i64_input", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(
+            f64_field => 1.5f64,
+            u64_field => 2u64,
+            i64_field => 3i64,
+        ))?;
+        writer.commit()?;
+
+        // Deliberately use a non-alphabetical expression order. The plan follows the compiler's
+        // public input order, not inference-map iteration order.
+        let expression = Function::Add.call_untyped_expr(vec![
+            UntypedExpr::variable("i64_input"),
+            Function::Add.call_untyped_expr(vec![
+                UntypedExpr::variable("f64_input"),
+                UntypedExpr::variable("u64_input"),
+            ]),
+        ]);
+        let plan = calculated_plan(&segment_reader(&index), "calculated", expression)?;
+        let mut source = plan.instantiate();
+        let mut accessor = ColumnBlockAccessor::default();
+        accessor.fetch_block(&[0], &mut source);
+        assert_eq!(decoded_values(&accessor), vec![6.5]);
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_selection_prefers_f64_then_u64_then_i64() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let json_field = schema_builder.add_json_field("json", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(json_field => json!({"mixed": 7u64})))?;
+        writer.add_document(doc!(json_field => json!({"mixed": 2.5f64})))?;
+        writer.commit()?;
+
+        let plan = calculated_plan(
+            &segment_reader(&index),
+            "calculated",
+            UntypedExpr::variable("json.mixed"),
+        )?;
+        let SegmentValueSourcePlan::CalculatedNumber(calculated_plan) = &plan else {
+            panic!("expected calculated plan");
+        };
+        assert_eq!(calculated_plan.bindings[0].variable_type, VarType::F64);
+
+        let mut source = plan.instantiate();
+        let mut accessor = ColumnBlockAccessor::default();
+        accessor.fetch_block(&[0, 1], &mut source);
+        assert_eq!(accessor.docids(), &[0, 1]);
+        assert_eq!(decoded_values(&accessor), vec![7.0, 2.5]);
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_resolver_caches_compiled_plan_but_instantiates_fresh_contexts(
+    ) -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_f64_field("value", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(field => 2.0f64))?;
+        writer.commit()?;
+        let reader = segment_reader(&index);
+        let mut columns = CalculatedColumns::new();
+        columns.register("calculated", UntypedExpr::variable("value"))?;
+        let mut cache = rustc_hash::FxHashMap::default();
+
+        let (left_plan, _) = resolve_segment_value_source(
+            &reader,
+            "calculated",
+            Some(&[ColumnType::F64]),
+            &columns,
+            &mut cache,
+        )?;
+        let (right_plan, _) = resolve_segment_value_source(
+            &reader,
+            "calculated",
+            Some(&[ColumnType::F64]),
+            &columns,
+            &mut cache,
+        )?;
+        let (
+            SegmentValueSourcePlan::CalculatedNumber(left_calculated_plan),
+            SegmentValueSourcePlan::CalculatedNumber(right_calculated_plan),
+        ) = (&left_plan, &right_plan)
+        else {
+            panic!("expected calculated plans");
+        };
+        assert!(Arc::ptr_eq(
+            &left_calculated_plan.compiled,
+            &right_calculated_plan.compiled
+        ));
+        assert_eq!(cache.len(), 1);
+
+        let mut left = left_plan.instantiate();
+        let mut right = right_plan.instantiate();
+        let mut left_block = ColumnBlockAccessor::default();
+        let mut right_block = ColumnBlockAccessor::default();
+        left_block.fetch_block(&[0], &mut left);
+        right_block.fetch_block(&[], &mut right);
+        right_block.fetch_block(&[0], &mut right);
+        assert_eq!(decoded_values(&left_block), vec![2.0]);
+        assert_eq!(decoded_values(&right_block), vec![2.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_multiple_optional_inputs_are_aligned_by_doc() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let left = schema_builder.add_f64_field("left", FAST);
+        let right = schema_builder.add_f64_field("right", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(left => 1.0f64))?;
+        writer.add_document(doc!(right => 2.0f64))?;
+        writer.add_document(doc!(left => 3.0f64, right => 4.0f64))?;
+        writer.add_document(doc!())?;
+        writer.commit()?;
+
+        let expression = Function::Add.call_untyped_expr(vec![
+            UntypedExpr::variable("left"),
+            UntypedExpr::variable("right"),
+        ]);
+        let plan = calculated_plan(&segment_reader(&index), "calculated", expression)?;
+        let mut source = plan.instantiate();
+        let mut accessor = ColumnBlockAccessor::default();
+        accessor.fetch_block(&[0, 1, 2, 3], &mut source);
+        assert_eq!(accessor.docids(), &[2]);
+        assert_eq!(decoded_values(&accessor), vec![7.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_optional_absent_and_repeated_blocks_align_inputs() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_f64_field("optional", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(field => 1.0f64))?;
+        writer.add_document(doc!())?;
+        writer.add_document(doc!(field => 3.0f64))?;
+        writer.add_document(doc!())?;
+        writer.commit()?;
+        let reader = segment_reader(&index);
+        let plan = calculated_plan(&reader, "calculated", UntypedExpr::variable("optional"))?;
+        let mut left = plan.instantiate();
+        let mut right = plan.clone().instantiate();
+        let mut left_block = ColumnBlockAccessor::default();
+        let mut right_block = ColumnBlockAccessor::default();
+
+        left_block.fetch_block(&[], &mut left);
+        assert!(left_block.values().is_empty());
+        left_block.fetch_block(&[0, 2], &mut left);
+        assert_eq!(decoded_values(&left_block), vec![1.0, 3.0]);
+        right_block.fetch_block(&[1, 3], &mut right);
+        assert!(right_block.values().is_empty());
+        left_block.fetch_block(&[0, 1, 2], &mut left);
+        let first = decoded_values(&left_block);
+        left_block.fetch_block(&[0, 1, 2], &mut left);
+        assert_eq!(decoded_values(&left_block), first);
+        assert_eq!(left_block.docids(), &[0, 2]);
+
+        let absent = calculated_plan(
+            &reader,
+            "absent_calculated",
+            UntypedExpr::variable("not_in_the_segment"),
+        )?;
+        let mut absent = absent.instantiate();
+        let mut values = vec![123];
+        let mut docids = vec![123];
+        let mut row_ids = vec![123];
+        assert_eq!(
+            absent.load_block(&[0, 1], &mut values, &mut docids, &mut row_ids),
+            Cardinality::Optional
+        );
+        assert!(values.is_empty());
+        assert!(docids.is_empty());
+        assert!(row_ids.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_rejects_multivalue_and_incompatible_inputs() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let numbers = schema_builder.add_f64_field("numbers", FAST);
+        let text = schema_builder.add_text_field("text", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(numbers => 1.0f64, numbers => 2.0f64, text => "x"))?;
+        writer.commit()?;
+        let reader = segment_reader(&index);
+
+        let multivalue =
+            calculated_plan(&reader, "multivalue", UntypedExpr::variable("numbers")).unwrap_err();
+        assert!(multivalue.to_string().contains("multivalued"));
+        let incompatible =
+            calculated_plan(&reader, "incompatible", UntypedExpr::variable("text")).unwrap_err();
+        assert!(incompatible.to_string().contains("incompatible"));
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_non_finite_results_are_missing() -> crate::Result<()> {
+        let schema = Schema::builder().build();
+        let index = Index::create_in_ram(schema);
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!())?;
+        writer.commit()?;
+        let plan = calculated_plan(
+            &segment_reader(&index),
+            "non_finite",
+            UntypedExpr::literal(f64::INFINITY),
+        )?;
+        let mut source = plan.instantiate();
+        let mut accessor = ColumnBlockAccessor::default();
+        accessor.fetch_block(&[0], &mut source);
+        assert!(accessor.values().is_empty());
+
+        let plan = calculated_plan(
+            &segment_reader(&index),
+            "nan",
+            UntypedExpr::literal(f64::NAN),
+        )?;
+        let mut source = plan.instantiate();
+        accessor.fetch_block(&[0], &mut source);
+        assert!(accessor.values().is_empty());
+
+        let unsupported = calculated_plan(
+            &segment_reader(&index),
+            "string_output",
+            UntypedExpr::literal("not numerical"),
+        )
+        .unwrap_err();
+        assert!(unsupported.to_string().contains("infer types"));
+        Ok(())
+    }
+
+    #[test]
+    fn calculated_name_collision_is_rejected() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let field = schema_builder.add_f64_field("physical", FAST);
+        schema_builder.add_json_field("json", FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        writer.add_document(doc!(field => 1.0f64))?;
+        writer.commit()?;
+        let mut columns = CalculatedColumns::new();
+        columns.register("physical", UntypedExpr::literal(1.0f64))?;
+        let error =
+            validate_calculated_column_names(&segment_reader(&index), &columns).unwrap_err();
+        assert!(error.to_string().contains("collides"));
+
+        let duplicate = columns
+            .register("physical", UntypedExpr::literal(2.0f64))
+            .unwrap_err();
+        assert!(duplicate.to_string().contains("more than once"));
+
+        let mut columns = CalculatedColumns::new();
+        columns.register("json.not_in_this_segment", UntypedExpr::literal(1.0f64))?;
+        let error =
+            validate_calculated_column_names(&segment_reader(&index), &columns).unwrap_err();
+        assert!(error.to_string().contains("collides"));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Rebase the last 3 commits of `paul.masurel/calc-field-in-agg` on top of `paul.masurel/jit-plus-refact` (merge of `paul.masurel/refact-agg-for-calc-fields` + `paul.masurel/jitexpr-core`)
- Make block value sources mutable
- Add segment value source plans
- Evaluate numerical calculated columns in aggregations

## Test plan
- [x] `cargo check -p tantivy`
- [x] `cargo test -p tantivy --lib aggregation` (317 passed)