### PR TITLE
Add DocPredicateQuery and a generic FunctionPredicate implementation

### DIFF
--- a/src/query/doc_predicate_query/function_predicate.rs
+++ b/src/query/doc_predicate_query/function_predicate.rs
@@ -1,0 +1,99 @@
+use super::{DocPredicate, SegmentDocPredicate};
+use crate::index::SegmentReader;
+use crate::DocId;
+
+/// Blanket [`SegmentDocPredicate`] implementation for any per-document
+/// closure.
+///
+/// Hidden contract: [`SegmentDocPredicate::eval`] takes `&self`, not
+/// `&mut self`, so the closure must be callable through an immutable
+/// reference (`Fn`, not `FnMut`). A caller that needs per-document mutable
+/// state must capture it behind its own synchronization primitive (for
+/// example `Arc<Mutex<_>>` or `Arc<AtomicUsize>`) rather than relying on
+/// interior mutability provided by this blanket impl.
+impl<F> SegmentDocPredicate for F
+where F: Fn(DocId) -> bool + Send + Sync + 'static
+{
+    fn eval(&self, doc_id: DocId) -> bool {
+        (self)(doc_id)
+    }
+}
+
+/// A [`DocPredicate`] built from a plain factory function.
+///
+/// `FunctionPredicate` wraps a factory closure that is called once per
+/// segment (via [`DocPredicate::doc_predicate`]) and returns a per-document
+/// closure evaluated once per candidate document. This predicate has no
+/// dependency on fast fields or any other segment data structure: the
+/// factory receives the [`SegmentReader`] and is free to ignore it entirely,
+/// for example to build a predicate over `doc_id` alone.
+///
+/// # Example
+///
+/// ```
+/// use tantivy::query::doc_predicate_query::FunctionPredicate;
+/// use tantivy::query::doc_predicate_query::DocPredicateQuery;
+/// use tantivy::index::SegmentReader;
+/// use tantivy::DocId;
+///
+/// // Matches every even doc id, in every segment.
+/// let predicate = FunctionPredicate::new(|_segment_reader: &SegmentReader| {
+///     Ok(move |doc_id: DocId| doc_id % 2 == 0)
+/// });
+/// let _query: DocPredicateQuery = predicate.into();
+/// ```
+pub struct FunctionPredicate<F> {
+    factory: F,
+}
+
+impl<F> FunctionPredicate<F> {
+    /// Creates a new predicate from a per-segment factory function.
+    ///
+    /// `factory` is called once per segment and must return a per-document
+    /// closure implementing `Fn(DocId) -> bool`.
+    pub fn new(factory: F) -> Self {
+        Self { factory }
+    }
+}
+
+// `F` is a plain closure or function type and will not generally implement
+// `Debug`. `DocPredicate` requires `Debug`, so this manual impl exists purely
+// to satisfy that bound; it intentionally does not attempt to expose the
+// closure's captured state.
+impl<F> std::fmt::Debug for FunctionPredicate<F> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter
+            .debug_struct("FunctionPredicate")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<F, SegmentF> DocPredicate for FunctionPredicate<F>
+where
+    F: Fn(&SegmentReader) -> crate::Result<SegmentF> + Send + Sync + 'static,
+    SegmentF: SegmentDocPredicate,
+{
+    type SegmentDocPredicate = SegmentF;
+
+    fn doc_predicate(&self, segment_reader: &SegmentReader) -> crate::Result<SegmentF> {
+        (self.factory)(segment_reader)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collector::Count;
+    use crate::query::doc_predicate_query::{create_index_for_test, DocPredicateQuery};
+
+    #[test]
+    fn test_function_predicate_matches_even_doc_ids() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        let predicate = FunctionPredicate::new(|_segment_reader: &SegmentReader| {
+            Ok(move |doc_id: DocId| doc_id % 2 == 0)
+        });
+        let query: DocPredicateQuery = predicate.into();
+        assert_eq!(searcher.search(&query, &Count).unwrap(), 2);
+    }
+}

