### PR TITLE
Fix fractional JSON range bounds on integer columns

### DIFF
--- a/src/query/range_query/range_query_fastfield.rs
+++ b/src/query/range_query/range_query_fastfield.rs
@@ -394,7 +394,8 @@ fn transform_from_f64_bounds<T: IntType + MonotonicallyMappableToU64>(
             if lower_bound.fract() == 0.0 {
                 TransformBound::Existing(T::from_f64(lower_bound).to_u64())
             } else {
-                TransformBound::NewBound(Bound::Included(T::from_f64(lower_bound.trunc()).to_u64()))
+                // No integer equals a fractional bound: both > and >= start at its ceiling.
+                TransformBound::NewBound(Bound::Included(T::from_f64(lower_bound.ceil()).to_u64()))
             }
         },
         |&upper_bound| {
@@ -408,7 +409,8 @@ fn transform_from_f64_bounds<T: IntType + MonotonicallyMappableToU64>(
             if upper_bound.fract() == 0.0 {
                 TransformBound::Existing(T::from_f64(upper_bound).to_u64())
             } else {
-                TransformBound::NewBound(Bound::Included(T::from_f64(upper_bound.trunc()).to_u64()))
+                // No integer equals a fractional bound: both < and <= end at its floor.
+                TransformBound::NewBound(Bound::Included(T::from_f64(upper_bound.floor()).to_u64()))
             }
         },
     )
@@ -696,6 +698,38 @@ mod tests {
             )),
             0
         );
+    }
+
+    #[test]
+    fn test_json_fractional_range_bounds() -> crate::Result<()> {
+        let mut schema_builder = Schema::builder();
+        let json_field = schema_builder.add_json_field("json", TEXT | FAST);
+        let index = Index::create_in_ram(schema_builder.build());
+        let mut writer = index.writer_for_tests()?;
+        for value in -4..=4 {
+            writer.add_document(doc!(json_field => serde_json::json!({"value": value})))?;
+        }
+        writer.commit()?;
+
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        for (lower, upper, expected_count) in [(1.5, 3.5, 2), (-3.5, -1.5, 2), (-1.5, 1.5, 3)] {
+            // No integer equals a fractional bound, so inclusion and exclusion agree.
+            for lower_bound in [Bound::Included(lower), Bound::Excluded(lower)] {
+                for upper_bound in [Bound::Included(upper), Bound::Excluded(upper)] {
+                    let query = RangeQuery::new(
+                        lower_bound.map(|value| get_json_term(json_field, "value", value)),
+                        upper_bound.map(|value| get_json_term(json_field, "value", value)),
+                    );
+                    assert_eq!(
+                        searcher.search(&query, &Count)?,
+                        expected_count,
+                        "range {lower_bound:?} to {upper_bound:?}"
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     fn get_json_term<T: FastValue>(field: Field, path: &str, value: T) -> Term {


### PR DESCRIPTION
## Summary

Fix fractional JSON range bounds when the underlying fast-field column stores integers.

`transform_from_f64_bounds` truncates fractional bounds toward zero. This widens some ranges: `value >= 1.5` incorrectly matches integer `1`, and `value <= -1.5` incorrectly matches integer `-1`.

- Round fractional lower bounds with `ceil()` and upper bounds with `floor()`.
- Keep the converted bounds inclusive: no integer equals the original fractional bound, so inclusive and exclusive fractional bounds have the same integer endpoints.
- Leave integral-bound and out-of-domain handling unchanged.

## Regression coverage

A single end-to-end unit test, `test_json_fractional_range_bounds`, indexes integers from -4 to 4 and covers:

- Positive bounds `1.5` to `3.5`: only `2` and `3` match.
- Negative bounds `-3.5` to `-1.5`: only `-3` and `-2` match.
- Bounds crossing zero `-1.5` to `1.5`: only `-1`, `0`, and `1` match.
- All four combinations of inclusive/exclusive endpoints for each range.

Only this bug's fix and regression test are included; pre-existing tests are unchanged.

## Validation

- The original regression tests failed before the production fix; their lower/upper-bound coverage is now consolidated into one end-to-end test.
- `cargo test -p tantivy --lib`: **1,249 passed, 0 failed, 8 ignored**.
- `git diff --check`: passed.
