### PR TITLE
stats aggregation metadata fast path

### DIFF
--- a/benches/agg_bench.rs
+++ b/benches/agg_bench.rs
@@ -78,6 +78,7 @@ fn bench_agg(runner: &mut BenchRunner, index: &Index, execute_filtered: Aggregat
             benchmark_config!(average_u64),
             benchmark_config!(average_f64),
             benchmark_config!(average_f64_u64),
+            benchmark_config!(min_max_f64),
             benchmark_config!(stats_f64),
             benchmark_config!(extendedstats_f64),
             benchmark_config!(percentiles_f64),
@@ -186,6 +187,12 @@ fn average_f64_u64() -> AggregationRequest {
     json!({
         "average_f64": { "avg": { "field": "score_f64" } },
         "average": { "avg": { "field": "score" } },
+    })
+}
+fn min_max_f64() -> AggregationRequest {
+    json!({
+        "min_f64": { "min": { "field": "score_f64" } },
+        "max_f64": { "max": { "field": "score_f64" } }
     })
 }
 fn stats_f64() -> AggregationRequest {

--- a/src/aggregation/agg_data.rs
+++ b/src/aggregation/agg_data.rs
@@ -239,24 +239,28 @@ impl PerRequestAggSegCtx {
 
 pub(crate) fn build_segment_agg_collectors_root(
     req: &mut AggregationsSegmentCtx,
+    // Only true when the query matches every document and the segment has no deletions.
+    collect_all: bool,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
-    build_segment_agg_collectors_generic(req, &req.per_request.agg_tree.clone())
+    build_segment_agg_collectors_generic(req, &req.per_request.agg_tree.clone(), collect_all)
 }
 
 pub(crate) fn build_segment_agg_collectors(
     req: &mut AggregationsSegmentCtx,
     nodes: &[AggRefNode],
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
-    build_segment_agg_collectors_generic(req, nodes)
+    // Bucket sub-aggregations do not see the entire segment.
+    build_segment_agg_collectors_generic(req, nodes, false)
 }
 
 fn build_segment_agg_collectors_generic(
     req: &mut AggregationsSegmentCtx,
     nodes: &[AggRefNode],
+    collect_all: bool,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
     let mut collectors = Vec::new();
     for node in nodes.iter() {
-        collectors.push(build_segment_agg_collector(req, node)?);
+        collectors.push(build_segment_agg_collector(req, node, collect_all)?);
     }
 
     req.context
@@ -273,6 +277,7 @@ fn build_segment_agg_collectors_generic(
 pub(crate) fn build_segment_agg_collector(
     req: &mut AggregationsSegmentCtx,
     node: &AggRefNode,
+    collect_all: bool,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
     match node.kind {
         AggKind::Terms => crate::aggregation::bucket::build_segment_term_collector(req, node),
@@ -328,7 +333,7 @@ pub(crate) fn build_segment_agg_collector(
                 | StatsType::Count
                 | StatsType::Max
                 | StatsType::Min
-                | StatsType::Stats => build_segment_stats_collector(req_data),
+                | StatsType::Stats => build_segment_stats_collector(req_data, collect_all),
                 StatsType::ExtendedStats(sigma) => Ok(Box::new(
                     SegmentExtendedStatsCollector::from_req(req_data, sigma),
                 )),

--- a/src/aggregation/collector.rs
+++ b/src/aggregation/collector.rs
@@ -7,8 +7,9 @@ use super::AggContextParams;
 use crate::aggregation::agg_data::{
     build_aggregations_data_from_req, build_segment_agg_collectors_root, AggregationsSegmentCtx,
 };
-use crate::collector::{Collector, SegmentCollector};
+use crate::collector::{default_collect_segment_impl, Collector, SegmentCollector};
 use crate::index::SegmentReader;
+use crate::query::{AllScorer, Weight};
 use crate::{DocId, SegmentOrdinal, TantivyError};
 
 /// The default max bucket count, before the aggregation fails.
@@ -86,6 +87,21 @@ impl Collector for DistributedAggregationCollector {
     ) -> crate::Result<Self::Fruit> {
         merge_fruits(segment_fruits)
     }
+
+    fn collect_segment(
+        &self,
+        weight: &dyn Weight,
+        segment_ord: u32,
+        reader: &SegmentReader,
+    ) -> crate::Result<<Self::Child as SegmentCollector>::Fruit> {
+        AggregationSegmentCollector::collect_segment(
+            &self.agg,
+            &self.context,
+            weight,
+            segment_ord,
+            reader,
+        )
+    }
 }
 
 impl Collector for AggregationCollector {
@@ -117,6 +133,21 @@ impl Collector for AggregationCollector {
         let res = merge_fruits(segment_fruits)?;
         res.into_final_result(self.agg.clone(), self.context.limits.clone())
     }
+
+    fn collect_segment(
+        &self,
+        weight: &dyn Weight,
+        segment_ord: u32,
+        reader: &SegmentReader,
+    ) -> crate::Result<<Self::Child as SegmentCollector>::Fruit> {
+        AggregationSegmentCollector::collect_segment(
+            &self.agg,
+            &self.context,
+            weight,
+            segment_ord,
+            reader,
+        )
+    }
 }
 
 fn merge_fruits(
@@ -141,6 +172,22 @@ pub struct AggregationSegmentCollector {
 }
 
 impl AggregationSegmentCollector {
+    fn collect_segment(
+        agg: &Aggregations,
+        context: &AggContextParams,
+        weight: &dyn Weight,
+        segment_ordinal: SegmentOrdinal,
+        reader: &SegmentReader,
+    ) -> crate::Result<<Self as SegmentCollector>::Fruit> {
+        let agg_data =
+            build_aggregations_data_from_req(agg, reader, segment_ordinal, context.clone())?;
+        // Column statistics include deleted documents and require matching the whole segment.
+        let collect_all = !reader.has_deletes() && weight.scorer(reader, 1.0)?.is::<AllScorer>();
+        let mut collector = Self::from_agg_data(agg_data, collect_all)?;
+        default_collect_segment_impl(&mut collector, weight, reader, false)?;
+        Ok(collector.harvest())
+    }
+
     /// Creates an `AggregationSegmentCollector from` an [`Aggregations`] request and a segment
     /// reader. Also includes validation, e.g. checking field types and existence.
     pub fn from_agg_req_and_reader(
@@ -149,10 +196,19 @@ impl AggregationSegmentCollector {
         segment_ordinal: SegmentOrdinal,
         context: &AggContextParams,
     ) -> crate::Result<Self> {
-        let mut agg_data =
+        let agg_data =
             build_aggregations_data_from_req(agg, reader, segment_ordinal, context.clone())?;
-        let mut result =
-            LowCardBufferedSubAggs::new(build_segment_agg_collectors_root(&mut agg_data)?);
+        Self::from_agg_data(agg_data, false)
+    }
+
+    fn from_agg_data(
+        mut agg_data: AggregationsSegmentCtx,
+        collect_all: bool,
+    ) -> crate::Result<Self> {
+        let mut result = LowCardBufferedSubAggs::new(build_segment_agg_collectors_root(
+            &mut agg_data,
+            collect_all,
+        )?);
         result
             .get_sub_agg_collector()
             .prepare_max_bucket(0, &agg_data)?; // prepare for bucket zero
@@ -218,4 +274,90 @@ impl SegmentCollector for AggregationSegmentCollector {
 
         Ok(sub_aggregation_res)
     }
+}
+
+#[test]
+fn test_column_stats_and_collecting_aggregations() -> crate::Result<()> {
+    use crate::aggregation::tests::get_test_index_from_values;
+    use crate::collector::Count;
+    use crate::query::AllQuery;
+
+    for merge_segments in [false, true] {
+        let index = get_test_index_from_values(merge_segments, &[-5.0, 2.0, 10.0])?;
+        let reader = index.reader()?;
+        let searcher = reader.searcher();
+        for request in [
+            json!({
+                "min": {"min": {"field": "score_f64"}},
+                "max": {"max": {"field": "score_f64"}},
+                "count": {"value_count": {"field": "score_f64"}},
+                "count_str": {"value_count": {"field": "string_id"}},
+                "count_empty": {"value_count": {"field": "absent"}}
+            }),
+            json!({
+                "min": {"min": {"field": "score_f64"}},
+                "sum": {"sum": {"field": "score_f64"}},
+                "count": {"value_count": {"field": "score_f64"}},
+                "count_missing": {"value_count": {"field": "absent", "missing": 42.0}},
+                "missing": {"max": {"field": "absent", "missing": 42.0}},
+                "empty": {"min": {"field": "absent"}}
+            }),
+            json!({
+                "max": {"max": {"field": "score_f64"}},
+                "terms": {
+                    "terms": {"field": "string_id"},
+                    "aggs": {
+                        "min": {"min": {"field": "score_f64"}},
+                        "count": {"value_count": {"field": "score_f64"}}
+                    }
+                }
+            }),
+        ] {
+            let collector = AggregationCollector::from_aggs(
+                serde_json::from_value(request)?,
+                Default::default(),
+            );
+            let optimized = searcher.search(&AllQuery, &collector)?;
+            // Tuple collectors use for_segment, without the full-segment optimization.
+            let (collected, _) = searcher.search(&AllQuery, &(collector, Count))?;
+            assert_eq!(optimized, collected);
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_column_stats_filtered_and_deleted_docs() -> crate::Result<()> {
+    use crate::aggregation::tests::get_test_index_from_values;
+    use crate::query::{AllQuery, TermQuery};
+    use crate::schema::IndexRecordOption;
+    use crate::Term;
+
+    let index = get_test_index_from_values(true, &[-5.0, 2.0, 10.0])?;
+    let reader = index.reader()?;
+    let field = index.schema().get_field("string_id")?;
+    let collector = AggregationCollector::from_aggs(
+        serde_json::from_value(json!({
+            "min": {"min": {"field": "score_f64"}},
+            "max": {"max": {"field": "score_f64"}},
+            "count": {"value_count": {"field": "score_f64"}}
+        }))?,
+        Default::default(),
+    );
+    let query = TermQuery::new(Term::from_field_text(field, "2"), IndexRecordOption::Basic);
+    assert_eq!(
+        serde_json::to_value(reader.searcher().search(&query, &collector)?)?,
+        json!({"min": {"value": 2.0}, "max": {"value": 2.0}, "count": {"value": 1.0}}),
+    );
+    let mut writer: crate::IndexWriter = index.writer_for_tests()?;
+    writer.delete_term(Term::from_field_text(field, "-5"));
+    writer.delete_term(Term::from_field_text(field, "10"));
+    writer.commit()?;
+    reader.reload()?;
+    assert!(reader.searcher().segment_reader(0).has_deletes());
+    assert_eq!(
+        serde_json::to_value(reader.searcher().search(&AllQuery, &collector)?)?,
+        json!({"min": {"value": 2.0}, "max": {"value": 2.0}, "count": {"value": 1.0}}),
+    );
+    Ok(())
 }

--- a/src/aggregation/metric/stats.rs
+++ b/src/aggregation/metric/stats.rs
@@ -199,36 +199,88 @@ pub enum StatsType {
 
 fn create_collector<const TYPE_ID: u8>(
     req: &MetricAggReqData,
+    precomputed: bool,
 ) -> Box<dyn SegmentAggregationCollector> {
-    Box::new(SegmentStatsCollector::<TYPE_ID> {
+    if precomputed {
+        create_stats_collector::<TYPE_ID, true>(req)
+    } else {
+        create_stats_collector::<TYPE_ID, false>(req)
+    }
+}
+
+fn create_stats_collector<const TYPE_ID: u8, const PRECOMPUTED: bool>(
+    req: &MetricAggReqData,
+) -> Box<dyn SegmentAggregationCollector> {
+    let mut stats = IntermediateStats::default();
+    if PRECOMPUTED {
+        stats.count = u64::from(req.accessor.values.num_vals());
+        if stats.count != 0 && !matches!(req.collecting_for, StatsType::Count) {
+            let min = f64_from_fastfield_u64(req.accessor.min_value(), req.field_type);
+            let max = f64_from_fastfield_u64(req.accessor.max_value(), req.field_type);
+            stats.min = stats.min.min(min);
+            stats.max = stats.max.max(max);
+        }
+    }
+    Box::new(SegmentStatsCollector::<TYPE_ID, PRECOMPUTED> {
         name: req.name.clone(),
         collecting_for: req.collecting_for,
         is_number_or_date_type: req.is_number_or_date_type,
         missing_u64: req.missing_u64,
         accessor: req.accessor.clone(),
-        buckets: vec![IntermediateStats::default()],
+        buckets: vec![stats],
     })
 }
 
-/// Build a concrete `SegmentStatsCollector` depending on the column type.
+/// Build a stats collector, using column statistics when the entire segment is collected.
 pub(crate) fn build_segment_stats_collector(
     req: &MetricAggReqData,
+    collect_all: bool,
 ) -> crate::Result<Box<dyn SegmentAggregationCollector>> {
+    let precomputed = collect_all
+        && req.missing.is_none()
+        && matches!(
+            req.collecting_for,
+            StatsType::Min | StatsType::Max | StatsType::Count
+        );
     match req.field_type {
-        ColumnType::I64 => Ok(create_collector::<{ ColumnType::I64 as u8 }>(req)),
-        ColumnType::U64 => Ok(create_collector::<{ ColumnType::U64 as u8 }>(req)),
-        ColumnType::F64 => Ok(create_collector::<{ ColumnType::F64 as u8 }>(req)),
-        ColumnType::Bool => Ok(create_collector::<{ ColumnType::Bool as u8 }>(req)),
-        ColumnType::DateTime => Ok(create_collector::<{ ColumnType::DateTime as u8 }>(req)),
-        ColumnType::Bytes => Ok(create_collector::<{ ColumnType::Bytes as u8 }>(req)),
-        ColumnType::Str => Ok(create_collector::<{ ColumnType::Str as u8 }>(req)),
-        ColumnType::IpAddr => Ok(create_collector::<{ ColumnType::IpAddr as u8 }>(req)),
+        ColumnType::I64 => Ok(create_collector::<{ ColumnType::I64 as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::U64 => Ok(create_collector::<{ ColumnType::U64 as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::F64 => Ok(create_collector::<{ ColumnType::F64 as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::Bool => Ok(create_collector::<{ ColumnType::Bool as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::DateTime => Ok(create_collector::<{ ColumnType::DateTime as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::Bytes => Ok(create_collector::<{ ColumnType::Bytes as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::Str => Ok(create_collector::<{ ColumnType::Str as u8 }>(
+            req,
+            precomputed,
+        )),
+        ColumnType::IpAddr => Ok(create_collector::<{ ColumnType::IpAddr as u8 }>(
+            req,
+            precomputed,
+        )),
     }
 }
 
 #[repr(C)]
 #[derive(Clone, Debug)]
-pub(crate) struct SegmentStatsCollector<const COLUMN_TYPE_ID: u8> {
+pub(crate) struct SegmentStatsCollector<const COLUMN_TYPE_ID: u8, const PRECOMPUTED: bool> {
     pub(crate) missing_u64: Option<u64>,
     pub(crate) accessor: Column<u64>,
     pub(crate) is_number_or_date_type: bool,
@@ -237,8 +289,8 @@ pub(crate) struct SegmentStatsCollector<const COLUMN_TYPE_ID: u8> {
     pub(crate) collecting_for: StatsType,
 }
 
-impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
-    for SegmentStatsCollector<COLUMN_TYPE_ID>
+impl<const COLUMN_TYPE_ID: u8, const PRECOMPUTED: bool> SegmentAggregationCollector
+    for SegmentStatsCollector<COLUMN_TYPE_ID, PRECOMPUTED>
 {
     #[inline]
     fn add_intermediate_aggregation_result(
@@ -285,6 +337,9 @@ impl<const COLUMN_TYPE_ID: u8> SegmentAggregationCollector
         docs: &[crate::DocId],
         agg_data: &mut AggregationsSegmentCtx,
     ) -> crate::Result<()> {
+        if PRECOMPUTED {
+            return Ok(());
+        }
         // Fast path: the caller hands us a single doc, which is the dominant case when a metric
         // sub-agg sits under a high-cardinality bucket agg. Streaming straight from the column
         // skips the block accessor's buffers entirely.


### PR DESCRIPTION
Use column statistics to avoid scanning for root min/max/count aggregations
