### PR TITLE
Added the capacity to build scorer and seek_danger in a joint manner.

### DIFF
--- a/src/docset.rs
+++ b/src/docset.rs
@@ -231,6 +231,10 @@ pub enum SeekDangerResult {
     /// We return a range in which the value could be.
     /// The given target can be any DocId, that is <= than the first document
     /// in the docset after the target.
+    ///
+    /// When the target is less than [`TERMINATED`], that doc id is required to be strictly greater
+    /// than the target used in the `seek_danger` call. For a target equal to [`TERMINATED`],
+    /// `SeekLowerBound(TERMINATED)` is returned.
     SeekLowerBound(DocId),
 }
 

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -359,7 +359,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             remove_and_count_all_and_empty_scorers(&mut must_scorers);
 
         if must_special_scorer_counts.num_empty_scorers > 0 {
-            return Ok(SpecializedScorer::Other(Box::new(EmptyScorer)));
+            return Ok(SpecializedScorer::empty());
         }
 
         let mut should_scorers = per_occur_scorers.remove(&Occur::Should).unwrap_or_default();
@@ -374,7 +374,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
 
         if exclude_special_scorer_counts.num_all_scorers > 0 {
             // We exclude all documents at one point.
-            return Ok(SpecializedScorer::Other(Box::new(EmptyScorer)));
+            return Ok(SpecializedScorer::empty());
         }
 
         let effective_minimum_number_should_match = self
