### PR TITLE
Bump coverage nightly pin to satisfy cranelift MSRV

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust
-        run: rustup toolchain install nightly-2025-12-01 --profile minimal --component llvm-tools-preview
+        run: rustup toolchain install nightly-2026-08-31 --profile minimal --component llvm-tools-preview
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@e4b3a0453201addddc06d3a72db90326aad87084 # cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo +nightly-2025-12-01 llvm-cov --all-features --workspace --doctests --lcov --output-path lcov.info
+        run: cargo +nightly-2026-08-31 llvm-cov --all-features --workspace --doctests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true


### PR DESCRIPTION
## Problem

The `Coverage` workflow fails on:

```
cargo +nightly-2025-12-01 llvm-cov --all-features --workspace --doctests --lcov --output-path lcov.info
```

`nightly-2025-12-01` is **rustc 1.93**. Because `--all-features --workspace` includes the `jitexpr` member, the build pulls in `cranelift 0.134.4` and its ~20 sibling crates, which declare `rust-version = "1.94.0"`. Cargo rejects this during resolution, before compiling anything:

```
error: rustc 1.93.1 is not supported by the following packages:
  cranelift@0.134.4 requires rustc 1.94.0
  cranelift-assembler-x64@0.134.4 requires rustc 1.94.0
  cranelift-bforest@0.134.4 requires rustc 1.94.0
  ...
```

## Fix

Bump the pin to `nightly-2026-08-31` (`1.100.0-nightly`) in both the `rustup toolchain install` step and the `cargo llvm-cov` invocation.

This does **not** affect the declared MSRV of tantivy (`rust-version = "1.87"`). `jitexpr` is a workspace member but not a dependency of the `tantivy` package, so `cargo build -p tantivy` is unchanged — only the all-features workspace build needs the newer toolchain.

## Verification

- `cargo +1.93 check -p jitexpr` reproduces the failure above.
- `cargo +nightly check -p jitexpr` (1.100.0-nightly, 0dfb098f3) exits 0.

Not verified locally: the `cargo llvm-cov` run itself, including `llvm-tools-preview` availability and `--doctests` support on this nightly. Leaving as draft so CI can confirm.