--- a/src/query/doc_predicate_query/function_predicate.rs
+++ b/src/query/doc_predicate_query/function_predicate.rs
@@ -3,18 +3,11 @@ use crate::index::SegmentReader;
 use crate::DocId;
 
 /// Blanket [`SegmentDocPredicate`] implementation for any per-document
-/// closure.
-///
-/// Hidden contract: [`SegmentDocPredicate::eval`] takes `&self`, not
-/// `&mut self`, so the closure must be callable through an immutable
-/// reference (`Fn`, not `FnMut`). A caller that needs per-document mutable
-/// state must capture it behind its own synchronization primitive (for
-/// example `Arc<Mutex<_>>` or `Arc<AtomicUsize>`) rather than relying on
-/// interior mutability provided by this blanket impl.
+/// function.
 impl<F> SegmentDocPredicate for F
 where F: Fn(DocId) -> bool + Send + Sync + 'static
 {
-    fn eval(&self, doc_id: DocId) -> bool {
+    fn eval(&mut self, doc_id: DocId) -> bool {
         (self)(doc_id)
     }
 }
@@ -23,43 +16,23 @@ where F: Fn(DocId) -> bool + Send + Sync + 'static
 ///
 /// `FunctionPredicate` wraps a factory closure that is called once per
 /// segment (via [`DocPredicate::doc_predicate`]) and returns a per-document
-/// closure evaluated once per candidate document. This predicate has no
-/// dependency on fast fields or any other segment data structure: the
-/// factory receives the [`SegmentReader`] and is free to ignore it entirely,
-/// for example to build a predicate over `doc_id` alone.
-///
-/// # Example
-///
-/// ```
-/// use tantivy::query::doc_predicate_query::FunctionPredicate;
-/// use tantivy::query::doc_predicate_query::DocPredicateQuery;
-/// use tantivy::index::SegmentReader;
-/// use tantivy::DocId;
-///
-/// // Matches every even doc id, in every segment.
-/// let predicate = FunctionPredicate::new(|_segment_reader: &SegmentReader| {
-///     Ok(move |doc_id: DocId| doc_id % 2 == 0)
-/// });
-/// let _query: DocPredicateQuery = predicate.into();
-/// ```
+/// closure evaluated once per candidate document.
 pub struct FunctionPredicate<F> {
-    factory: F,
+    segment_predicate_factory: F,
 }
 
-impl<F> FunctionPredicate<F> {
-    /// Creates a new predicate from a per-segment factory function.
-    ///
-    /// `factory` is called once per segment and must return a per-document
-    /// closure implementing `Fn(DocId) -> bool`.
-    pub fn new(factory: F) -> Self {
-        Self { factory }
+impl<F, SegmentF> From<F> for FunctionPredicate<F>
+where
+    F: Fn(&SegmentReader) -> crate::Result<SegmentF> + Send + 'static,
+    SegmentF: SegmentDocPredicate,
+{
+    fn from(segment_predicate_factory: F) -> Self {
+        Self {
+            segment_predicate_factory,
+        }
     }
 }
 
-// `F` is a plain closure or function type and will not generally implement
-// `Debug`. `DocPredicate` requires `Debug`, so this manual impl exists purely
-// to satisfy that bound; it intentionally does not attempt to expose the
-// closure's captured state.
 impl<F> std::fmt::Debug for FunctionPredicate<F> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter
@@ -76,7 +49,7 @@ where
     type SegmentDocPredicate = SegmentF;
 
     fn doc_predicate(&self, segment_reader: &SegmentReader) -> crate::Result<SegmentF> {
-        (self.factory)(segment_reader)
+        (self.segment_predicate_factory)(segment_reader)
     }
 }
 
@@ -84,13 +57,14 @@ where
 mod tests {
     use super::*;
     use crate::collector::Count;
-    use crate::query::doc_predicate_query::{create_index_for_test, DocPredicateQuery};
+    use crate::query::doc_predicate_query::tests::create_index_for_test;
+    use crate::query::doc_predicate_query::DocPredicateQuery;
 
     #[test]
     fn test_function_predicate_matches_even_doc_ids() {
         let index = create_index_for_test(4);
         let searcher = index.reader().unwrap().searcher();
-        let predicate = FunctionPredicate::new(|_segment_reader: &SegmentReader| {
+        let predicate = FunctionPredicate::from(|_segment_reader: &SegmentReader| {
             Ok(move |doc_id: DocId| doc_id % 2 == 0)
         });
         let query: DocPredicateQuery = predicate.into();

--- a/src/query/doc_predicate_query/mod.rs
+++ b/src/query/doc_predicate_query/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-/// A [`DocPredicate`] built from a plain Rust factory function.
 mod function_predicate;
 
 pub use function_predicate::FunctionPredicate;
@@ -11,11 +10,7 @@ use crate::query::explanation::does_not_match;
 use crate::query::{ConstScorer, EnableScoring, Explanation, Query, Scorer, Weight};
 use crate::{DocId, DocSet, Score};
 
-/// A query that evaluates a boolean JIT expression against fast-field columns.
-///
-/// Variable names in the expression are resolved as fast-field names for each
-/// segment. Multivalued columns contribute their first value. A document with a
-/// missing input value does not match.
+/// A query that evaluates, for each DocId, whether it matches or not.
 #[derive(Clone, Debug)]
 pub struct DocPredicateQuery {
     predicate: Arc<dyn DocPredicateBoxable>,
@@ -118,8 +113,7 @@ impl<TSegmentDocPredicate: SegmentDocPredicate> DocPredicateDocSet<TSegmentDocPr
             match self.seek_danger(target) {
                 SeekDangerResult::Found => return target,
                 SeekDangerResult::SeekLowerBound(next_target) => {
-                    if next_target >= self.max_doc {
-                        self.doc = TERMINATED;
+                    if next_target >= TERMINATED {
                         return TERMINATED;
                     }
                     target = next_target;
@@ -128,11 +122,8 @@ impl<TSegmentDocPredicate: SegmentDocPredicate> DocPredicateDocSet<TSegmentDocPr
         }
     }
 }
+
 /// A dyn-safe, type-erased [`DocPredicate`].
-///
-/// Every [`DocPredicate`] implementation gets a blanket impl of this trait,
-/// which is what lets [`DocPredicateQuery`] store its predicate as
-/// `Arc<dyn DocPredicateBoxable>` regardless of the concrete predicate type.
 pub trait DocPredicateBoxable: std::fmt::Debug + 'static + Send + Sync {
     /// Builds a [`Scorer`] over the predicate's matching documents in the
     /// given segment.
@@ -181,10 +172,8 @@ impl<TDocPredicate: DocPredicate> DocPredicateBoxable for TDocPredicate {
 /// A per-query predicate that produces a [`SegmentDocPredicate`] for each
 /// segment.
 ///
-/// Implementing this trait is all that's needed to make a type usable as a
-/// [`DocPredicateQuery`]: [`DocPredicateBoxable`] and
-/// `From<TDocPredicate> for DocPredicateQuery` are both implemented
-/// generically for every [`DocPredicate`].
+/// Implementing this trait is all that's needed to make a type usable in a
+/// [`DocPredicateQuery`].
 pub trait DocPredicate: Send + Sync + 'static + std::fmt::Debug {
     /// The per-segment predicate produced by [`Self::doc_predicate`].
     type SegmentDocPredicate: SegmentDocPredicate;
@@ -201,41 +190,30 @@ pub trait DocPredicate: Send + Sync + 'static + std::fmt::Debug {
 }
 
 /// The per-segment predicate produced by a [`DocPredicate`].
-pub trait SegmentDocPredicate: Send + Sync + 'static {
+pub trait SegmentDocPredicate: Send + 'static {
     /// Returns whether `doc_id` matches the predicate.
-    ///
-    /// Hidden contract: this takes `&self`, not `&mut self`, so any scratch
-    /// state used during evaluation must be behind interior mutability (see
-    /// `jitexpr_predicate`'s use of `RefCell`) or a synchronization
-    /// primitive, rather than plain mutable fields.
-    fn eval(&self, doc_id: DocId) -> bool;
-}
-
-/// Builds an in-RAM index with an empty schema and `num_docs` empty documents.
-///
-/// Shared across the test modules of this module tree so each
-/// `DocPredicate` implementation's tests don't each define their own.
-#[cfg(test)]
-fn create_index_for_test(num_docs: u32) -> crate::Index {
-    let schema_builder = crate::schema::Schema::builder();
-    let schema = schema_builder.build();
-    let index = crate::Index::create_in_ram(schema);
-    let mut writer = index.writer_for_tests().unwrap();
-    for _ in 0..num_docs {
-        writer.add_document(doc!()).unwrap();
-    }
-    writer.commit().unwrap();
-    index
+    fn eval(&mut self, doc_id: DocId) -> bool;
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::collector::Count;
-    use crate::query::doc_predicate_query::FunctionPredicate;
+
+    pub(crate) fn create_index_for_test(num_docs: u32) -> crate::Index {
+        let schema_builder = crate::schema::Schema::builder();
+        let schema = schema_builder.build();
+        let index = crate::Index::create_in_ram(schema);
+        let mut writer = index.writer_for_tests().unwrap();
+        for _ in 0..num_docs {
+            writer.add_document(doc!()).unwrap();
+        }
+        writer.commit().unwrap();
+        index
+    }
 
     fn even_doc_id_query() -> DocPredicateQuery {
-        FunctionPredicate::new(|_segment_reader: &SegmentReader| {
+        FunctionPredicate::from(|_segment_reader: &SegmentReader| {
             Ok(move |doc_id: DocId| doc_id % 2 == 0)
         })
         .into()

--- a/src/query/doc_predicate_query/mod.rs
+++ b/src/query/doc_predicate_query/mod.rs
@@ -1,0 +1,309 @@
+use std::sync::Arc;
+
+/// A [`DocPredicate`] built from a plain Rust factory function.
+mod function_predicate;
+
+pub use function_predicate::FunctionPredicate;
+
+use crate::docset::{SeekDangerResult, TERMINATED};
+use crate::index::SegmentReader;
+use crate::query::explanation::does_not_match;
+use crate::query::{ConstScorer, EnableScoring, Explanation, Query, Scorer, Weight};
+use crate::{DocId, DocSet, Score};
+
+/// A query that evaluates a boolean JIT expression against fast-field columns.
+///
+/// Variable names in the expression are resolved as fast-field names for each
+/// segment. Multivalued columns contribute their first value. A document with a
+/// missing input value does not match.
+#[derive(Clone, Debug)]
+pub struct DocPredicateQuery {
+    predicate: Arc<dyn DocPredicateBoxable>,
+}
+
+impl From<Arc<dyn DocPredicateBoxable>> for DocPredicateQuery {
+    fn from(predicate: Arc<dyn DocPredicateBoxable>) -> Self {
+        DocPredicateQuery { predicate }
+    }
+}
+
+impl<TDocPredicateBoxable: DocPredicateBoxable> From<TDocPredicateBoxable> for DocPredicateQuery {
+    fn from(predicate: TDocPredicateBoxable) -> Self {
+        DocPredicateQuery {
+            predicate: Arc::new(predicate),
+        }
+    }
+}
+
+impl Query for DocPredicateQuery {
+    fn weight(&self, _enable_scoring: EnableScoring) -> crate::Result<Box<dyn Weight>> {
+        Ok(Box::new(self.clone()))
+    }
+}
+
+impl Weight for DocPredicateQuery {
+    fn scorer(&self, reader: &SegmentReader, boost: Score) -> crate::Result<Box<dyn Scorer>> {
+        self.predicate.scorer(reader, boost)
+    }
+
+    fn scorer_danger(
+        &self,
+        reader: &SegmentReader,
+        target: DocId,
+        boost: Score,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        self.predicate.scorer_danger(reader, target, boost)
+    }
+
+    fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
+        let mut docset = self.predicate.scorer(reader, 1.0f32)?;
+        if docset.seek(doc) != doc {
+            return Err(does_not_match(doc));
+        }
+        Ok(Explanation::new("CalculatedPredicateQuery", 1.0))
+    }
+}
+
+/// A [`DocSet`] that walks documents by repeatedly evaluating a
+/// [`SegmentDocPredicate`], starting from doc `0`.
+pub struct DocPredicateDocSet<TSegmentDocPredicate> {
+    doc_predicate: TSegmentDocPredicate,
+    doc: DocId,
+    max_doc: DocId,
+}
+
+impl<TSegmentDocPredicate: SegmentDocPredicate> DocSet
+    for DocPredicateDocSet<TSegmentDocPredicate>
+{
+    fn advance(&mut self) -> DocId {
+        if self.doc == TERMINATED {
+            return TERMINATED;
+        }
+        self.find_match(self.doc + 1)
+    }
+
+    fn seek(&mut self, target: DocId) -> DocId {
+        debug_assert!(target >= self.doc);
+        if self.doc == TERMINATED {
+            return TERMINATED;
+        }
+        self.find_match(target)
+    }
+
+    fn seek_danger(&mut self, target: DocId) -> SeekDangerResult {
+        if target >= self.max_doc {
+            self.doc = TERMINATED;
+            return SeekDangerResult::SeekLowerBound(TERMINATED);
+        }
+        if self.doc_predicate.eval(target) {
+            self.doc = target;
+            SeekDangerResult::Found
+        } else {
+            SeekDangerResult::SeekLowerBound(target + 1)
+        }
+    }
+
+    fn doc(&self) -> DocId {
+        self.doc
+    }
+
+    fn size_hint(&self) -> u32 {
+        self.max_doc
+    }
+}
+
+impl<TSegmentDocPredicate: SegmentDocPredicate> DocPredicateDocSet<TSegmentDocPredicate> {
+    fn find_match(&mut self, mut target: DocId) -> DocId {
+        loop {
+            match self.seek_danger(target) {
+                SeekDangerResult::Found => return target,
+                SeekDangerResult::SeekLowerBound(next_target) => {
+                    if next_target >= self.max_doc {
+                        self.doc = TERMINATED;
+                        return TERMINATED;
+                    }
+                    target = next_target;
+                }
+            }
+        }
+    }
+}
+/// A dyn-safe, type-erased [`DocPredicate`].
+///
+/// Every [`DocPredicate`] implementation gets a blanket impl of this trait,
+/// which is what lets [`DocPredicateQuery`] store its predicate as
+/// `Arc<dyn DocPredicateBoxable>` regardless of the concrete predicate type.
+pub trait DocPredicateBoxable: std::fmt::Debug + 'static + Send + Sync {
+    /// Builds a [`Scorer`] over the predicate's matching documents in the
+    /// given segment.
+    fn scorer(&self, segment_reader: &SegmentReader, boost: f32) -> crate::Result<Box<dyn Scorer>>;
+
+    /// Builds a [`Scorer`] seeked to `target`, following
+    /// [`Weight::scorer_danger`]'s contract.
+    fn scorer_danger(
+        &self,
+        segment_reader: &SegmentReader,
+        target: DocId,
+        boost: f32,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)>;
+}
+
+impl<TDocPredicate: DocPredicate> DocPredicateBoxable for TDocPredicate {
+    fn scorer(&self, segment_reader: &SegmentReader, boost: f32) -> crate::Result<Box<dyn Scorer>> {
+        let doc_predicate = self.doc_predicate(segment_reader)?;
+        let mut doc_set = DocPredicateDocSet {
+            doc_predicate,
+            doc: 0u32,
+            max_doc: segment_reader.max_doc(),
+        };
+        doc_set.doc = doc_set.find_match(0);
+        Ok(Box::new(ConstScorer::new(doc_set, boost)) as Box<dyn Scorer>)
+    }
+
+    fn scorer_danger(
+        &self,
+        segment_reader: &SegmentReader,
+        target: DocId,
+        boost: f32,
+    ) -> crate::Result<(SeekDangerResult, Box<dyn Scorer>)> {
+        let doc_predicate = self.doc_predicate(segment_reader)?;
+        let mut doc_set = DocPredicateDocSet {
+            doc_predicate,
+            doc: target,
+            max_doc: segment_reader.max_doc(),
+        };
+        let seek_result = doc_set.seek_danger(target);
+        let scorer = Box::new(ConstScorer::new(doc_set, boost)) as Box<dyn Scorer>;
+        Ok((seek_result, scorer))
+    }
+}
+
+/// A per-query predicate that produces a [`SegmentDocPredicate`] for each
+/// segment.
+///
+/// Implementing this trait is all that's needed to make a type usable as a
+/// [`DocPredicateQuery`]: [`DocPredicateBoxable`] and
+/// `From<TDocPredicate> for DocPredicateQuery` are both implemented
+/// generically for every [`DocPredicate`].
+pub trait DocPredicate: Send + Sync + 'static + std::fmt::Debug {
+    /// The per-segment predicate produced by [`Self::doc_predicate`].
+    type SegmentDocPredicate: SegmentDocPredicate;
+
+    /// Builds the predicate used to evaluate documents of `segment_reader`.
+    ///
+    /// Called once per segment; segment-level setup (such as opening
+    /// fast-field columns) belongs here rather than in
+    /// [`SegmentDocPredicate::eval`].
+    fn doc_predicate(
+        &self,
+        segment_reader: &SegmentReader,
+    ) -> crate::Result<Self::SegmentDocPredicate>;
+}
+
+/// The per-segment predicate produced by a [`DocPredicate`].
+pub trait SegmentDocPredicate: Send + Sync + 'static {
+    /// Returns whether `doc_id` matches the predicate.
+    ///
+    /// Hidden contract: this takes `&self`, not `&mut self`, so any scratch
+    /// state used during evaluation must be behind interior mutability (see
+    /// `jitexpr_predicate`'s use of `RefCell`) or a synchronization
+    /// primitive, rather than plain mutable fields.
+    fn eval(&self, doc_id: DocId) -> bool;
+}
+
+/// Builds an in-RAM index with an empty schema and `num_docs` empty documents.
+///
+/// Shared across the test modules of this module tree so each
+/// `DocPredicate` implementation's tests don't each define their own.
+#[cfg(test)]
+fn create_index_for_test(num_docs: u32) -> crate::Index {
+    let schema_builder = crate::schema::Schema::builder();
+    let schema = schema_builder.build();
+    let index = crate::Index::create_in_ram(schema);
+    let mut writer = index.writer_for_tests().unwrap();
+    for _ in 0..num_docs {
+        writer.add_document(doc!()).unwrap();
+    }
+    writer.commit().unwrap();
+    index
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collector::Count;
+    use crate::query::doc_predicate_query::FunctionPredicate;
+
+    fn even_doc_id_query() -> DocPredicateQuery {
+        FunctionPredicate::new(|_segment_reader: &SegmentReader| {
+            Ok(move |doc_id: DocId| doc_id % 2 == 0)
+        })
+        .into()
+    }
+
+    #[test]
+    fn test_doc_predicate_query_matches_expected_documents() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        assert_eq!(searcher.search(&even_doc_id_query(), &Count).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_doc_predicate_query_explain() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        let query = even_doc_id_query();
+        let weight = query
+            .weight(EnableScoring::disabled_from_searcher(&searcher))
+            .unwrap();
+        let segment_reader = searcher.segment_reader(0);
+
+        assert!(weight.explain(segment_reader, 0).is_ok());
+        assert!(weight.explain(segment_reader, 1).is_err());
+    }
+
+    #[test]
+    fn test_doc_predicate_query_scorer_danger_seeks_to_next_match() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        let query = even_doc_id_query();
+        let weight = query
+            .weight(EnableScoring::disabled_from_searcher(&searcher))
+            .unwrap();
+        let segment_reader = searcher.segment_reader(0);
+
+        let (seek_result, mut scorer) = weight.scorer_danger(segment_reader, 1, 1.0).unwrap();
+        assert_eq!(seek_result, SeekDangerResult::SeekLowerBound(2));
+        assert_eq!(scorer.seek_danger(2), SeekDangerResult::Found);
+        assert_eq!(scorer.doc(), 2);
+    }
+
+    #[test]
+    fn test_doc_predicate_query_scorer_danger_target_is_a_match() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        let query = even_doc_id_query();
+        let weight = query
+            .weight(EnableScoring::disabled_from_searcher(&searcher))
+            .unwrap();
+        let segment_reader = searcher.segment_reader(0);
+
+        let (seek_result, scorer) = weight.scorer_danger(segment_reader, 2, 1.0).unwrap();
+        assert_eq!(seek_result, SeekDangerResult::Found);
+        assert_eq!(scorer.doc(), 2);
+    }
+
+    #[test]
+    fn test_doc_predicate_query_scorer_danger_target_past_max_doc() {
+        let index = create_index_for_test(4);
+        let searcher = index.reader().unwrap().searcher();
+        let query = even_doc_id_query();
+        let weight = query
+            .weight(EnableScoring::disabled_from_searcher(&searcher))
+            .unwrap();
+        let segment_reader = searcher.segment_reader(0);
+
+        let (seek_result, _scorer) = weight.scorer_danger(segment_reader, 4, 1.0).unwrap();
+        assert_eq!(seek_result, SeekDangerResult::SeekLowerBound(TERMINATED));
+    }
+}

--- a/src/query/doc_predicate_query/mod.rs
+++ b/src/query/doc_predicate_query/mod.rs
@@ -51,8 +51,8 @@ impl Weight for DocPredicateQuery {
     }
 
     fn explain(&self, reader: &SegmentReader, doc: DocId) -> crate::Result<Explanation> {
-        let mut docset = self.predicate.scorer(reader, 1.0f32)?;
-        if docset.seek(doc) != doc {
+        let (seek_result, _docset) = self.predicate.scorer_danger(reader, doc, 1.0f32)?;
+        if let SeekDangerResult::SeekLowerBound(_) = seek_result {
             return Err(does_not_match(doc));
         }
         Ok(Explanation::new("CalculatedPredicateQuery", 1.0))

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,6 +7,9 @@ mod boost_query;
 mod const_score_query;
 mod disjunction;
 mod disjunction_max_query;
+/// A query evaluated by a [`doc_predicate_query::DocPredicate`] against each
+/// document of a segment.
+pub mod doc_predicate_query;
 mod empty_query;
 mod exclude;
 mod exist_query;


### PR DESCRIPTION
## Summary
- Adds `DocPredicateQuery`, a query that evaluates a per-document predicate against each document of a segment, with support for `Weight::scorer_danger` to allow fast seeking within intersections.
- Adds `FunctionPredicate`, a generic `DocPredicate` implementation built from a plain per-segment factory closure that returns a per-document closure. Has no dependency on fast fields or any other segment data structure.

## Test plan
- `cargo test query::doc_predicate_query`