### PR TITLE
Minor change: removing BooleanWeight::new as it is quite the footgun

### DIFF
--- a/src/query/boolean_query/boolean_weight.rs
+++ b/src/query/boolean_query/boolean_weight.rs
@@ -188,20 +188,6 @@ pub struct BooleanWeight<TScoreCombiner: ScoreCombiner> {
 }
 
 impl<TScoreCombiner: ScoreCombiner> BooleanWeight<TScoreCombiner> {
-    /// Creates a new boolean weight.
-    pub fn new(
-        weights: Vec<(Occur, Box<dyn Weight>)>,
-        scoring_enabled: bool,
-        score_combiner_fn: Box<dyn Fn() -> TScoreCombiner + Sync + Send + 'static>,
-    ) -> BooleanWeight<TScoreCombiner> {
-        BooleanWeight {
-            weights,
-            scoring_enabled,
-            score_combiner_fn,
-            minimum_number_should_match: 1,
-        }
-    }
-
     /// Create a new boolean weight with minimum number of required should clauses specified.
     pub fn with_minimum_number_should_match(
         weights: Vec<(Occur, Box<dyn Weight>)>,

--- a/src/query/disjunction_max_query.rs
+++ b/src/query/disjunction_max_query.rs
@@ -97,8 +97,9 @@ impl Query for DisjunctionMaxQuery {
             .map(|disjunct| Ok((Occur::Should, disjunct.weight(enable_scoring)?)))
             .collect::<crate::Result<_>>()?;
         let tie_breaker = self.tie_breaker;
-        Ok(Box::new(BooleanWeight::new(
+        Ok(Box::new(BooleanWeight::with_minimum_number_should_match(
             disjuncts,
+            1,
             enable_scoring.is_scoring_enabled(),
             Box::new(move || DisjunctionMaxCombiner::with_tie_breaker(tie_breaker)),
         )))

--- a/src/query/set_query.rs
+++ b/src/query/set_query.rs
@@ -60,8 +60,9 @@ impl TermSetQuery {
             ));
         }
 
-        Ok(BooleanWeight::new(
+        Ok(BooleanWeight::with_minimum_number_should_match(
             sub_queries,
+            1,
             false,
             Box::new(|| DoNothingCombiner),
         ))

--- a/sstable/src/delta.rs
+++ b/sstable/src/delta.rs
@@ -220,10 +220,7 @@ where TValueReader: value::ValueReader
         } else {
             self.idx += 1;
         }
-        if !self.read_delta_key() {
-            return Ok(false);
-        }
-        Ok(true)
+        Ok(self.read_delta_key())
     }
 
     #[inline(always)]


### PR DESCRIPTION
BooleanWeight::new just default min_should_match to 1. This is misleading because I think someone who passes a single must clause would expect the result to match that clause.

Due to min_should_match, it actually returns nothing.