@@ -386,7 +386,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             if effective_minimum_number_should_match > num_of_should_scorers {
                 // We don't have enough scorers to satisfy the minimum number of should matches.
                 // The request will match no documents.
-                return Ok(SpecializedScorer::Other(Box::new(EmptyScorer)));
+                return Ok(SpecializedScorer::empty());
             }
             match effective_minimum_number_should_match {
                 0 if num_of_should_scorers == 0 => ShouldScorersCombinationMethod::Ignored,

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -1,6 +1,7 @@
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use crate::docset::COLLECT_BLOCK_BUFFER_LEN;
+use crate::docset::{SeekDangerResult, COLLECT_BLOCK_BUFFER_LEN};
 use crate::index::SegmentReader;
 use crate::postings::FreqReadingOption;
 use crate::query::disjunction::Disjunction;
@@ -12,12 +13,18 @@ use crate::query::{
     intersect_scorers, AllScorer, BufferedUnionScorer, EmptyScorer, Exclude, Explanation, Occur,
     RequiredOptionalScorer, Scorer, Weight,
 };
-use crate::{DocId, Score};
+use crate::{DocId, Score, TERMINATED};
 
 enum SpecializedScorer {
     TermUnion(Vec<TermScorer>),
     TermIntersection(Vec<TermScorer>),
     Other(Box<dyn Scorer>),
+}
+
+impl SpecializedScorer {
+    fn empty() -> Self {
+        Self::Other(Box::new(EmptyScorer))
+    }
 }
 
 fn scorer_disjunction<TScoreCombiner>(
@@ -113,6 +120,8 @@ fn into_box_scorer<TScoreCombiner: ScoreCombiner>(
 
 /// Returns the effective MUST scorer, accounting for removed AllScorers.
 ///
+/// All scorers in `must_scorers` must be valid and aligned on the same document.
+///
 /// When AllScorer instances are removed from must_scorers as an optimization,
 /// we must restore the "match all" semantics if the list becomes empty.
 fn effective_must_scorer(
@@ -170,6 +179,68 @@ fn effective_should_scorer_for_union<TScoreCombiner: ScoreCombiner>(
     }
 }
 
+/// Creates the scorers that will form an intersection in any order.
+///
+/// If successful, all returned scorers are valid and aligned on the same document.
+///
+/// The first scorer supplies the initial candidate. Every subsequent scorer is created with
+/// `scorer_danger`, so implementations can avoid eagerly locating their first match and instead
+/// start at the intersection's current candidate. If that candidate does not match, all scorers
+/// created so far are advanced with `seek_danger` until they agree.
+///
+/// The returned Scorers are guaranteed to be in a "no-danger" state.
+///
+/// If the method identifies no doc in the intersection, we return a single empty scorer.
+/// Semantically, it is different from returning a empty Vec, which is returned when weights was
+/// empty.
+fn create_aligned_scorers_for_intersection(
+    weights: &[Box<dyn Weight>],
+    reader: &SegmentReader,
+    boost: Score,
+) -> crate::Result<Vec<Box<dyn Scorer>>> {
+    let mut candidate = 0u32;
+    let mut scorers = Vec::with_capacity(weights.len());
+
+    for weight in weights {
+        let (seek_result, scorer) = weight.scorer_danger(reader, candidate, boost)?;
+        scorers.push(scorer);
+
+        if let SeekDangerResult::SeekLowerBound(new_candidate) = seek_result {
+            debug_assert!(new_candidate > candidate);
+            candidate = new_candidate;
+        }
+
+        if candidate >= TERMINATED {
+            return Ok(vec![Box::new(EmptyScorer)]);
+        }
+    }
+
+    // This eventually terminates because, at each iteration, the pair
+    // (candidate, num_scorer_aligned) increases according to lexicographic order.
+    //
+    // Eventually, either candidate will reach TERMINATED or
+    // num_scorer_aligned will reach scorers.len().
+    let mut num_scorer_aligned = 0;
+    for scorer_id in (0..scorers.len()).cycle() {
+        if let SeekDangerResult::SeekLowerBound(seek_lower_bound) =
+            scorers[scorer_id].seek_danger(candidate)
+        {
+            debug_assert!(candidate < seek_lower_bound);
+            candidate = seek_lower_bound;
+            if candidate == TERMINATED {
+                return Ok(vec![Box::new(EmptyScorer)]);
+            }
+            num_scorer_aligned = 0;
+        } else {
+            num_scorer_aligned += 1;
+            if num_scorer_aligned == scorers.len() {
+                return Ok(scorers);
+            }
+        }
+    }
+    Ok(scorers)
+}
+
 enum ShouldScorersCombinationMethod {
     // Should scorers are irrelevant.
     Ignored,
@@ -181,7 +252,7 @@ enum ShouldScorersCombinationMethod {
 
 /// Weight associated to the `BoolQuery`.
 pub struct BooleanWeight<TScoreCombiner: ScoreCombiner> {
-    weights: Vec<(Occur, Box<dyn Weight>)>,
+    per_occur_weights: HashMap<Occur, Vec<Box<dyn Weight>>>,
     minimum_number_should_match: usize,
     scoring_enabled: bool,
     score_combiner_fn: Box<dyn Fn() -> TScoreCombiner + Sync + Send>,
@@ -195,28 +266,53 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
         scoring_enabled: bool,
         score_combiner_fn: Box<dyn Fn() -> TScoreCombiner + Sync + Send + 'static>,
     ) -> BooleanWeight<TScoreCombiner> {
-        BooleanWeight {
-            weights,
-            minimum_number_should_match,
-            scoring_enabled,
-            score_combiner_fn,
+        let mut per_occur_weights: HashMap<Occur, Vec<Box<dyn Weight>>> = HashMap::default();
+        for (occur, weight) in weights {
+            per_occur_weights.entry(occur).or_default().push(weight);
         }
-    }
 
-    fn per_occur_scorers(
-        &self,
-        reader: &SegmentReader,
-        boost: Score,
-    ) -> crate::Result<HashMap<Occur, Vec<Box<dyn Scorer>>>> {
-        let mut per_occur_scorers: HashMap<Occur, Vec<Box<dyn Scorer>>> = HashMap::new();
-        for (occur, subweight) in &self.weights {
-            let sub_scorer: Box<dyn Scorer> = subweight.scorer(reader, boost)?;
-            per_occur_scorers
-                .entry(*occur)
-                .or_default()
-                .push(sub_scorer);
+        // Optimisation: we rewrite the bool weight depending on the number of minimum should match
+        // and the number of should clauses.
+        let num_should_weights = per_occur_weights
+            .get(&Occur::Should)
+            .map(Vec::len)
+            .unwrap_or(0);
+
+        match num_should_weights.cmp(&minimum_number_should_match) {
+            Ordering::Greater => {
+                // nothing to do. We will need the minimum should match logic.
+                BooleanWeight {
+                    per_occur_weights,
+                    minimum_number_should_match,
+                    scoring_enabled,
+                    score_combiner_fn,
+                }
+            }
+            Ordering::Equal => {
+                // Equal! All should clause will be required. We promote them to Must!
+                let should_weights = per_occur_weights.remove(&Occur::Should);
+                per_occur_weights
+                    .entry(Occur::Must)
+                    .or_default()
+                    .extend(should_weights.into_iter().flatten());
+                BooleanWeight {
+                    per_occur_weights,
+                    minimum_number_should_match: 0,
+                    scoring_enabled,
+                    score_combiner_fn,
+                }
+            }
+            Ordering::Less => {
+                // We will never be able to match the minimum should match threshold.
+                // Let's return the empty weight
+                BooleanWeight {
+                    per_occur_weights: Default::default(),
+                    minimum_number_should_match: 0,
+                    scoring_enabled,
+                    score_combiner_fn,
+                }
+            }
         }
-        Ok(per_occur_scorers)
     }
 
     fn complex_scorer<TComplexScoreCombiner: ScoreCombiner>(
@@ -226,25 +322,54 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
         score_combiner_fn: impl Fn() -> TComplexScoreCombiner,
     ) -> crate::Result<SpecializedScorer> {
         let num_docs = reader.num_docs();
-        let mut per_occur_scorers = self.per_occur_scorers(reader, boost)?;
+
+        let intersection_weights: &[Box<dyn Weight>] = self
+            .per_occur_weights
+            .get(&Occur::Must)
+            .map(|weights| weights.as_slice())
+            .unwrap_or(&[]);
+
+        let required_scorers: Vec<Box<dyn Scorer>> =
+            create_aligned_scorers_for_intersection(intersection_weights, reader, boost)?;
+
+        let mut per_occur_scorers: HashMap<Occur, Vec<Box<dyn Scorer>>> = HashMap::new();
+
+        if !required_scorers.is_empty() {
+            // all scorer are aligned, it is ok to test a single one.
+            if required_scorers[0].doc() >= TERMINATED {
+                return Ok(SpecializedScorer::empty());
+            }
+            per_occur_scorers.insert(Occur::Must, required_scorers);
+        }
+
+        for occur in [Occur::MustNot, Occur::Should] {
+            if let Some(occur_weights) = self.per_occur_weights.get(&occur) {
+                let occur_scorers = per_occur_scorers.entry(occur).or_default();
+                for occur_weight in occur_weights {
+                    let occur_scorer = occur_weight.scorer(reader, boost)?;
+                    occur_scorers.push(occur_scorer);
+                }
+            }
+        }
 
         // Indicate how should clauses are combined with must clauses.
         let mut must_scorers: Vec<Box<dyn Scorer>> =
             per_occur_scorers.remove(&Occur::Must).unwrap_or_default();
-        let must_special_scorer_counts = remove_and_count_all_and_empty_scorers(&mut must_scorers);
+        let must_special_scorer_counts: AllAndEmptyScorerCounts =
+            remove_and_count_all_and_empty_scorers(&mut must_scorers);
 
         if must_special_scorer_counts.num_empty_scorers > 0 {
             return Ok(SpecializedScorer::Other(Box::new(EmptyScorer)));
         }
 
         let mut should_scorers = per_occur_scorers.remove(&Occur::Should).unwrap_or_default();
-        let should_special_scorer_counts =
+        let should_special_scorer_counts: AllAndEmptyScorerCounts =
             remove_and_count_all_and_empty_scorers(&mut should_scorers);
 
         let mut exclude_scorers: Vec<Box<dyn Scorer>> = per_occur_scorers
             .remove(&Occur::MustNot)
             .unwrap_or_default();
-        let exclude_special_scorer_counts =
+        let exclude_special_scorer_counts: AllAndEmptyScorerCounts =
             remove_and_count_all_and_empty_scorers(&mut exclude_scorers);
 
         if exclude_special_scorer_counts.num_all_scorers > 0 {
@@ -444,10 +569,17 @@ fn remove_and_count_all_and_empty_scorers(
 impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombiner> {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         let num_docs = reader.num_docs();
-        if self.weights.is_empty() {
+        let num_sub_weights: usize = self.per_occur_weights.values().map(Vec::len).sum();
+        if num_sub_weights == 0 {
             Ok(Box::new(EmptyScorer))
-        } else if self.weights.len() == 1 {
-            let &(occur, ref weight) = &self.weights[0];
+        } else if num_sub_weights == 1 {
+            // We have single subscorer. Let's just just short circuit our logic and return it.
+            let (occur, weight) = self
+                .per_occur_weights
+                .iter()
+                .flat_map(|(occur, weights)| weights.iter().map(|weight| (*occur, weight)))
+                .next()
+                .unwrap();
             if occur == Occur::MustNot {
                 Ok(Box::new(EmptyScorer))
             } else {
@@ -476,10 +608,12 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         }
 
         let mut explanation = Explanation::new("BooleanClause. sum of ...", scorer.score());
-        for (occur, subweight) in &self.weights {
-            if is_include_occur(*occur) {
-                if let Ok(child_explanation) = subweight.explain(reader, doc) {
-                    explanation.add_detail(child_explanation);
+        for (occur, subweights) in &self.per_occur_weights {
+            for subweight in subweights {
+                if is_include_occur(*occur) {
+                    if let Ok(child_explanation) = subweight.explain(reader, doc) {
+                        explanation.add_detail(child_explanation);
+                    }
                 }
             }
         }
@@ -605,5 +739,133 @@ fn is_include_occur(occur: Occur) -> bool {
     match occur {
         Occur::Must | Occur::Should => true,
         Occur::MustNot => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_aligned_scorers_for_intersection;
+    use crate::query::{EmptyScorer, EnableScoring, Query, TermQuery, Weight};
+    use crate::schema::{Field, IndexRecordOption, Schema, TEXT};
+    use crate::{Index, Searcher, Term, TERMINATED};
+
+    fn test_index() -> crate::Result<(Index, Field)> {
+        let mut schema_builder = Schema::builder();
+        let text = schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+
+        for terms in [
+            "a", "b", "a b", "c", "a c", "b c", "a b c", "a b", "a b c", "x", "y",
+        ] {
+            writer.add_document(doc!(text => terms))?;
+        }
+        writer.commit()?;
+
+        Ok((index, text))
+    }
+
+    fn term_weight(
+        searcher: &Searcher,
+        field: Field,
+        term: &str,
+    ) -> crate::Result<Box<dyn Weight>> {
+        TermQuery::new(Term::from_field_text(field, term), IndexRecordOption::Basic)
+            .weight(EnableScoring::disabled_from_searcher(searcher))
+    }
+
+    #[test]
+    fn test_create_aligned_scorers_for_empty_intersection() -> crate::Result<()> {
+        let (index, _) = test_index()?;
+        let searcher = index.reader()?.searcher();
+        let weights: Vec<Box<dyn Weight>> = Vec::new();
+
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert!(scorers.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_aligned_scorers_for_single_weight() -> crate::Result<()> {
+        let (index, text) = test_index()?;
+        let searcher = index.reader()?.searcher();
+        let weights = vec![term_weight(&searcher, text, "a")?];
+
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert_eq!(scorers.len(), 1);
+        assert_eq!(scorers[0].doc(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_aligned_scorers_aligns_all_scorers() -> crate::Result<()> {
+        let (index, text) = test_index()?;
+        let searcher = index.reader()?.searcher();
+        let weights = vec![
+            term_weight(&searcher, text, "a")?,
+            term_weight(&searcher, text, "b")?,
+            term_weight(&searcher, text, "c")?,
+        ];
+
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert_eq!(scorers.len(), 3);
+        assert!(scorers.iter().all(|scorer| scorer.doc() == 6));
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_aligned_scorers_returns_empty_scorer_for_disjoint_weights() -> crate::Result<()>
+    {
+        let (index, text) = test_index()?;
+        let searcher = index.reader()?.searcher();
+        let weights = vec![
+            term_weight(&searcher, text, "x")?,
+            term_weight(&searcher, text, "y")?,
+        ];
+
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert_eq!(scorers.len(), 1);
+        assert!(scorers[0].is::<EmptyScorer>());
+        assert_eq!(scorers[0].doc(), TERMINATED);
+
+        // We also test for the opposite order
+        let weights = vec![
+            term_weight(&searcher, text, "a")?,
+            term_weight(&searcher, text, "missing")?,
+        ];
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert_eq!(scorers.len(), 1);
+        assert!(scorers[0].is::<EmptyScorer>());
+        assert_eq!(scorers[0].doc(), TERMINATED);
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_aligned_scorers_returns_empty_scorer_when_first_weight_is_empty(
+    ) -> crate::Result<()> {
+        let (index, text) = test_index()?;
+        let searcher = index.reader()?.searcher();
+        let weights = vec![
+            term_weight(&searcher, text, "missing")?,
+            term_weight(&searcher, text, "a")?,
+        ];
+
+        let scorers =
+            create_aligned_scorers_for_intersection(&weights, searcher.segment_reader(0), 1.0)?;
+
+        assert_eq!(scorers.len(), 1);
+        assert!(scorers[0].is::<EmptyScorer>());
+        assert_eq!(scorers[0].doc(), TERMINATED);
+        Ok(())
     }
 }

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -201,6 +201,7 @@ fn create_aligned_scorers_for_intersection(
     let mut candidate = 0u32;
     let mut scorers = Vec::with_capacity(weights.len());
 
+    let mut num_scorer_aligned = 0;
     for weight in weights {
         let (seek_result, scorer) = weight.scorer_danger(reader, candidate, boost)?;
         scorers.push(scorer);
@@ -208,6 +209,9 @@ fn create_aligned_scorers_for_intersection(
         if let SeekDangerResult::SeekLowerBound(new_candidate) = seek_result {
             debug_assert!(new_candidate > candidate);
             candidate = new_candidate;
+            num_scorer_aligned = 0
+        } else {
+            num_scorer_aligned += 1;
         }
 
         if candidate >= TERMINATED {
@@ -220,10 +224,10 @@ fn create_aligned_scorers_for_intersection(
     //
     // Eventually, either candidate will reach TERMINATED or
     // num_scorer_aligned will reach scorers.len().
-    let mut num_scorer_aligned = 0;
-    for scorer_id in (0..scorers.len()).cycle() {
+    let mut scorer_ord = 0;
+    while num_scorer_aligned < scorers.len() {
         if let SeekDangerResult::SeekLowerBound(seek_lower_bound) =
-            scorers[scorer_id].seek_danger(candidate)
+            scorers[scorer_ord].seek_danger(candidate)
         {
             debug_assert!(candidate < seek_lower_bound);
             candidate = seek_lower_bound;
@@ -233,10 +237,8 @@ fn create_aligned_scorers_for_intersection(
             num_scorer_aligned = 0;
         } else {
             num_scorer_aligned += 1;
-            if num_scorer_aligned == scorers.len() {
-                return Ok(scorers);
-            }
         }
+        scorer_ord = (scorer_ord + 1) % scorers.len();
     }
     Ok(scorers)
 }

--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
 
+use super::occur_weights::OccurWeights;
 use crate::docset::{SeekDangerResult, COLLECT_BLOCK_BUFFER_LEN};
 use crate::index::SegmentReader;
 use crate::postings::FreqReadingOption;
@@ -254,7 +254,7 @@ enum ShouldScorersCombinationMethod {
 
 /// Weight associated to the `BoolQuery`.
 pub struct BooleanWeight<TScoreCombiner: ScoreCombiner> {
-    per_occur_weights: HashMap<Occur, Vec<Box<dyn Weight>>>,
+    per_occur_weights: OccurWeights,
     minimum_number_should_match: usize,
     scoring_enabled: bool,
     score_combiner_fn: Box<dyn Fn() -> TScoreCombiner + Sync + Send>,
@@ -268,17 +268,14 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
         scoring_enabled: bool,
         score_combiner_fn: Box<dyn Fn() -> TScoreCombiner + Sync + Send + 'static>,
     ) -> BooleanWeight<TScoreCombiner> {
-        let mut per_occur_weights: HashMap<Occur, Vec<Box<dyn Weight>>> = HashMap::default();
+        let mut per_occur_weights = OccurWeights::default();
         for (occur, weight) in weights {
-            per_occur_weights.entry(occur).or_default().push(weight);
+            per_occur_weights.push(occur, weight);
         }
 
         // Optimisation: we rewrite the bool weight depending on the number of minimum should match
         // and the number of should clauses.
-        let num_should_weights = per_occur_weights
-            .get(&Occur::Should)
-            .map(Vec::len)
-            .unwrap_or(0);
+        let num_should_weights = per_occur_weights.get(Occur::Should).len();
 
         match num_should_weights.cmp(&minimum_number_should_match) {
             Ordering::Greater => {
@@ -292,11 +289,7 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             }
             Ordering::Equal => {
                 // Equal! All should clause will be required. We promote them to Must!
-                let should_weights = per_occur_weights.remove(&Occur::Should);
-                per_occur_weights
-                    .entry(Occur::Must)
-                    .or_default()
-                    .extend(should_weights.into_iter().flatten());
+                per_occur_weights.promote_should_to_must();
                 BooleanWeight {
                     per_occur_weights,
                     minimum_number_should_match: 0,
@@ -325,38 +318,31 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
     ) -> crate::Result<SpecializedScorer> {
         let num_docs = reader.num_docs();
 
-        let intersection_weights: &[Box<dyn Weight>] = self
-            .per_occur_weights
-            .get(&Occur::Must)
-            .map(|weights| weights.as_slice())
-            .unwrap_or(&[]);
+        let intersection_weights: &[Box<dyn Weight>] = self.per_occur_weights.get(Occur::Must);
 
-        let required_scorers: Vec<Box<dyn Scorer>> =
+        let mut must_scorers: Vec<Box<dyn Scorer>> =
             create_aligned_scorers_for_intersection(intersection_weights, reader, boost)?;
 
-        let mut per_occur_scorers: HashMap<Occur, Vec<Box<dyn Scorer>>> = HashMap::new();
-
-        if !required_scorers.is_empty() {
+        if !must_scorers.is_empty() {
             // all scorer are aligned, it is ok to test a single one.
-            if required_scorers[0].doc() >= TERMINATED {
+            if must_scorers[0].doc() >= TERMINATED {
                 return Ok(SpecializedScorer::empty());
             }
-            per_occur_scorers.insert(Occur::Must, required_scorers);
         }
 
-        for occur in [Occur::MustNot, Occur::Should] {
-            if let Some(occur_weights) = self.per_occur_weights.get(&occur) {
-                let occur_scorers = per_occur_scorers.entry(occur).or_default();
-                for occur_weight in occur_weights {
-                    let occur_scorer = occur_weight.scorer(reader, boost)?;
-                    occur_scorers.push(occur_scorer);
-                }
-            }
+        let mut should_scorers =
+            Vec::with_capacity(self.per_occur_weights.get(Occur::Should).len());
+        for should_weight in self.per_occur_weights.get(Occur::Should) {
+            should_scorers.push(should_weight.scorer(reader, boost)?);
+        }
+
+        let mut exclude_scorers =
+            Vec::with_capacity(self.per_occur_weights.get(Occur::MustNot).len());
+        for exclude_weight in self.per_occur_weights.get(Occur::MustNot) {
+            exclude_scorers.push(exclude_weight.scorer(reader, boost)?);
         }
 
         // Indicate how should clauses are combined with must clauses.
-        let mut must_scorers: Vec<Box<dyn Scorer>> =
-            per_occur_scorers.remove(&Occur::Must).unwrap_or_default();
         let must_special_scorer_counts: AllAndEmptyScorerCounts =
             remove_and_count_all_and_empty_scorers(&mut must_scorers);
 
@@ -364,13 +350,8 @@ impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
             return Ok(SpecializedScorer::empty());
         }
 
-        let mut should_scorers = per_occur_scorers.remove(&Occur::Should).unwrap_or_default();
         let should_special_scorer_counts: AllAndEmptyScorerCounts =
             remove_and_count_all_and_empty_scorers(&mut should_scorers);
-
-        let mut exclude_scorers: Vec<Box<dyn Scorer>> = per_occur_scorers
-            .remove(&Occur::MustNot)
-            .unwrap_or_default();
         let exclude_special_scorer_counts: AllAndEmptyScorerCounts =
             remove_and_count_all_and_empty_scorers(&mut exclude_scorers);
 
@@ -571,17 +552,12 @@ fn remove_and_count_all_and_empty_scorers(
 impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombiner> {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
         let num_docs = reader.num_docs();
-        let num_sub_weights: usize = self.per_occur_weights.values().map(Vec::len).sum();
+        let num_sub_weights: usize = self.per_occur_weights.len();
         if num_sub_weights == 0 {
             Ok(Box::new(EmptyScorer))
         } else if num_sub_weights == 1 {
             // We have single subscorer. Let's just just short circuit our logic and return it.
-            let (occur, weight) = self
-                .per_occur_weights
-                .iter()
-                .flat_map(|(occur, weights)| weights.iter().map(|weight| (*occur, weight)))
-                .next()
-                .unwrap();
+            let (occur, weight) = self.per_occur_weights.iter().next().unwrap();
             if occur == Occur::MustNot {
                 Ok(Box::new(EmptyScorer))
             } else {
@@ -610,12 +586,10 @@ impl<TScoreCombiner: ScoreCombiner + Sync> Weight for BooleanWeight<TScoreCombin
         }
 
         let mut explanation = Explanation::new("BooleanClause. sum of ...", scorer.score());
-        for (occur, subweights) in &self.per_occur_weights {
-            for subweight in subweights {
-                if is_include_occur(*occur) {
-                    if let Ok(child_explanation) = subweight.explain(reader, doc) {
-                        explanation.add_detail(child_explanation);
-                    }
+        for (occur, subweight) in self.per_occur_weights.iter() {
+            if is_include_occur(occur) {
+                if let Ok(child_explanation) = subweight.explain(reader, doc) {
+                    explanation.add_detail(child_explanation);
                 }
             }
         }

--- a/src/query/boolean_query/mod.rs
+++ b/src/query/boolean_query/mod.rs
@@ -2,6 +2,7 @@ mod block_wand_intersection;
 mod block_wand_union;
 mod boolean_query;
 mod boolean_weight;
+mod occur_weights;
 
 pub(crate) use self::block_wand_intersection::block_wand_intersection;
 pub(crate) use self::block_wand_union::{block_wand, block_wand_single_scorer};

--- a/src/query/boolean_query/occur_weights.rs
+++ b/src/query/boolean_query/occur_weights.rs
@@ -1,0 +1,110 @@
+use query_grammar::Occur;
+
+use crate::query::Weight;
+
+/// A replacement for `HashMap<Occur, Vec<Box<dyn Weight>>>`.
+///
+/// `Occur` only has 3 possible variants, so we store one `Vec<Box<dyn Weight>>` per variant
+/// instead of paying for hashing.
+#[derive(Default)]
+pub struct OccurWeights {
+    must: Vec<Box<dyn Weight>>,
+    should: Vec<Box<dyn Weight>>,
+    must_not: Vec<Box<dyn Weight>>,
+}
+
+impl OccurWeights {
+    pub fn push(&mut self, occur: Occur, weight: Box<dyn Weight>) {
+        let occur_weights = match occur {
+            Occur::Must => &mut self.must,
+            Occur::Should => &mut self.should,
+            Occur::MustNot => &mut self.must_not,
+        };
+        occur_weights.push(weight);
+    }
+
+    pub fn get(&self, occur: Occur) -> &[Box<dyn Weight>] {
+        match occur {
+            Occur::Must => &self.must,
+            Occur::Should => &self.should,
+            Occur::MustNot => &self.must_not,
+        }
+    }
+
+    /// Moves all SHOULD weights into MUST, emptying the SHOULD bucket.
+    ///
+    /// Used when the number of SHOULD clauses equals the minimum number of should clauses
+    /// required to match: at that point every SHOULD clause is effectively required.
+    pub fn promote_should_to_must(&mut self) {
+        let should_weights = std::mem::take(&mut self.should);
+        self.must.extend(should_weights);
+    }
+
+    pub fn len(&self) -> usize {
+        self.must.len() + self.should.len() + self.must_not.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (Occur, &Box<dyn Weight>)> {
+        [Occur::Must, Occur::Should, Occur::MustNot]
+            .into_iter()
+            .flat_map(move |occur| self.get(occur).iter().map(move |weight| (occur, weight)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OccurWeights;
+    use crate::query::{EnableScoring, Occur, Query, TermQuery, Weight};
+    use crate::schema::{IndexRecordOption, Schema, TEXT};
+    use crate::{Index, Term};
+
+    fn term_weight(searcher: &crate::Searcher, term: &str) -> Box<dyn Weight> {
+        let field = searcher.schema().get_field("text").unwrap();
+        TermQuery::new(Term::from_field_text(field, term), IndexRecordOption::Basic)
+            .weight(EnableScoring::disabled_from_searcher(searcher))
+            .unwrap()
+    }
+
+    fn test_searcher() -> crate::Searcher {
+        let mut schema_builder = Schema::builder();
+        schema_builder.add_text_field("text", TEXT);
+        let index = Index::create_in_ram(schema_builder.build());
+        index.reader().unwrap().searcher()
+    }
+
+    #[test]
+    fn test_push_and_get() {
+        let searcher = test_searcher();
+        let mut weights = OccurWeights::default();
+        weights.push(Occur::Must, term_weight(&searcher, "a"));
+        weights.push(Occur::Must, term_weight(&searcher, "b"));
+        weights.push(Occur::Should, term_weight(&searcher, "c"));
+        assert_eq!(weights.get(Occur::Must).len(), 2);
+        assert_eq!(weights.get(Occur::Should).len(), 1);
+        assert!(weights.get(Occur::MustNot).is_empty());
+        assert_eq!(weights.len(), 3);
+    }
+
+    #[test]
+    fn test_promote_should_to_must() {
+        let searcher = test_searcher();
+        let mut weights = OccurWeights::default();
+        weights.push(Occur::Must, term_weight(&searcher, "a"));
+        weights.push(Occur::Should, term_weight(&searcher, "b"));
+        weights.push(Occur::Should, term_weight(&searcher, "c"));
+        weights.promote_should_to_must();
+        assert_eq!(weights.get(Occur::Must).len(), 3);
+        assert!(weights.get(Occur::Should).is_empty());
+    }
+
+    #[test]
+    fn test_iter_visits_all_buckets_in_order() {
+        let searcher = test_searcher();
+        let mut weights = OccurWeights::default();
+        weights.push(Occur::Must, term_weight(&searcher, "a"));
+        weights.push(Occur::Should, term_weight(&searcher, "b"));
+        weights.push(Occur::MustNot, term_weight(&searcher, "c"));
+        let occurs: Vec<Occur> = weights.iter().map(|(occur, _)| occur).collect();
+        assert_eq!(occurs, vec![Occur::Must, Occur::Should, Occur::MustNot]);
+    }
+}

--- a/src/query/boost_query.rs
+++ b/src/query/boost_query.rs
@@ -83,6 +83,16 @@ impl Weight for BoostWeight {
     fn count(&self, reader: &SegmentReader) -> crate::Result<u32> {
         self.weight.count(reader)
     }
+
+    fn scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        self.weight
+            .scorer_danger(reader, target, boost * self.boost)
+    }
 }
 
 pub(crate) struct BoostScorer<S: Scorer> {

--- a/src/query/const_score_query.rs
+++ b/src/query/const_score_query.rs
@@ -67,7 +67,7 @@ impl ConstWeight {
 
 impl Weight for ConstWeight {
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
-        let inner_scorer = self.weight.scorer(reader, boost)?;
+        let inner_scorer = self.weight.scorer(reader, 1.0f32)?;
         Ok(Box::new(ConstScorer::new(inner_scorer, boost * self.score)))
     }
 
@@ -85,6 +85,19 @@ impl Weight for ConstWeight {
 
     fn count(&self, reader: &SegmentReader) -> crate::Result<u32> {
         self.weight.count(reader)
+    }
+
+    fn scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        let (seek_result, inner_scorer) = self.weight.scorer_danger(reader, target, 1.0f32)?;
+        Ok((
+            seek_result,
+            Box::new(ConstScorer::new(inner_scorer, boost * self.score)) as Box<dyn Scorer>,
+        ))
     }
 }
 

--- a/src/query/intersection.rs
+++ b/src/query/intersection.rs
@@ -80,6 +80,7 @@ fn go_to_first_doc<TDocSet: DocSet>(docsets: &mut [TDocSet]) -> DocId {
 
 impl<TDocSet: DocSet> Intersection<TDocSet, TDocSet> {
     /// num_docs is the number of documents in the segment.
+    /// It is required to have at least  two docsets.
     pub(crate) fn new(
         mut docsets: Vec<TDocSet>,
         segment_num_docs: u32,
@@ -129,7 +130,8 @@ impl<TDocSet: DocSet, TOtherDocSet: DocSet> DocSet for Intersection<TDocSet, TOt
 
         // Termination: candidate strictly increases.
         'outer: while candidate < TERMINATED {
-            // As we enter the loop, we should always have candidate < next_doc.
+            // As we enter the loop, we should always have prev_intersection_doc < candidate <=
+            // next_intersection_doc.
 
             candidate = left.seek(candidate);
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -98,7 +98,7 @@ mod tests {
         assert_eq!(do_search("(a OR b) AND C"), vec![2, 1]);
         // The intersection code has special code for more than 2 intersections
         // left, right + others
-        // The will place the union in the "others" insersection to that seek_into_the_danger_zone
+        // The will place the union in the "others" intersection to that seek_danger
         // is called
         assert_eq!(
             do_search("(a OR b) AND (c OR a) AND (b OR c)"),

--- a/src/query/phrase_query/phrase_scorer.rs
+++ b/src/query/phrase_query/phrase_scorer.rs
@@ -368,6 +368,42 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
         slop: u32,
         offset: usize,
     ) -> PhraseScorer<TPostings> {
+        let (seek_result, mut scorer) = Self::new_danger(
+            term_postings_with_offset,
+            similarity_weight_opt,
+            fieldnorm_reader,
+            slop,
+            offset,
+            0,
+        );
+        if let SeekDangerResult::SeekLowerBound(target) = seek_result {
+            if target < TERMINATED {
+                scorer.seek(target);
+            }
+        }
+        scorer
+    }
+
+    /// Creates a phrase scorer near `target` without scanning forward to the next phrase match.
+    ///
+    /// On a miss, the scorer follows the danger-state contract: it must only receive further
+    /// `seek_danger` calls until one returns [`SeekDangerResult::Found`].
+    pub(crate) fn new_danger(
+        mut term_postings_with_offset: Vec<(usize, TPostings)>,
+        similarity_weight_opt: Option<Bm25Weight>,
+        fieldnorm_reader: FieldNormReader,
+        slop: u32,
+        offset: usize,
+        target: DocId,
+    ) -> (SeekDangerResult, PhraseScorer<TPostings>) {
+        for (_, postings) in &mut term_postings_with_offset {
+            if postings.doc() < target {
+                // We do not optimize for that seek.
+                // This would require a constructor Intersection::new that
+                // accepts postings in the danger zone and we prefer to avoid that.
+                postings.seek(target);
+            }
+        }
         let num_docs = fieldnorm_reader.num_docs();
         let max_offset = term_postings_with_offset
             .iter()
@@ -396,10 +432,18 @@ impl<TPostings: Postings> PhraseScorer<TPostings> {
             slops_buffer: Vec::with_capacity(100),
             positions_buffer: Vec::with_capacity(100),
         };
-        if scorer.doc() != TERMINATED && !scorer.phrase_match() {
-            scorer.advance();
-        }
-        scorer
+        let doc = scorer.doc();
+        debug_assert!(doc >= target);
+        let seek_result = if doc >= TERMINATED {
+            SeekDangerResult::SeekLowerBound(TERMINATED)
+        } else if doc > target {
+            SeekDangerResult::SeekLowerBound(doc)
+        } else if scorer.phrase_match() {
+            SeekDangerResult::Found
+        } else {
+            SeekDangerResult::SeekLowerBound(target + 1)
+        };
+        (seek_result, scorer)
     }
 
     pub fn phrase_count(&self) -> u32 {

--- a/src/query/phrase_query/phrase_weight.rs
+++ b/src/query/phrase_query/phrase_weight.rs
@@ -1,4 +1,5 @@
 use super::PhraseScorer;
+use crate::docset::SeekDangerResult;
 use crate::fieldnorm::FieldNormReader;
 use crate::index::SegmentReader;
 use crate::postings::SegmentPostings;
@@ -6,7 +7,7 @@ use crate::query::bm25::Bm25Weight;
 use crate::query::explanation::does_not_match;
 use crate::query::{EmptyScorer, Explanation, Scorer, Weight};
 use crate::schema::{IndexRecordOption, Term};
-use crate::{DocId, DocSet, Score};
+use crate::{DocId, DocSet, Score, TERMINATED};
 
 pub struct PhraseWeight {
     phrase_terms: Vec<(usize, Term)>,
@@ -44,6 +45,23 @@ impl PhraseWeight {
         reader: &SegmentReader,
         boost: Score,
     ) -> crate::Result<Option<PhraseScorer<SegmentPostings>>> {
+        let Some((seek_result, mut scorer)) = self.phrase_scorer_danger(reader, 0, boost)? else {
+            return Ok(None);
+        };
+        if let SeekDangerResult::SeekLowerBound(target) = seek_result {
+            if target < TERMINATED {
+                scorer.seek(target);
+            }
+        }
+        Ok(Some(scorer))
+    }
+
+    fn phrase_scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<Option<(SeekDangerResult, PhraseScorer<SegmentPostings>)>> {
         let similarity_weight_opt = self
             .similarity_weight_opt
             .as_ref()
@@ -51,20 +69,21 @@ impl PhraseWeight {
         let fieldnorm_reader = self.fieldnorm_reader(reader)?;
         let mut term_postings_list = Vec::new();
         for &(offset, ref term) in &self.phrase_terms {
-            if let Some(postings) = reader
+            let Some(postings) = reader
                 .inverted_index(term.field())?
                 .read_postings(term, IndexRecordOption::WithFreqsAndPositions)?
-            {
-                term_postings_list.push((offset, postings));
-            } else {
+            else {
                 return Ok(None);
-            }
+            };
+            term_postings_list.push((offset, postings));
         }
-        Ok(Some(PhraseScorer::new(
+        Ok(Some(PhraseScorer::new_danger(
             term_postings_list,
             similarity_weight_opt,
             fieldnorm_reader,
             self.slop,
+            0,
+            target,
         )))
     }
 
@@ -80,6 +99,21 @@ impl Weight for PhraseWeight {
         } else {
             Ok(Box::new(EmptyScorer))
         }
+    }
+
+    fn scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        let Some((seek_result, scorer)) = self.phrase_scorer_danger(reader, target, boost)? else {
+            return Ok((
+                SeekDangerResult::SeekLowerBound(TERMINATED),
+                Box::new(EmptyScorer),
+            ));
+        };
+        Ok((seek_result, Box::new(scorer)))
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
@@ -105,8 +139,8 @@ impl Weight for PhraseWeight {
 #[cfg(test)]
 mod tests {
     use super::super::tests::create_index;
-    use crate::docset::TERMINATED;
-    use crate::query::{EnableScoring, PhraseQuery};
+    use crate::docset::{SeekDangerResult, TERMINATED};
+    use crate::query::{EnableScoring, PhraseQuery, Weight};
     use crate::{DocSet, Term};
 
     #[test]
@@ -130,6 +164,43 @@ mod tests {
         assert_eq!(phrase_scorer.doc(), 2);
         assert_eq!(phrase_scorer.phrase_count(), 1);
         assert_eq!(phrase_scorer.advance(), TERMINATED);
+        Ok(())
+    }
+
+    #[test]
+    fn test_phrase_weight_scorer_danger() -> crate::Result<()> {
+        let index = create_index(&["a b", "a c b", "a b", "a c"])?;
+        let schema = index.schema();
+        let text_field = schema.get_field("text").unwrap();
+        let searcher = index.reader()?.searcher();
+        let phrase_query = PhraseQuery::new(vec![
+            Term::from_field_text(text_field, "a"),
+            Term::from_field_text(text_field, "b"),
+        ]);
+        let phrase_weight =
+            phrase_query.phrase_weight(EnableScoring::disabled_from_searcher(&searcher))?;
+        let reader = searcher.segment_reader(0);
+
+        let (seek_result, mut scorer) = phrase_weight.scorer_danger(reader, 1, 1.0)?;
+        assert_eq!(seek_result, SeekDangerResult::SeekLowerBound(2));
+        assert_eq!(scorer.seek_danger(2), SeekDangerResult::Found);
+        assert_eq!(scorer.doc(), 2);
+
+        let (seek_result, scorer) = phrase_weight.scorer_danger(reader, 2, 1.0)?;
+        assert_eq!(seek_result, SeekDangerResult::Found);
+        assert_eq!(scorer.doc(), 2);
+
+        let (seek_result, _) = phrase_weight.scorer_danger(reader, 3, 1.0)?;
+        assert_eq!(seek_result, SeekDangerResult::SeekLowerBound(TERMINATED));
+
+        let scoring_phrase_weight =
+            phrase_query.phrase_weight(EnableScoring::enabled_from_searcher(&searcher))?;
+        let (seek_result, mut danger_scorer) =
+            scoring_phrase_weight.scorer_danger(reader, 2, 2.0)?;
+        assert_eq!(seek_result, SeekDangerResult::Found);
+        let mut regular_scorer = scoring_phrase_weight.scorer(reader, 2.0)?;
+        assert_eq!(regular_scorer.seek(2), 2);
+        assert_eq!(danger_scorer.score(), regular_scorer.score());
         Ok(())
     }
 }

--- a/src/query/weight.rs
+++ b/src/query/weight.rs
@@ -1,5 +1,5 @@
 use super::Scorer;
-use crate::docset::COLLECT_BLOCK_BUFFER_LEN;
+use crate::docset::{SeekDangerResult, COLLECT_BLOCK_BUFFER_LEN};
 use crate::index::SegmentReader;
 use crate::query::Explanation;
 use crate::{DocId, DocSet, Score, TERMINATED};
@@ -70,6 +70,36 @@ pub trait Weight: Send + Sync + 'static {
     ///
     /// See [`Query`](crate::query::Query).
     fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>>;
+
+    /// !!!Dragons ahead!!!
+    /// Returns a scorer initialized around `target` for use in an intersection.
+    ///
+    /// # Warning
+    ///
+    /// The result and the state of the returned scorer follow the semantics of
+    /// [`DocSet::seek_danger`]. When this method returns
+    /// [`SeekDangerResult::SeekLowerBound`], the scorer may be in an invalid state and must only
+    /// receive further calls to [`DocSet::seek_danger`] until one returns
+    /// [`SeekDangerResult::Found`].
+    ///
+    /// Some scorer types require substantial CPU work to locate their first matching document.
+    /// During intersection initialization, this hook lets them start near the current candidate
+    /// instead.
+    fn scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        let mut scorer = self.scorer(reader, boost)?;
+        let scorer_doc = scorer.doc();
+        let seek_danger_result = match scorer_doc.cmp(&target) {
+            std::cmp::Ordering::Less => scorer.seek_danger(target),
+            std::cmp::Ordering::Equal => SeekDangerResult::Found,
+            std::cmp::Ordering::Greater => SeekDangerResult::SeekLowerBound(scorer_doc),
+        };
+        Ok((seek_danger_result, scorer))
+    }
 
     /// Returns an [`Explanation`] for the given document.
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation>;

--- a/src/query/weight.rs
+++ b/src/query/weight.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use super::Scorer;
 use crate::docset::{SeekDangerResult, COLLECT_BLOCK_BUFFER_LEN};
 use crate::index::SegmentReader;
@@ -94,9 +96,9 @@ pub trait Weight: Send + Sync + 'static {
         let mut scorer = self.scorer(reader, boost)?;
         let scorer_doc = scorer.doc();
         let seek_danger_result = match scorer_doc.cmp(&target) {
-            std::cmp::Ordering::Less => scorer.seek_danger(target),
-            std::cmp::Ordering::Equal => SeekDangerResult::Found,
-            std::cmp::Ordering::Greater => SeekDangerResult::SeekLowerBound(scorer_doc),
+            Ordering::Less => scorer.seek_danger(target),
+            Ordering::Equal => SeekDangerResult::Found,
+            Ordering::Greater => SeekDangerResult::SeekLowerBound(scorer_doc),
         };
         Ok((seek_danger_result, scorer))
     }


### PR DESCRIPTION
This PR introduces an optimization follow up to the seek_danger logic.

seek_danger has been introduced to allow Scorer for which seeking is someone slow to lazily just answer "that document don't match" instead of seeking for the actual next document they match.
e.g. A phrase scorer would have to find the next doc.

That optimization was NOT usable however for scorer initialization. All scorer have to be initialized and positioned on their first doc.

The main motivation is the future addition of predicate queries that are based on a calculated field.
Asking for the first doc of such a Score would mean scanning and evaluating that predicate for every doc until one matches.

This PR addresses that issue by adding a new method to Weight called scorer_danger. It is the equivalent of seek_danger but for Scorer initialization.

The only caller is BooleanWeight, which will use it to create the scorers associated to its must clause.
All of the code that manipulates scorer in a "dangerous", almost undefined state is contained in create_aligned_scorers_for_intersection.

